### PR TITLE
feat: add Shows Watched to llms.txt hub

### DIFF
--- a/packages/content/data/websites/shows-watched-llms-txt.mdx
+++ b/packages/content/data/websites/shows-watched-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Shows Watched'
+description: 'Track all the shows watched and movies you love with ShowsWatched.com. Keep a personal diary of shows watched, discover trending content, and connect with fans.'
+website: 'https://showswatched.com'
+llmsUrl: 'https://showswatched.com/llms.txt'
+llmsFullUrl: 'https://showswatched.com/llms-full.txt'
+category: 'content-media'
+publishedAt: '2025-09-29'
+---
+
+# Shows Watched
+
+Track all the shows watched and movies you love with ShowsWatched.com. Keep a personal diary of shows watched, discover trending content, and connect with fans.


### PR DESCRIPTION
This PR adds Shows Watched to the llms.txt hub.

Submitted by: admin

**Website:** https://showswatched.com
**llms.txt:** https://showswatched.com/llms.txt
**llms-full.txt:** https://showswatched.com/llms-full.txt  
**Category:** content-media

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new website entry, “Shows Watched (LLMs.txt),” with complete metadata (title, description, link, category, publication date).
  * The entry is now visible in the Websites catalog and will appear in existing listings, browsing, and search/filter experiences.
  * This is a content addition only; no changes to app behavior or settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->