### PR TITLE
feat(community): add cloud-latitude-GCN2026-raffle to llms.txt hub

### DIFF
--- a/packages/content/data/websites/cloud-latitude-gcn2026-raffle-llms-txt.mdx
+++ b/packages/content/data/websites/cloud-latitude-gcn2026-raffle-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'cloud-latitude-GCN2026-raffle'
+description: 'Book a free 10-minute Cloud Intel Brief with Cloud Latitude and enter to win conference passes, hotel stays, and flights to Google Cloud Next 2026 in Las Vegas.'
+website: 'https://cloudlatitude.io/'
+llmsUrl: 'https://cloudlatitude.io/llms.txt'
+llmsFullUrl: 'https://cloudlatitude.io/llms-full.txt'
+category: 'marketing-sales'
+publishedAt: '2026-03-09'
+---
+
+# cloud-latitude-GCN2026-raffle
+
+Book a free 10-minute Cloud Intel Brief with Cloud Latitude and enter to win conference passes, hotel stays, and flights to Google Cloud Next 2026 in Las Vegas.


### PR DESCRIPTION
This PR adds cloud-latitude-GCN2026-raffle to the llms.txt hub.

Submitted by: joe

**Website:** https://cloudlatitude.io/
**llms.txt:** https://cloudlatitude.io/llms.txt
**llms-full.txt:** https://cloudlatitude.io/llms-full.txt  
**Category:** marketing-sales

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new content describing a Cloud Intel Brief booking opportunity and raffle prize details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->