### PR TITLE
fix(web): restore CSRF protection for extension feedback submissions

### DIFF
--- a/apps/web/__tests__/middleware-public-routes.test.ts
+++ b/apps/web/__tests__/middleware-public-routes.test.ts
@@ -10,11 +10,11 @@ describe('middleware public route coverage', () => {
     expect(source).toContain("'/api/extension-feedback(.*)'")
   })
 
-  it('exempts uninstall feedback route from CSRF validation', () => {
+  it('keeps uninstall feedback route protected by CSRF validation', () => {
     const middlewarePath = join(process.cwd(), 'middleware.ts')
     const source = readFileSync(middlewarePath, 'utf8')
 
-    expect(source).toContain("!req.nextUrl.pathname.startsWith('/api/extension-feedback')")
+    expect(source).not.toContain("!req.nextUrl.pathname.startsWith('/api/extension-feedback')")
   })
 
   it('allows plausible analytics proxy non-safe method requests', () => {

--- a/apps/web/app/extension/uninstall/__tests__/uninstall-feedback-form.test.tsx
+++ b/apps/web/app/extension/uninstall/__tests__/uninstall-feedback-form.test.tsx
@@ -57,6 +57,11 @@ describe('UninstallFeedbackForm', () => {
   })
 
   it('submits expected payload directly to extension feedback API', async () => {
+    const csrfMeta = document.createElement('meta')
+    csrfMeta.setAttribute('name', 'csrf-token')
+    csrfMeta.setAttribute('content', 'test-csrf-token')
+    document.head.appendChild(csrfMeta)
+
     const fetchMock = jest.fn().mockResolvedValueOnce({
       ok: true,
       json: async () => ({ ok: true })
@@ -88,7 +93,8 @@ describe('UninstallFeedbackForm', () => {
       expect.objectContaining({
         method: 'POST',
         headers: expect.objectContaining({
-          'Content-Type': 'application/json'
+          'Content-Type': 'application/json',
+          'x-csrf-token': 'test-csrf-token'
         })
       })
     )
@@ -106,6 +112,8 @@ describe('UninstallFeedbackForm', () => {
     await waitFor(() => {
       expect(screen.getByText('Thanks for the feedback')).toBeInTheDocument()
     })
+
+    csrfMeta.remove()
   })
 
   it('shows an error state when API submission fails', async () => {

--- a/apps/web/app/extension/uninstall/uninstall-feedback-form.tsx
+++ b/apps/web/app/extension/uninstall/uninstall-feedback-form.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { useMemo, useState } from 'react'
+import { fetchWithCSRF } from '@/lib/csrf-client'
 import { getRoute } from '@/lib/routes'
 
 export const UNINSTALL_REASONS = [
@@ -60,7 +61,7 @@ export function UninstallFeedbackForm({ version, lang }: UninstallFeedbackFormPr
     try {
       setSubmitState('submitting')
 
-      const response = await fetch('/api/extension-feedback', {
+      const response = await fetchWithCSRF('/api/extension-feedback', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json'

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -412,7 +412,6 @@ export default clerkMiddleware(async (auth, req) => {
       !req.nextUrl.pathname.startsWith('/api/members') &&
       !req.nextUrl.pathname.startsWith('/api/auth') &&
       !req.nextUrl.pathname.startsWith('/api/cli/') &&
-      !req.nextUrl.pathname.startsWith('/api/extension-feedback') &&
       !['GET', 'HEAD', 'OPTIONS'].includes(req.method)
     ) {
       const isValidCSRF = await validateCSRFToken(req)


### PR DESCRIPTION
### Motivation

- The extension uninstall feedback endpoint was previously exempted from CSRF validation and the client stopped sending a CSRF token, enabling cross-site POSTs that could pollute analytics and bypass IP rate limits. 
- The change restores same-origin CSRF protection for non-safe methods on `/api/extension-feedback` while preserving the anonymous uninstall feedback flow.

### Description

- Removed the explicit exemption for `/api/extension-feedback` from the middleware CSRF skip list so non-safe requests are validated via `validateCSRFToken` (file: `apps/web/middleware.ts`).
- Updated the uninstall feedback client to use `fetchWithCSRF(...)` so the client sends the `x-csrf-token` header when a token is available (file: `apps/web/app/extension/uninstall/uninstall-feedback-form.tsx`).
- Adjusted tests to reflect secure behavior: the middleware test now asserts the feedback route is not CSRF-exempt and the uninstall form test injects a CSRF meta token and verifies the `x-csrf-token` header is sent (files: `apps/web/__tests__/middleware-public-routes.test.ts` and `apps/web/app/extension/uninstall/__tests__/uninstall-feedback-form.test.tsx`).

### Testing

- Ran `pnpm test -- --runTestsByPath __tests__/middleware-public-routes.test.ts` and it passed.
- Ran `pnpm test -- --runTestsByPath app/extension/uninstall/__tests__/uninstall-feedback-form.test.tsx` and it passed.
- All modified unit tests passed locally, validating that the endpoint is protected and the client includes the CSRF token header.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69adb11d56e0832f839ed8c5c66d6102)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled CSRF protection on the extension uninstall feedback submission form to ensure consistent security coverage across all API endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->