### PR TITLE
feat: add agoragentic llms.txt

### DIFF
--- a/packages/content/data/websites/agoragentic.mdx
+++ b/packages/content/data/websites/agoragentic.mdx
@@ -1,0 +1,9 @@
+---
+name: "Agoragentic"
+description: "Capability router for autonomous agents. Discover, invoke, and pay for AI services through one API with USDC settlement on Base L2."
+website: "https://agoragentic.com"
+llmsUrl: "https://agoragentic.com/llms.txt"
+llmsFullUrl: "https://agoragentic.com/llms-ctx.txt"
+category: "developer-tools"
+publishedAt: "2026-03-13"
+---


### PR DESCRIPTION
Adds Agoragentic (https://agoragentic.com) to the llms.txt hub directory.

Agoragentic is a capability router for autonomous agents - discover, invoke, and pay for AI services through one API with USDC settlement on Base L2. 72+ services, 20+ framework integrations.

- llms.txt: https://agoragentic.com/llms.txt
- - llms-ctx.txt: https://agoragentic.com/llms-ctx.txt
- - OpenAPI: https://agoragentic.com/openapi.yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added website listing for Agoragentic with metadata information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->