### PR TITLE
feat: add ads.txt Guru to llms.txt hub

### DIFF
--- a/packages/content/data/websites/ads-txt-guru-llms-txt.mdx
+++ b/packages/content/data/websites/ads-txt-guru-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'ads.txt Guru'
+description: 'Manage your ads.txt files online, automatically validate your ads.txt files, and collaborate between publisher and ad network to automate ads.txt updates.'
+website: 'https://adstxt.guru'
+llmsUrl: 'https://adstxt.guru/llms.txt'
+llmsFullUrl: 'https://adstxt.guru/llms-full.txt'
+category: 'marketing-sales'
+publishedAt: '2025-10-04'
+---
+
+# ads.txt Guru
+
+Manage your ads.txt files online, automatically validate your ads.txt files, and collaborate between publisher and ad network to automate ads.txt updates.


### PR DESCRIPTION
This PR adds ads.txt Guru to the llms.txt hub.

Submitted by: adstxt

**Website:** https://adstxt.guru
**llms.txt:** https://adstxt.guru/llms.txt
**llms-full.txt:** https://adstxt.guru/llms-full.txt  
**Category:** marketing-sales

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a new website entry for Ads.txt Guru, including name, description, website, LLMs.txt URLs, category, and publish date. This resource is now discoverable in listings and search.

- Documentation
  - Included a basic description of Ads.txt Guru to inform users about the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->