### PR TITLE
feat: add Kigurumi Wiki to llms.txt hub

### DIFF
--- a/packages/content/data/websites/kigurumi-wiki-llms-txt.mdx
+++ b/packages/content/data/websites/kigurumi-wiki-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Kigurumi Wiki'
+description: 'Kig.Wiki - The open source Kigurumi Mask (着ぐるみ) wiki.'
+website: 'https://kig.wiki'
+llmsUrl: 'https://kig.wiki/llms.txt'
+llmsFullUrl: 'https://kig.wiki/llms-full.txt'
+category: 'other'
+publishedAt: '2025-09-25'
+---
+
+# Kigurumi Wiki
+
+Kig.Wiki - The open source Kigurumi Mask (着ぐるみ) wiki.


### PR DESCRIPTION
This PR adds Kigurumi Wiki to the llms.txt hub.

Submitted by: kamen

**Website:** https://kig.wiki
**llms.txt:** https://kig.wiki/llms.txt
**llms-full.txt:** https://kig.wiki/llms-full.txt  
**Category:** other

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new Kigurumi Wiki entry to the websites catalog, complete with name, short description, website link, category, and publication date.
  - The listing includes a concise page with a clear header and brief summary, making it easier to understand the resource at a glance.
  - Users can now discover and access Kigurumi Wiki directly from the app’s website listings, with both direct and full links available for convenient navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->