### PR TITLE
feat: add Aspose.Words Product Family to llms.txt hub

### DIFF
--- a/packages/content/data/websites/aspose-words-product-family-llms-txt.mdx
+++ b/packages/content/data/websites/aspose-words-product-family-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Aspose.Words Product Family'
+description: 'Aspose.Words is a class library that can be used by developers for various platforms for a variety of document processing tasks.'
+website: 'https://docs.aspose.com/words/'
+llmsUrl: 'https://docs.aspose.com/words/llms.txt'
+llmsFullUrl: 'https://docs.aspose.com/words/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2025-10-01'
+---
+
+# Aspose.Words Product Family
+
+Aspose.Words is a class library that can be used by developers for various platforms for a variety of document processing tasks.


### PR DESCRIPTION
This PR adds Aspose.Words Product Family to the llms.txt hub.

Submitted by: mary.gerasimova

**Website:** https://docs.aspose.com/words/
**llms.txt:** https://docs.aspose.com/words/llms.txt
**llms-full.txt:** https://docs.aspose.com/words/llms-full.txt  
**Category:** developer-tools

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added a new content entry for the Aspose.Words Product Family, including a title, description, website link, LLM resource links, category, and publish date.
  - Introduces a header and concise overview to improve clarity and discoverability within the website catalog.
  - Content will appear in relevant listings and searches, enhancing navigation and reference for users.
  - No functional or API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->