### PR TITLE
feat(community): add zKettle to llms.txt hub

### DIFF
--- a/packages/content/data/websites/zkettle-llms-txt.mdx
+++ b/packages/content/data/websites/zkettle-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'zKettle'
+description: 'Self-hosted zero-knowledge encrypted secrets that boil away. AES-256-GCM encryption, one-time URLs, configurable burn. Single binary. AI-native.'
+website: 'https://github.com/benderterminal/zkettle/'
+llmsUrl: 'https://github.com/benderterminal/zkettle/blob/main/llms.txt'
+llmsFullUrl: ''
+category: 'security-identity'
+publishedAt: '2026-02-24'
+---
+
+# zKettle
+
+Self-hosted zero-knowledge encrypted secrets that boil away. AES-256-GCM encryption, one-time URLs, configurable burn. Single binary. AI-native.


### PR DESCRIPTION
This PR adds zKettle to the llms.txt hub.

Submitted by: benderterminal

**Website:** https://github.com/benderterminal/zkettle/
**llms.txt:** https://github.com/benderterminal/zkettle/blob/main/llms.txt

**Category:** security-identity

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new content page for the zKettle project with project information and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->