### PR TITLE
Add SoloFury - Multi-coin SHA-256 solo mining pool

### DIFF
--- a/packages/content/data/websites/solofury-llms-txt.mdx
+++ b/packages/content/data/websites/solofury-llms-txt.mdx
@@ -1,0 +1,8 @@
+---
+domain: "solofury.com"
+name: "SoloFury"
+category: "crypto"
+description: "Multi-coin SHA-256 solo mining pool supporting BCH, BTC, BC2, BCH2 and XEC. No registration required, automatic vardiff, 3 global servers, direct trustless payouts."
+llmsTxtUrl: "https://solofury.com/llms.txt"
+llmsFullTxtUrl: "https://solofury.com/llms-full.txt"
+---

--- a/packages/content/data/websites/solofury-llms-txt.mdx
+++ b/packages/content/data/websites/solofury-llms-txt.mdx
@@ -1,8 +1,9 @@
 ---
-domain: "solofury.com"
+website: "solofury.com"
 name: "SoloFury"
-category: "crypto"
+category: "finance-fintech"
 description: "Multi-coin SHA-256 solo mining pool supporting BCH, BTC, BC2, BCH2 and XEC. No registration required, automatic vardiff, 3 global servers, direct trustless payouts."
-llmsTxtUrl: "https://solofury.com/llms.txt"
-llmsFullTxtUrl: "https://solofury.com/llms-full.txt"
+llmsUrl: "https://solofury.com/llms.txt"
+llmsFullUrl: "https://solofury.com/llms-full.txt"
+publishedAt: "2026-04-06"
 ---


### PR DESCRIPTION
Adding SoloFury (solofury.com) to the llms.txt directory. SoloFury is a multi-coin SHA-256 solo mining pool with direct trustless payouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Content**
  * Added a SoloFury profile for solofury.com to the supported websites directory, including site name, finance/fintech category, a description of the multi-coin SHA-256 solo mining pool, and publication timestamp.
  * Included public links to the site's llms.txt and llms-full.txt so the LLMs listing can reference its published policies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->