### PR TITLE
Add Silicon Friendly: MCP server rating websites on AI-agent compatibility (L0-L5)

### DIFF
--- a/packages/content/data/websites/silicon-friendly-llms-txt.mdx
+++ b/packages/content/data/websites/silicon-friendly-llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
 name: 'Silicon Friendly'
-description: 'siliconfriendly.com - Directory that rates websites on AI-agent friendliness using a 30-criteria L0-L5 taxonomy'
+description: 'Directory that rates websites on AI-agent friendliness using a 30-criteria L0-L5 taxonomy'
 website: 'https://siliconfriendly.com'
 llmsUrl: 'https://siliconfriendly.com/llms.txt'
 category: 'other'
@@ -9,4 +9,4 @@ publishedAt: '2026-02-25'
 
 # Silicon Friendly
 
-siliconfriendly.com - Directory that rates websites on AI-agent friendliness using a 30-criteria L0-L5 taxonomy. Search the entire internet to find which websites are truly accessible to AI agents.
+Silicon Friendly is a directory that rates websites on AI-agent friendliness using a 30-criteria L0-L5 taxonomy. Search the entire internet to find which websites are truly accessible to AI agents.


### PR DESCRIPTION
## Summary

Adds [Silicon Friendly](https://siliconfriendly.com) to the websites directory.

Silicon Friendly is a directory that rates websites on AI-agent friendliness using a 30-criteria L0-L5 taxonomy. It helps users discover which websites are truly accessible to AI agents.

- **Website**: https://siliconfriendly.com
- **llms.txt**: https://siliconfriendly.com/llms.txt
- **Category**: other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new content page for siliconfriendly.com with front-matter metadata (name, description, website link, AI-models URL, category, publish date) and a page section describing the site and its AI-agent friendliness rating approach. This adds discoverable content and contextual information for end-users viewing the site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->