### PR TITLE
feat(community): add Inbox SuperPilot to llms.txt hub

### DIFF
--- a/packages/content/data/websites/inboxsuperpilot-com-llms-txt.mdx
+++ b/packages/content/data/websites/inboxsuperpilot-com-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'inboxsuperpilot.com'
+description: 'AI email intelligence platform for Gmail. Drafts with citations from your knowledge base, voice matching, auto-archive, and outreach sequences.'
+website: 'https://inboxsuperpilot.com'
+llmsUrl: 'https://inboxsuperpilot.com/llms.txt'
+category: 'saas'
+publishedAt: '2026-03-03'
+---
+
+# Inbox SuperPilot
+
+AI email intelligence platform for Gmail. Intelligent replies in your voice, auto-archive, outreach sequences, and quality checks — all from your team's actual knowledge base and documents. Every draft cites its sources. Free Chrome extension.


### PR DESCRIPTION
## Add Inbox SuperPilot

- **Website:** https://inboxsuperpilot.com
- **llms.txt:** https://inboxsuperpilot.com/llms.txt
- **Category:** SaaS
- **Description:** AI email intelligence platform for Gmail. Drafts with citations from your knowledge base, voice matching, auto-archive, and outreach sequences.

The llms.txt file follows the llmstxt.org spec with H1 title, blockquote description, 6 H2 sections (Core Pages, Use Cases, Comparisons, Case Studies, Optional, Contact), and 26 annotated links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added website entry for Inbox SuperPilot, an AI-powered email intelligence platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->