### PR TITLE
feat: add Purple Flea to websites.json

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -3983,6 +3983,16 @@
     "publishedAt": "2025-04-07"
   },
   {
+    "name": "Purple Flea",
+    "domain": "https://purpleflea.com",
+    "description": "Blue chip financial infrastructure for AI agents — casino, wallet, trading, domains, escrow, and faucet APIs",
+    "llmsTxtUrl": "https://purpleflea.com/llms.txt",
+    "llmsFullTxtUrl": "https://purpleflea.com/llms.txt",
+    "category": "finance",
+    "favicon": "https://www.google.com/s2/favicons?domain=purpleflea.com&sz=128",
+    "publishedAt": "2026-03-06"
+  },
+  {
     "name": "Pydantic",
     "domain": "https://docs.pydantic.dev/latest/",
     "description": "Pydantic is the most widely used data validation library for Python.",


### PR DESCRIPTION
## Summary

- Adds [Purple Flea](https://purpleflea.com) to the llms-txt-hub directory
- Purple Flea provides blue chip financial infrastructure for AI agents: casino, wallet, trading, domains, escrow, and faucet APIs
- llms.txt is live at https://purpleflea.com/llms.txt
- Category: `finance`

## Checklist

- [x] Entry added to `data/websites.json`
- [x] `llmsTxtUrl` verified live: https://purpleflea.com/llms.txt
- [x] `category` set to `finance`
- [x] JSON is valid and alphabetically ordered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Purple Flea to the website collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->