### PR TITLE
Add mailbox.bot

### DIFF
--- a/packages/content/data/websites/mailbox-bot-llms-txt.mdx
+++ b/packages/content/data/websites/mailbox-bot-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'mailbox.bot'
+description: 'CMRA postal mail infrastructure for AI agents. Real mailing address ($2/mo), inbound scanning, outbound print-and-mail via API. MCP, A2A, OpenClaw, REST.'
+website: 'https://mailbox.bot'
+llmsUrl: 'https://mailbox.bot/llms.txt'
+llmsFullUrl: 'https://mailbox.bot/llms-full.txt'
+category: 'automation-workflow'
+publishedAt: '2026-03-25'
+---
+
+# mailbox.bot
+
+CMRA postal mail infrastructure for AI agents. Real mailing address ($2/mo), inbound scanning, outbound print-and-mail via API. MCP, A2A, OpenClaw, REST.

--- a/packages/content/data/websites/mailbox-bot-llms-txt.mdx
+++ b/packages/content/data/websites/mailbox-bot-llms-txt.mdx
@@ -1,13 +1,18 @@
----
-name: 'mailbox.bot'
-description: 'CMRA postal mail infrastructure for AI agents. Real mailing address ($2/mo), inbound scanning, outbound print-and-mail via API. MCP, A2A, OpenClaw, REST.'
-website: 'https://mailbox.bot'
-llmsUrl: 'https://mailbox.bot/llms.txt'
-llmsFullUrl: 'https://mailbox.bot/llms-full.txt'
-category: 'automation-workflow'
-publishedAt: '2026-03-25'
----
+  ---
+  name: 'mailbox.bot'                                                                                                                                       
+  description: 'CMRA postal mail infrastructure for AI agents. Outbound print-and-mail live via API. Inbound scanning in beta ($5/mo). MCP, A2A, OpenClaw,
+  REST.'                                                                                                                                                    
+  website: 'https://mailbox.bot'
+  llmsUrl: 'https://mailbox.bot/llms.txt'                                                                                                                   
+  llmsFullUrl: 'https://mailbox.bot/llms-full.txt'
+  category: 'integration-automation'                                                                                                                        
+  publishedAt: '2026-03-25'                                                                                                                                 
+  ---
+                                                                                                                                                            
+  # mailbox.bot   
 
-# mailbox.bot
-
-CMRA postal mail infrastructure for AI agents. Real mailing address ($2/mo), inbound scanning, outbound print-and-mail via API. MCP, A2A, OpenClaw, REST.
+  CMRA postal mail infrastructure for AI agents. Outbound print-and-mail live via API. Inbound scanning in beta ($5/mo). MCP, A2A, OpenClaw, REST.          
+   
+  Two changes from what you had:                                                                                                                            
+  1. category → integration-automation (fixes the CodeRabbit issue)
+  2. Description rewritten to reflect outbound=live, inbound=beta $5/mo    

--- a/packages/content/data/websites/mailbox-bot-llms-txt.mdx
+++ b/packages/content/data/websites/mailbox-bot-llms-txt.mdx
@@ -1,18 +1,13 @@
-  ---
-  name: 'mailbox.bot'                                                                                                                                       
-  description: 'CMRA postal mail infrastructure for AI agents. Outbound print-and-mail live via API. Inbound scanning in beta ($5/mo). MCP, A2A, OpenClaw,
-  REST.'                                                                                                                                                    
-  website: 'https://mailbox.bot'
-  llmsUrl: 'https://mailbox.bot/llms.txt'                                                                                                                   
-  llmsFullUrl: 'https://mailbox.bot/llms-full.txt'
-  category: 'integration-automation'                                                                                                                        
-  publishedAt: '2026-03-25'                                                                                                                                 
-  ---
-                                                                                                                                                            
-  # mailbox.bot   
+---
+name: 'mailbox.bot'
+description: 'CMRA postal mail infrastructure for AI agents. Outbound print-and-mail live via API. Inbound scanning in beta ($5/mo). MCP, A2A, OpenClaw, REST.'
+website: 'https://mailbox.bot'
+llmsUrl: 'https://mailbox.bot/llms.txt'
+llmsFullUrl: 'https://mailbox.bot/llms-full.txt'
+category: 'integration-automation'
+publishedAt: '2026-03-25'
+---
 
-  CMRA postal mail infrastructure for AI agents. Outbound print-and-mail live via API. Inbound scanning in beta ($5/mo). MCP, A2A, OpenClaw, REST.          
-   
-  Two changes from what you had:                                                                                                                            
-  1. category → integration-automation (fixes the CodeRabbit issue)
-  2. Description rewritten to reflect outbound=live, inbound=beta $5/mo    
+# mailbox.bot
+
+CMRA postal mail infrastructure for AI agents. Outbound print-and-mail live via API. Inbound scanning in beta ($5/mo). MCP, A2A, OpenClaw, REST.

--- a/packages/content/data/websites/mailbox-bot-llms-txt.mdx
+++ b/packages/content/data/websites/mailbox-bot-llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
 name: 'mailbox.bot'
-description: 'CMRA postal mail infrastructure for AI agents. Outbound print-and-mail live via API. Inbound scanning in beta ($5/mo). MCP, A2A, OpenClaw, REST.'
+description: 'Postal mail API for AI agents. Send outbound physical mail and turn forwarded inbound scans, PDFs, photos, and notices into structured drafting context. MCP, A2A, OpenClaw, REST.'
 website: 'https://mailbox.bot'
 llmsUrl: 'https://mailbox.bot/llms.txt'
 llmsFullUrl: 'https://mailbox.bot/llms-full.txt'
@@ -10,4 +10,4 @@ publishedAt: '2026-03-25'
 
 # mailbox.bot
 
-CMRA postal mail infrastructure for AI agents. Outbound print-and-mail live via API. Inbound scanning in beta ($5/mo). MCP, A2A, OpenClaw, REST.
+mailbox.bot is a postal mail API for AI agents and software. It supports outbound physical mail via API plus forwarded inbound mail context from scans, PDFs, photos, provider notices, and human notes, with access through MCP, A2A, OpenClaw, and REST.


### PR DESCRIPTION
## Adding mailbox.bot

- **Website**: https://mailbox.bot
- **llms.txt**: https://mailbox.bot/llms.txt
- **llms-full.txt**: https://mailbox.bot/llms-full.txt
- **Category**: integration-automation

mailbox.bot is a postal mail API for AI agents and software. It supports two live workflows: outbound physical mail via API, and forwarded inbound mail context from scans, PDFs, photos, provider notices, and human notes that agents can use to draft linked replies.

It exposes llms.txt and llms-full.txt and integrates through MCP, A2A, OpenClaw, and REST.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a mailbox.bot listing to the website directory: postal mail API for AI agents — outbound physical mail via API, inbound scans/PDFs/photos converted for drafting context, and LLM integration endpoints (MCP, A2A, OpenClaw, REST). Categorized as "integration-automation", published 2026-03-25.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thedaviddias/llms-txt-hub/pull/804?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->