### PR TITLE
feat: add Rspack Rsbuild Rslib llms.txt

### DIFF
--- a/content/websites/rsbuild-llms-txt.mdx
+++ b/content/websites/rsbuild-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Rsbuild'
+description: 'Rsbuild is a high-performance build tool powered by Rspack. It provides out-of-the-box setup for enjoyable development experience.'
+website: 'https://rsbuild.dev'
+llmsUrl: 'https://rsbuild.dev/llms.txt'
+llmsFullUrl: 'https://rsbuild.dev/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2025-04-25'
+---
+
+# Rsbuild
+
+Rsbuild is a high-performance build tool powered by Rspack. It provides out-of-the-box setup for enjoyable development experience.

--- a/content/websites/rslib-llms-txt.mdx
+++ b/content/websites/rslib-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Rslib'
+description: 'Rslib is a library development tool that leverages the well-designed configurations and plugins of Rsbuild.'
+website: 'https://lib.rsbuild.dev'
+llmsUrl: 'https://lib.rsbuild.dev/llms.txt'
+llmsFullUrl: 'https://lib.rsbuild.dev/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2025-04-25'
+---
+
+# Rslib
+
+Rslib is a library development tool that leverages the well-designed configurations and plugins of Rsbuild.

--- a/content/websites/rspack-llms-txt.mdx
+++ b/content/websites/rspack-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Rspack'
+description: 'Rspack is a high performance JavaScript bundler written in Rust. It offers strong compatibility with the webpack ecosystem, and lightning fast build speeds.'
+website: 'https://rspack.dev'
+llmsUrl: 'https://rspack.dev/llms.txt'
+llmsFullUrl: 'https://rspack.dev/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2025-04-25'
+---
+
+# Rspack
+
+Rspack is a high performance JavaScript bundler written in Rust. It offers strong compatibility with the webpack ecosystem, and lightning fast build speeds.


### PR DESCRIPTION
This PR adds Rspack Rsbuild and Rslib to the llms.txt hub.

[Rspack](https://rspack.dev)

Website:[rspack.dev](https://rspack.dev)
llms.txt: [rspack.dev/llms.txt](https://rspack.dev/llms.txt)
llms-full.txt: [rspack.dev/llms-full.txt](rspack.dev/llms-full.txt)
Category: developer-tools

[Rsbuild](https://rsbuild.dev/)

Website:[rsbuild.dev](https://rsbuild.dev)
llms.txt: [rsbuild.dev/llms.txt](https://rsbuild.dev/llms.txt)
llms-full.txt: [rsbuild.dev/llms-full.txt](rsbuild.dev/llms-full.txt)
Category: developer-tools

[Rslib](https://lib.rsbuild.dev)

Website:[lib.rsbuild.dev](https://lib.rsbuild.dev)
llms.txt: [lib.rsbuild.dev/llms.txt](https://lib.rsbuild.dev/llms.txt)
llms-full.txt: [lib.rsbuild.dev/llms-full.txt](lib.rsbuild.dev/llms-full.txt)
Category: developer-tools

Please review your PR, a reviewer will merge it if appropriate.




