### PR TITLE
chore: ignore Jetbrains ide config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ lychee-out.md
 .lycheecache
 .env*.local
 .content-collections
+
+# Jetbrains
+.idea


### PR DESCRIPTION
# Motivation

I used WebStorm to prepare PR #283 and noticed that its project configuration files were not ignored by Git. Assuming there’s no particular reason to include them in the repo, here’s a PR to ignore those JetBrains files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated file exclusions to ignore JetBrains IDE configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->