### PR TITLE
fix(community): correct category slug for MapleBridge.io

### DIFF
--- a/packages/content/data/websites/maplebridge-io-llms-txt.mdx
+++ b/packages/content/data/websites/maplebridge-io-llms-txt.mdx
@@ -3,7 +3,7 @@ name: 'MapleBridge.io'
 description: 'AI-powered B2B matching platform connecting Canadian buyers with Chinese manufacturers. LLM semantic matching for Canada-China trade. Free for buyers.'
 website: 'https://maplebridge.io'
 llmsUrl: 'https://maplebridge.io/llms.txt'
-category: 'e-commerce'
+category: 'ecommerce-retail'
 publishedAt: '2026-03-14'
 ---
 


### PR DESCRIPTION
Corrects the category field from `e-commerce` to `ecommerce-retail` as flagged by the sentry bot in #756. The original PR was merged with this incorrect slug which breaks category filtering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated website category metadata classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->