### PR TITLE
feat: add UI Thing to llms-txt-hub

### DIFF
--- a/packages/content/data/websites/ui-thing-llms-txt.mdx
+++ b/packages/content/data/websites/ui-thing-llms-txt.mdx
@@ -10,20 +10,19 @@ priority: 'high'
 ---
 
 # UI Thing
-<br/>
+
 UI Thing is a collection of beautifully designed, reusable UI components built specifically for **Nuxt**, powered by **Reka UI** and **Tailwind CSS**. It follows a shadcn-style workflow where you scaffold components into your project so you can fully own and customize the code.
-<br/>
+
 ## Key Focus Areas
-<br/>
+
 - **Nuxt UI Components**: A large set of accessible components with clear examples and variants
 - **CLI Scaffolding**: Add components (plus required utilities/config) via `npx ui-thing@latest`
 - **Blocks & Templates**: Pre-built page blocks and patterns to assemble screens quickly
 - **AI Assistant Support (MCP)**: An MCP server so tools like Cursor, VS Code, and Claude can fetch component source code, docs, dependencies, and install steps
-<br/>
+
 ## About llms.txt Implementation
-<br/>
+
 UI Thing publishes both **/llms.txt** (fast navigation + essentials) and **/llms-full.txt** (full documentation context) so language models can reliably locate canonical docs, setup steps, and implementation details.
-<br/>
+
 For deeper tool-driven workflows, UI Thing also provides an **MCP server** at `https://uithing.com/mcp`, exposing structured resources, tools, and guided prompts to help AI assistants work with UI Thing components, blocks, and documentation.
-<br/>
 This makes it easy for developers using AI coding assistants to discover, understand, and implement UI Thing components directly within their coding environment.


### PR DESCRIPTION
### PR Title
Add UI Thing to llms-txt-hub registry

### Summary
This PR adds **UI Thing** to the llms-txt-hub registry so the VS Code extension(& other tools) can discover and fetch its **llms.txt** documentation.

### What’s included
- Added a new MDX registry entry for **UI Thing** with:
  - `name`, `description`, `website`
  - `llmsUrl` (`/llms.txt`) and `llmsFullUrl` (`/llms-full.txt`)
  - `category`, `priority`, and `publishedAt`
- Added additional context describing:
  - **Nuxt + Tailwind** component focus
  - **CLI scaffolding** workflow
  - **AI tooling support via MCP** (`/mcp`)

### Why
UI Thing provides LLM-readable docs and structured entry points that improve AI-assisted workflows in editors. Registering it ensures users can quickly access the canonical docs through the llmstxthub extension.

### Verification
- Confirmed the registry entry renders correctly in preview
- Verified `llms.txt` and `llms-full.txt` URLs resolve
- Confirmed formatting follows hub conventions (headings + bold emphasis)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive UI Thing documentation covering Nuxt UI components, CLI scaffolding, blocks & templates.
  * Documented AI assistant (MCP) integration and the purpose/use of llms.txt vs llms-full.txt for model navigation and context.
  * Noted availability of an MCP server for AI-assisted workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->