### PR TITLE
Add TherapyDave site

### DIFF
--- a/packages/content/websites/data/therapydave.mdx
+++ b/packages/content/websites/data/therapydave.mdx
@@ -1,8 +1,8 @@
 ---
-name: TherapyDave
+name: TherapyDave - Dave Lechnyr, LCSW
 description: Licensed Clinical Social Worker (LCSW, ACSW) and Certified Gottman Therapist offering couples therapy, discernment counseling, individual therapy, and relationship coaching. Based in Oregon and Arizona with global coaching availability.
 website: https://therapydave.com
 llms: https://therapydave.com/llms.txt
-category: Therapy
+category: Mental Health
 ---
 

--- a/packages/content/websites/data/therapydave.mdx
+++ b/packages/content/websites/data/therapydave.mdx
@@ -6,6 +6,6 @@ name: TherapyDave - Dave Lechnyr, LCSW
 +  relationship coaching, based in Oregon and Arizona with global coaching
 +  availability.
 website: https://therapydave.com
-llms: https://therapydave.com/llms.txt
+llmsUrl: https://therapydave.com/llms.txt
 category: other
 ---

--- a/packages/content/websites/data/therapydave.mdx
+++ b/packages/content/websites/data/therapydave.mdx
@@ -3,7 +3,7 @@ name: TherapyDave - Dave Lechnyr, LCSW
 +description: >-
 +  Licensed Clinical Social Worker (LCSW, ACSW) and Certified Gottman Therapist
 +  offering couples therapy, discernment counseling, individual therapy, and
-+  relationship coaching. Based in Oregon and Arizona with global coaching
++  relationship coaching, based in Oregon and Arizona with global coaching
 +  availability.
 website: https://therapydave.com
 llms: https://therapydave.com/llms.txt

--- a/packages/content/websites/data/therapydave.mdx
+++ b/packages/content/websites/data/therapydave.mdx
@@ -1,0 +1,8 @@
+---
+name: TherapyDave
+description: Licensed Clinical Social Worker (LCSW, ACSW) and Certified Gottman Therapist offering couples therapy, discernment counseling, individual therapy, and relationship coaching. Based in Oregon and Arizona with global coaching availability.
+website: https://therapydave.com
+llms: https://therapydave.com/llms.txt
+category: Therapy
+---
+

--- a/packages/content/websites/data/therapydave.mdx
+++ b/packages/content/websites/data/therapydave.mdx
@@ -1,8 +1,11 @@
 ---
 name: TherapyDave - Dave Lechnyr, LCSW
-description: Licensed Clinical Social Worker (LCSW, ACSW) and Certified Gottman Therapist offering couples therapy, discernment counseling, individual therapy, and relationship coaching. Based in Oregon and Arizona with global coaching availability.
++description: >-
++  Licensed Clinical Social Worker (LCSW, ACSW) and Certified Gottman Therapist
++  offering couples therapy, discernment counseling, individual therapy, and
++  relationship coaching. Based in Oregon and Arizona with global coaching
++  availability.
 website: https://therapydave.com
 llms: https://therapydave.com/llms.txt
-category: Mental Health
+category: other
 ---
-


### PR DESCRIPTION
Adds TherapyDave (https://therapydave.com) with llms.txt entry under category 'other'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new mental health provider listing: "TherapyDave – Dave Lechnyr, LCSW." Includes service offerings (couples therapy, discernment counseling, individual therapy, relationship coaching), regional availability (Oregon, Arizona) and global coaching availability. Provides direct links to the provider website and an LLMs resource for additional information. No visible page body content beyond the listing metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->