### PR TITLE
feat: Add Nitro to llms-txt-hub registry

### DIFF
--- a/packages/content/data/websites/nitro-llms-txt.mdx
+++ b/packages/content/data/websites/nitro-llms-txt.mdx
@@ -1,0 +1,26 @@
+---
+name: 'Nitro'
+description: 'Open source server toolkit for building web servers with h3 and deploying anywhere'
+website: 'https://nitro.build'
+llmsUrl: 'https://nitro.build/llms.txt'
+llmsFullUrl: 'https://nitro.build/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-01-18'
+priority: 'high'
+---
+
+# Nitro
+
+Nitro is an open source framework to build web servers using **h3** with a strong focus on portability and a "deploy anywhere" workflow. It can be used standalone and also powers the server engine for frameworks like **Nuxt**.
+
+## Key Focus Areas
+
+- **Server Framework** (h3-based)
+- **Filesystem Routing**
+- **Deploy Presets** (multiple providers and runtimes)
+- **Storage, Cache, and Database Utilities**
+- **Tasks and Server Utilities**
+
+## About llms.txt Implementation
+
+Nitro’s **llms.txt** acts as a curated entry point to the docs and links to **llms-full.txt** for the complete documentation corpus. This helps LLM-powered tools quickly find canonical guidance for routing, storage, caching, deployment presets, and runtime support.


### PR DESCRIPTION
### Summary
This PR adds **Nitro** to the registry so the VS Code extension(& other tools) can discover and fetch Nitro’s **llms.txt** documentation.

### What’s included
- Added a new MDX registry entry for **Nitro** with:
  - `name`, `description`, `website`
  - `llmsUrl` (`https://nitro.build/llms.txt`)
  - `llmsFullUrl` (`https://nitro.build/llms-full.txt`)
  - `category`, `priority`, and `publishedAt`

### Why
Nitro is a widely used open source server toolkit (built on **h3**) that targets “deploy anywhere” portability. Registering its `llms.txt` helps LLM-powered tools and the llmstxthub VS Code extension quickly locate canonical Nitro documentation and deep links.

### Verification
- Confirmed the registry entry renders correctly in preview
- Verified `llms.txt` and `llms-full.txt` URLs resolve
- Confirmed formatting follows hub conventions (headings + **bold** emphasis)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for Nitro covering its open source server toolkit features, including server framework capabilities, filesystem routing, deployment presets, and storage/cache/database utilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->