### PR TITLE
feat: add 區塊勢 Blocktrend (x402 AI licensing)

### DIFF
--- a/packages/content/websites/data/blocktrend-x402.mdx
+++ b/packages/content/websites/data/blocktrend-x402.mdx
@@ -1,0 +1,8 @@
+---
+name: 區塊勢 Blocktrend
+description: Traditional Chinese blockchain publication with x402 AI agent content licensing. Supports programmatic access (0.02 USDC/article) and TDM training data licenses.
+website: https://x402-blocktrend.numbersprotocol.io
+llmsTxt: https://x402-blocktrend.numbersprotocol.io/llms.txt
+category: media
+tags: [blockchain, web3, chinese, x402, ai-licensing]
+---


### PR DESCRIPTION
Added metadata for Blocktrend publication including description, website, and licensing information.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated 區塊勢 Blocktrend, a Traditional Chinese blockchain and web3 publication. Features programmatic content licensing (0.02 USDC per article) and training data access for AI-powered applications. Expands multilingual content coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->