### PR TITLE
Add Strale - The trust layer for AI agents

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -4555,7 +4555,7 @@
   {
   "name": "Strale",
   "domain": "https://strale.dev",
-  "description": "Capability marketplace for AI agents. Agents call strale.do(task) to buy missing capabilities at runtime across multiple verticals and countries.",
+  "description": "The trust layer for AI agents. One API to access hundreds of capabilities at runtime, with built-in audit trails and compliance.",
   "llmsTxtUrl": "https://strale.dev/llms.txt",
   "category": "ai-ml",
   "favicon": "https://www.google.com/s2/favicons?domain=strale.dev&sz=128",


### PR DESCRIPTION
Adds [Strale](https://strale.dev/) to the directory.

Strale is the trust layer for AI agents — one API to access hundreds of capabilities at runtime, with built-in audit trails and compliance. MCP server, A2A Agent Cards, and framework plugins for LangChain, Semantic Kernel, and CrewAI.

- llms.txt: https://strale.dev/llms.txt
- Category: AI & ML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Strale as a new website source, including its domain, description, category, favicon, and published date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->