### PR TITLE
content: fix llms File structure example

### DIFF
--- a/packages/content/data/guides/getting-started-llms-txt.mdx
+++ b/packages/content/data/guides/getting-started-llms-txt.mdx
@@ -58,19 +58,19 @@ The llms.txt file uses Markdown with a specific structure:
 
 ## Documentation
 
-- [Getting Started](/docs/getting-started) - Guide for new users
-- [API Reference](/docs/api) - Complete API documentation
-- [Tutorials](/docs/tutorials) - Step-by-step guides
+- [Getting Started](/docs/getting-started): Guide for new users
+- [API Reference](/docs/api): Complete API documentation
+- [Tutorials](/docs/tutorials): Step-by-step guides
 
 ## Examples
 
-- [Basic Implementation](/examples/basic) - Simple integration example
-- [Advanced Features](/examples/advanced) - Using advanced capabilities
+- [Basic Implementation](/examples/basic): Simple integration example
+- [Advanced Features](/examples/advanced): Using advanced capabilities
 
 ## Optional Resources
 
-- [Community Forum](/community) - Get help from other users
-- [Change Log](/changelog) - Track updates and changes
+- [Community Forum](/community): Get help from other users
+- [Change Log](/changelog): Track updates and changes
 ```
 
 ### 2. Place the File in the Correct Location


### PR DESCRIPTION
The [file structure example](https://llmstxthub.com/guides/getting-started-llms-txt) uses a hyphen before the short description, but in fact everyone uses a colon:

Befor: `- [Getting Started](/docs/getting-started) - Guide for new users`
After:  `- [Getting Started](/docs/getting-started): Guide for new users`