### PR TITLE
Add Kernel-Error technical blog

### DIFF
--- a/packages/content/data/websites/kernel-error-llms-txt.mdx
+++ b/packages/content/data/websites/kernel-error-llms-txt.mdx
@@ -5,7 +5,7 @@ website: 'https://www.kernel-error.de'
 llmsUrl: 'https://www.kernel-error.de/llms.txt'
 llmsFullUrl: 'https://www.kernel-error.de/llms-full.txt'
 category: 'personal'
-publishedAt: '2025-01-25'
+publishedAt: '2026-01-25'
 ---
 
 # Kernel-Error


### PR DESCRIPTION
## Summary
- Adds llms.txt entry for [kernel-error.de](https://www.kernel-error.de)
- German technical blog by IT security expert Sebastian van de Meer
- Running since 2003 with 600+ articles
- Topics: IT Security, FreeBSD, Mail Infrastructure (Postfix/Dovecot/DKIM/DMARC/DANE), DNS/DNSSEC, Self-Hosting

## Links
- Website: https://www.kernel-error.de
- llms.txt: https://www.kernel-error.de/llms.txt
- llms-full.txt: https://www.kernel-error.de/llms-full.txt

## Category
`personal` - Personal technical blog

## Checklist
- [x] llms.txt is publicly accessible
- [x] Website is active and maintained
- [x] Appropriate category selected
- [x] MDX file follows the required format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added new website content introducing the Kernel-Error blog, outlining its focus areas (IT security, mail infrastructure, DNS/DNSSEC, Unix/BSD/Linux, self-hosting, IoT) and an explainer on llms.txt implementation and security posture, including post-quantum crypto, DNSSEC/DANE/TLSA, and email authentication policies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->