### PR TITLE
feat: add APS SDK’s OpenAPI Specification | aps to llms.txt hub

### DIFF
--- a/packages/content/websites/data/aps-sdk’s-openapi-specification-|-aps-llms-txt.mdx
+++ b/packages/content/websites/data/aps-sdk’s-openapi-specification-|-aps-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'APS SDK’s OpenAPI Specification | aps'
+description: 'OpenAPI specifications used for generating the APS SDKs.'
+website: 'https://wallabyway.github.io/aps-sdk-openapi/'
+llmsUrl: 'https://wallabyway.github.io/aps-sdk-openapi/llms.txt'
+llmsFullUrl: 'https://wallabyway.github.io/aps-sdk-openapi/llms-full.txt'
+category: 'integration-automation'
+publishedAt: '2025-05-08'
+---
+
+# APS SDK’s OpenAPI Specification | aps
+
+OpenAPI specifications used for generating the APS SDKs.


### PR DESCRIPTION
This PR adds APS SDK’s OpenAPI Specification | aps to the llms.txt hub.

Submitted by: @wallabyway

Website: https://wallabyway.github.io/aps-sdk-openapi/
llms.txt: https://wallabyway.github.io/aps-sdk-openapi/llms.txt
llms-full.txt: https://wallabyway.github.io/aps-sdk-openapi/llms-full.txt
Category: integration-automation


Please review your PR, a reviewer will merge it if appropriate.