### PR TITLE
feat(community): add CerebrusPulse to llms.txt hub

### DIFF
--- a/packages/content/data/websites/cerebruspulse-llms-txt.mdx
+++ b/packages/content/data/websites/cerebruspulse-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'CerebrusPulse'
+description: 'Real-time crypto intelligence API for Hyperliquid perpetuals. Technical analysis, sentiment, funding rates for 30+ perps via x402 micropayments.'
+website: 'https://cerebruspulse.xyz'
+llmsUrl: 'https://cerebruspulse.xyz/llms.txt'
+category: 'finance-fintech'
+publishedAt: '2026-03-04'
+---
+
+# CerebrusPulse
+
+Real-time crypto intelligence API for Hyperliquid perpetuals. Technical analysis, sentiment, funding rates for 30+ perps via x402 micropayments.


### PR DESCRIPTION
This PR adds CerebrusPulse to the llms.txt hub.

**Website:** https://cerebruspulse.xyz
**llms.txt:** https://cerebruspulse.xyz/llms.txt
**Category:** finance-fintech

**Description:** Real-time crypto intelligence API for Hyperliquid perpetuals. Technical analysis, sentiment, funding rates for 30+ perps via x402 micropayments.

---

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CerebrusPulse website entry with metadata and description information to the content database.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->