### PR TITLE
Add Stagetimer

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -2401,7 +2401,7 @@
     "llmsTxtUrl": "https://stagetimer.io/llms.txt",
     "llmsFullTxtUrl": "https://stagetimer.io/llms-full.txt",
     "category": "developer-tools",
-    "favicon": "https://www.google.com/s2/favicons?domain=stagetimer.io&sz=128",
+    "favicon": "https://stagetimer.io/android-chrome-192x192.png",
     "publishedAt": "2026-02-18"
   },
   {


### PR DESCRIPTION
**Name:** Stagetimer
**Domain:** https://stagetimer.io
**Description:** Cloud-based, remote-controlled countdown timer for live events, presentations, broadcasts, and video productions. Control timers from one device while presenters see a fullscreen countdown on another.
**Category:** developer-tools

**Links:**
- llms.txt: https://stagetimer.io/llms.txt
- llms-full.txt: https://stagetimer.io/llms-full.txt
- OpenAPI spec: https://storage.googleapis.com/stagetimer-prod.appspot.com/public/stagetimer-api-v1-spec.yaml

Stagetimer offers both HTTP endpoints and a socket.io endpoint for real-time updates. The API is available with any paid license. Used by event producers, broadcast operators, and video production studios worldwide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stagetimer, a cloud-based countdown timer service for live events, presentations, broadcasts, and video productions with remote control capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->