### PR TITLE
Add TryOpenClaw.ai

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -4865,15 +4865,6 @@
     "publishedAt": "2025-08-26"
   },
   {
-    "name": "TryOpenClaw.ai",
-    "domain": "https://www.tryopenclaw.ai",
-    "description": "Managed hosting platform for OpenClaw, the open-source AI assistant that connects to WhatsApp, Telegram, Discord, Slack, and iMessage.",
-    "llmsTxtUrl": "https://www.tryopenclaw.ai/llms.txt",
-    "category": "infrastructure-cloud",
-    "favicon": "https://www.google.com/s2/favicons?domain=www.tryopenclaw.ai&sz=128",
-    "publishedAt": "2026-03-01"
-  },
-  {
     "name": "Turbo",
     "domain": "https://turbo.build",
     "description": "Turbo is an incremental bundler and build system optimized for JavaScript and TypeScript, written in Rust.",

--- a/packages/content/data/websites/tryopenclaw-ai-llms-txt.mdx
+++ b/packages/content/data/websites/tryopenclaw-ai-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'TryOpenClaw.ai'
+description: 'Managed hosting platform for OpenClaw, the open-source AI assistant that connects to WhatsApp, Telegram, Discord, Slack, and iMessage.'
+website: 'https://www.tryopenclaw.ai'
+llmsUrl: 'https://www.tryopenclaw.ai/llms.txt'
+category: 'infrastructure-cloud'
+publishedAt: '2026-03-01'
+---
+
+# TryOpenClaw.ai
+
+Managed hosting platform for OpenClaw, the open-source AI assistant that connects to WhatsApp, Telegram, Discord, Slack, and iMessage.


### PR DESCRIPTION
Adds TryOpenClaw.ai to the directory.

- **Name**: TryOpenClaw.ai
- **Domain**: https://www.tryopenclaw.ai
- **llms.txt**: https://www.tryopenclaw.ai/llms.txt
- **Category**: infrastructure-cloud
- **Description**: Managed hosting platform for OpenClaw, the open-source AI assistant that connects to WhatsApp, Telegram, Discord, Slack, and iMessage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added website information for TryOpenClaw.ai, a managed hosting platform for OpenClaw integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->