### PR TITLE
feat: add KIKMAL - FTM prosthetics e-commerce

### DIFF
--- a/packages/content/data/websites/kikmal-llms-txt.mdx
+++ b/packages/content/data/websites/kikmal-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'KIKMAL'
+description: 'FTM prosthetics and packing gear for trans men. Medical-grade silicone STP packers, soft packers, harnesses, and binders designed for comfort, confidence, and daily wear.'
+website: 'https://kikmal.com/'
+llmsUrl: 'https://kikmal.com/llms.txt'
+llmsFullUrl: ''
+category: 'e-commerce'
+publishedAt: '2026-04-12'
+---
+
+# KIKMAL
+
+FTM prosthetics and packing gear for trans men. Medical-grade silicone STP packers, soft packers, harnesses, and binders designed for comfort, confidence, and daily wear.


### PR DESCRIPTION
This PR adds KIKMAL to the llms.txt hub.

- Website: https://kikmal.com
- llms.txt: https://kikmal.com/llms.txt
- Category: e-commerce

KIKMAL is an FTM prosthetics store offering medical-grade silicone STP packers, soft packers, harnesses, and binders for trans men and non-binary individuals.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added KIKMAL, an e-commerce website, to the platform with corresponding metadata and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->