### PR TITLE
feat: add The David Dias | Front to llms.txt hub

### DIFF
--- a/packages/content/data/websites/the-david-dias-front-llms-txt.mdx
+++ b/packages/content/data/websites/the-david-dias-front-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'The David Dias | Front'
+description: 'Hey, I''m David Dias, a Front-End Developer based in Toronto/Canada. I love discussing code, technology, expatriation and life.'
+website: 'https://thedaviddias.com'
+llmsUrl: 'https://thedaviddias.com/llms.txt'
+llmsFullUrl: ''
+category: 'personal'
+publishedAt: '2025-09-02'
+---
+
+# The David Dias | Front
+
+Hey, I'm David Dias, a Front-End Developer based in Toronto/Canada. I love discussing code, technology, expatriation and life.


### PR DESCRIPTION
This PR adds The David Dias | Front to the llms.txt hub.

Submitted by: thedaviddias (thedaviddias@gmail.com)

**Website:** https://thedaviddias.com
**llms.txt:** https://thedaviddias.com/llms.txt

**Category:** personal

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new website entry: “The David Dias | Front,” featuring an overview of David Dias, a Toronto-based Front-End Developer.
  - Includes metadata (name, description, category, publish date) to improve browsing and filtering in the websites directory.
  - Provides a direct LLMS resource link for quick access to related content.
  - Displays a clear title and introductory paragraph on the detail page for a consistent reading experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->