### PR TITLE
feat: add FragBin to llms.txt hub

### DIFF
--- a/packages/content/data/websites/fragbin-llms-txt.mdx
+++ b/packages/content/data/websites/fragbin-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'FragBin'
+description: 'Share code or text instantly with optional expiry, password protection, and Markdown support from a simple paste - an alternative to Pastebin.'
+website: 'https://www.fragbin.com/'
+llmsUrl: 'https://www.fragbin.com/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2025-09-19'
+---
+
+# FragBin
+
+Share code or text instantly with optional expiry, password protection, and Markdown support from a simple paste - an alternative to Pastebin.


### PR DESCRIPTION
This PR adds FragBin to the llms.txt hub.

Submitted by: fragbin

**Website:** https://www.fragbin.com/
**llms.txt:** https://www.fragbin.com/llms.txt

**Category:** developer-tools

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added FragBin to the website catalog under Developer Tools. The entry includes name, description, site link (https://www.fragbin.com), LLMS endpoint (https://www.fragbin.com/llms.txt), and publication date (2025-09-19). The page renders an H1 title and description, making the item available alongside existing listings for users to browse and access directly from the catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->