### PR TITLE
Add Absurdity Index (absurdityindex.org)

### DIFF
--- a/packages/content/data/websites/absurdity-index-llms-txt.mdx
+++ b/packages/content/data/websites/absurdity-index-llms-txt.mdx
@@ -1,0 +1,21 @@
+---
+name: 'Absurdity Index'
+description: 'Scores real U.S. federal legislation on a 1-10 absurdity scale and publishes satirical common-sense bills. Features build-time Zod schema validation, Pagefind search, public JSON API, and embeddable bill widgets.'
+website: 'https://absurdityindex.org'
+llmsUrl: 'https://absurdityindex.org/llms.txt'
+llmsFullUrl: 'https://absurdityindex.org/llms-full.txt'
+category: 'content-media'
+publishedAt: '2026-02-11'
+---
+
+# Absurdity Index
+
+Absurdity Index scores real U.S. federal legislation on a 1–10 absurdity scale and publishes satirical common-sense alternative bills. Built with Astro 5, MDX, and Tailwind CSS v4, the site features structured content collections with Zod-validated frontmatter, Pagefind full-text search, a public JSON API, and embeddable bill widgets.
+
+## Key Features
+
+- Real bill coverage with sourced absurdity scores and congressional metadata
+- Satirical "sensible" and "absurd" alternative bills for commentary
+- Bill comparison, evolution tracking, cost calculator, and quiz tools
+- Public API at `/api/today.json` for daily featured legislation
+- Full llms.txt and llms-full.txt for AI-assisted discovery


### PR DESCRIPTION
## Summary

- Adds [Absurdity Index](https://absurdityindex.org) to the llms-txt-hub directory under the `content-media` category
- The site scores real U.S. federal legislation on a 1–10 absurdity scale and publishes satirical common-sense alternative bills
- Both `llms.txt` and `llms-full.txt` are served at the root: [llms.txt](https://absurdityindex.org/llms.txt) · [llms-full.txt](https://absurdityindex.org/llms-full.txt)

## Checklist

- [x] New MDX file created at `packages/content/data/websites/absurdity-index-llms-txt.mdx`
- [x] Follows existing entry format and schema
- [x] `llms.txt` and `llms-full.txt` URLs are live and accessible
- [x] Category: `content-media`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the Absurdity Index website, which scores U.S. legislation on an absurdity scale and provides bill comparison, evolution tracking, and public API access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->