### PR TITLE
feat: add Washin Village Guide (和心村ガイド)

### DIFF
--- a/packages/content/data/websites/washin-village-guide-llms-txt.mdx
+++ b/packages/content/data/websites/washin-village-guide-llms-txt.mdx
@@ -1,0 +1,31 @@
+---
+name: 'Washin Village Guide'
+description: 'Official guide for Washin Village (和心村) — a satoyama glamping retreat in Futtsu, Chiba, Japan. Features a 200-year-old farmhouse, 16 rescue cats, Finnish wood-fired sauna, and Kengo Kuma × Snow Peak JYUBAKO units. Multilingual (JA/EN/ZH-TW) with TQ experience data from 262 real Google Maps reviews.'
+website: 'https://guide.washinmura.jp'
+llmsUrl: 'https://guide.washinmura.jp/llms.txt'
+llmsFullUrl: 'https://guide.washinmura.jp/llms-full.txt'
+category: 'international'
+publishedAt: '2026-02-26'
+---
+
+# Washin Village Guide (和心村ガイド)
+
+Washin Village is a satoyama glamping retreat located in the Boso Peninsula, Chiba, Japan — about 80 minutes from Tokyo. The facility is an animal sanctuary with 16 rescue cats, dogs, and goats, combined with premium accommodation and nature experiences.
+
+## Key Features
+
+- 200-year-old traditional Japanese farmhouse (kominka)
+- Kengo Kuma × Snow Peak "JYUBAKO" mobile architecture units
+- Finnish wood-fired sauna (free for guests)
+- 16 rescue cats roaming freely 24/7
+- BBQ with local ingredients, bonfire experiences
+
+## About llms.txt Implementation
+
+Washin Village maintains comprehensive AI-readable documentation:
+
+- `/llms.txt` — Structured overview with room types, experiences, FAQ, and blog index
+- `/llms-full.txt` — Full detailed content for deep AI understanding
+- TQ (Tourism Quantum) API — AI analysis of 262 real Google Maps reviews across 12 experience categories
+- All 32 blog articles available in 3 languages (Japanese, English, Traditional Chinese)
+- Schema.org structured data and AI content declaration meta tags on every page


### PR DESCRIPTION
## New Website Submission

**Washin Village Guide** (和心村ガイド) — Official guide for a satoyama glamping retreat in Futtsu, Chiba, Japan.

### Details

| Field | Value |
|-------|-------|
| Website | https://guide.washinmura.jp |
| llms.txt | https://guide.washinmura.jp/llms.txt |
| llms-full.txt | https://guide.washinmura.jp/llms-full.txt |
| Category | international |
| Languages | Japanese, English, Traditional Chinese |

### Why This Site

- 200-year-old farmhouse, 16 rescue cats, Finnish sauna, Kengo Kuma × Snow Peak units
- Comprehensive llms.txt with structured facility info, room types, experiences, FAQ, and 32 blog articles
- TQ (Tourism Quantum) API providing AI analysis of 262 real Google Maps reviews
- Schema.org structured data and AI content declaration meta tags on every page
- Full AEO (AI Engine Optimization) implementation

### Verification

```bash
curl -s https://guide.washinmura.jp/llms.txt | head -5
curl -s https://guide.washinmura.jp/llms-full.txt | head -5
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Washin Village Guide content resource with multilingual blog articles and llms.txt implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->