### PR TITLE
feat(community): add Sidero Labs to llms.txt hub

### DIFF
--- a/packages/content/data/websites/sidero-labs-llms-txt.mdx
+++ b/packages/content/data/websites/sidero-labs-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Sidero Labs'
+description: 'Sidero Labs builds Talos Linux, an immutable API-driven Kubernetes OS, and Omni, a managed infrastructure control plane for Talos clusters at scale.'
+website: 'https://docs.siderolabs.com'
+llmsUrl: 'https://docs.siderolabs.com/llms.txt'
+llmsFullUrl: 'https://docs.siderolabs.com/llms-full.txt'
+category: 'infrastructure-cloud'
+publishedAt: '2026-04-11'
+---
+
+# Sidero Labs
+
+Sidero Labs builds Talos Linux, an immutable API-driven Kubernetes OS, and Omni, a managed infrastructure control plane for Talos clusters at scale.


### PR DESCRIPTION
This PR adds Sidero Labs to the llms.txt hub.

**Website:** https://docs.siderolabs.com
**llms.txt:** https://docs.siderolabs.com/llms.txt
**llms-full.txt:** https://docs.siderolabs.com/llms-full.txt  
**Category:** infrastructure-cloud

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Sidero Labs website documentation with AI content specification resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->