### PR TITLE
feat: add WatchMy.bike to llms.txt hub

### DIFF
--- a/packages/content/data/websites/watchmy-bike-llms-txt.mdx
+++ b/packages/content/data/websites/watchmy-bike-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'WatchMy.bike'
+description: 'Track every bike component, sync with Strava for automatic mileage, get maintenance alerts, and share your builds with a custom profile. Free to start.'
+website: 'https://watchmy.bike'
+llmsUrl: 'https://watchmy.bike/llms.txt'
+llmsFullUrl: ''
+category: 'agency-services'
+publishedAt: '2026-01-06'
+---
+
+# WatchMy.bike
+
+Track every bike component, sync with Strava for automatic mileage, get maintenance alerts, and share your builds with a custom profile. Free to start.


### PR DESCRIPTION
This PR adds WatchMy.bike to the llms.txt hub.

Submitted by: marien

**Website:** https://watchmy.bike
**llms.txt:** https://watchmy.bike/llms.txt

**Category:** agency-services

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new website entry to the content catalog.
> 
> - New `packages/content/data/websites/watchmy-bike-llms-txt.mdx` with frontmatter (`name`, `description`, `website`, `llmsUrl`, `llmsFullUrl`, `category: 'agency-services'`, `publishedAt`) and a short description section
> - Links WatchMy.bike site and its `llms.txt` for discovery
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 494bd862657224713dc4823a3736ae1d867552a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added new content documentation for WatchMy.bike website with metadata and descriptive information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->