### PR TITLE
feat(community): add REinfinite Group, REinfinite Ltd, InfiniVerde

### DIFF
--- a/packages/content/data/websites/infiniverde-llms-txt.mdx
+++ b/packages/content/data/websites/infiniverde-llms-txt.mdx
@@ -3,7 +3,7 @@ name: 'InfiniVerde Ltd'
 description: 'Closed-source quantitative research across 30+ UK and European built environment markets.'
 website: 'https://infiniverde.com'
 llmsUrl: 'https://infiniverde.com/llms.txt'
-llmsFullUrl: ''
+llmsFullUrl: null
 category: 'data-analytics'
 publishedAt: '2026-04-13'
 ---

--- a/packages/content/data/websites/infiniverde-llms-txt.mdx
+++ b/packages/content/data/websites/infiniverde-llms-txt.mdx
@@ -1,5 +1,5 @@
 ---
-name: 'InfiniVerde'
+name: 'InfiniVerde Ltd'
 description: 'Closed-source quantitative research across 30+ UK and European built environment markets.'
 website: 'https://infiniverde.com'
 llmsUrl: 'https://infiniverde.com/llms.txt'
@@ -8,6 +8,6 @@ category: 'data-analytics'
 publishedAt: '2026-04-13'
 ---
 
-# InfiniVerde
+# InfiniVerde Ltd
 
 Closed-source quantitative research across 30+ UK and European built environment markets.

--- a/packages/content/data/websites/infiniverde-llms-txt.mdx
+++ b/packages/content/data/websites/infiniverde-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'InfiniVerde'
+description: 'Closed-source quantitative research across 30+ UK and European built environment markets.'
+website: 'https://infiniverde.com'
+llmsUrl: 'https://infiniverde.com/llms.txt'
+llmsFullUrl: ''
+category: 'data-analytics'
+publishedAt: '2026-04-13'
+---
+
+# InfiniVerde
+
+Closed-source quantitative research across 30+ UK and European built environment markets.

--- a/packages/content/data/websites/infiniverde-llms-txt.mdx
+++ b/packages/content/data/websites/infiniverde-llms-txt.mdx
@@ -5,7 +5,7 @@ website: 'https://infiniverde.com'
 llmsUrl: 'https://infiniverde.com/llms.txt'
 llmsFullUrl: null
 category: 'data-analytics'
-publishedAt: '2026-04-13'
+publishedAt: '2026-04-28'
 ---
 
 # InfiniVerde Ltd

--- a/packages/content/data/websites/reinfinite-group-llms-txt.mdx
+++ b/packages/content/data/websites/reinfinite-group-llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
 name: 'REinfinite Group Ltd'
-description: 'Institutional capital into UK and European real estate through closed-end fund vehicles.'
+description: 'Quantitative real estate firm. Institutional capital deployed through closed-end fund vehicles across UK and European markets.'
 website: 'https://reinfinitegroup.com'
 llmsUrl: 'https://reinfinitegroup.com/llms.txt'
 llmsFullUrl: null
@@ -10,4 +10,4 @@ publishedAt: '2026-04-13'
 
 # REinfinite Group Ltd
 
-Institutional capital into UK and European real estate through closed-end fund vehicles.
+Quantitative real estate firm. Institutional capital deployed through closed-end fund vehicles across UK and European markets.

--- a/packages/content/data/websites/reinfinite-group-llms-txt.mdx
+++ b/packages/content/data/websites/reinfinite-group-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'REinfinite Group'
+description: 'Institutional capital into UK and European real estate through closed-end fund vehicles.'
+website: 'https://reinfinitegroup.com'
+llmsUrl: 'https://reinfinitegroup.com/llms.txt'
+llmsFullUrl: ''
+category: 'data-analytics'
+publishedAt: '2026-04-13'
+---
+
+# REinfinite Group
+
+Institutional capital into UK and European real estate through closed-end fund vehicles.

--- a/packages/content/data/websites/reinfinite-group-llms-txt.mdx
+++ b/packages/content/data/websites/reinfinite-group-llms-txt.mdx
@@ -3,7 +3,7 @@ name: 'REinfinite Group Ltd'
 description: 'Institutional capital into UK and European real estate through closed-end fund vehicles.'
 website: 'https://reinfinitegroup.com'
 llmsUrl: 'https://reinfinitegroup.com/llms.txt'
-llmsFullUrl: ''
+llmsFullUrl: null
 category: 'data-analytics'
 publishedAt: '2026-04-13'
 ---

--- a/packages/content/data/websites/reinfinite-group-llms-txt.mdx
+++ b/packages/content/data/websites/reinfinite-group-llms-txt.mdx
@@ -1,5 +1,5 @@
 ---
-name: 'REinfinite Group'
+name: 'REinfinite Group Ltd'
 description: 'Institutional capital into UK and European real estate through closed-end fund vehicles.'
 website: 'https://reinfinitegroup.com'
 llmsUrl: 'https://reinfinitegroup.com/llms.txt'
@@ -8,6 +8,6 @@ category: 'data-analytics'
 publishedAt: '2026-04-13'
 ---
 
-# REinfinite Group
+# REinfinite Group Ltd
 
 Institutional capital into UK and European real estate through closed-end fund vehicles.

--- a/packages/content/data/websites/reinfinite-group-llms-txt.mdx
+++ b/packages/content/data/websites/reinfinite-group-llms-txt.mdx
@@ -4,8 +4,8 @@ description: 'Quantitative real estate firm. Institutional capital deployed thro
 website: 'https://reinfinitegroup.com'
 llmsUrl: 'https://reinfinitegroup.com/llms.txt'
 llmsFullUrl: null
-category: 'data-analytics'
-publishedAt: '2026-04-13'
+category: 'finance-fintech'
+publishedAt: '2026-04-28'
 ---
 
 # REinfinite Group Ltd

--- a/packages/content/data/websites/reinfinite-ltd-llms-txt.mdx
+++ b/packages/content/data/websites/reinfinite-ltd-llms-txt.mdx
@@ -3,7 +3,7 @@ name: 'REinfinite Ltd'
 description: 'Biophilic and neuroarchitectural development with precision delivery and lifecycle stewardship.'
 website: 'https://re-infinite.com'
 llmsUrl: 'https://re-infinite.com/llms.txt'
-llmsFullUrl: ''
+llmsFullUrl: null
 category: 'data-analytics'
 publishedAt: '2026-04-13'
 ---

--- a/packages/content/data/websites/reinfinite-ltd-llms-txt.mdx
+++ b/packages/content/data/websites/reinfinite-ltd-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'REinfinite Ltd'
+description: 'Biophilic and neuroarchitectural development with precision delivery and lifecycle stewardship.'
+website: 'https://re-infinite.com'
+llmsUrl: 'https://re-infinite.com/llms.txt'
+llmsFullUrl: ''
+category: 'data-analytics'
+publishedAt: '2026-04-13'
+---
+
+# REinfinite Ltd
+
+Biophilic and neuroarchitectural development with precision delivery and lifecycle stewardship.

--- a/packages/content/data/websites/reinfinite-ltd-llms-txt.mdx
+++ b/packages/content/data/websites/reinfinite-ltd-llms-txt.mdx
@@ -4,8 +4,8 @@ description: 'Biophilic and neuroarchitectural development with precision delive
 website: 'https://re-infinite.com'
 llmsUrl: 'https://re-infinite.com/llms.txt'
 llmsFullUrl: null
-category: 'data-analytics'
-publishedAt: '2026-04-13'
+category: 'agency-services'
+publishedAt: '2026-04-28'
 ---
 
 # REinfinite Ltd


### PR DESCRIPTION
## Summary

- **REinfinite Group** ([reinfinitegroup.com](https://reinfinitegroup.com)) — Institutional capital into UK and European real estate through closed-end fund vehicles
- **REinfinite Ltd** ([re-infinite.com](https://re-infinite.com)) — Biophilic and neuroarchitectural development with precision delivery and lifecycle stewardship
- **InfiniVerde** ([infiniverde.com](https://infiniverde.com)) — Closed-source quantitative research across 30+ UK and European built environment markets

All three sites have spec-compliant `/llms.txt` files deployed and verified.

## Checklist

- [x] MDX frontmatter follows schema (name, description, website, llmsUrl, category, publishedAt)
- [x] Descriptions end with period
- [x] Category: `data-analytics`
- [x] `/llms.txt` accessible on all 3 domains (H1, blockquote, H2 sections, link lists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new website content pages: InfiniVerde Ltd, REinfinite Group, and REinfinite Ltd.
  * Each page includes site metadata (name, description, website, category, publication date and related URLs) and renders a top-level heading with the description as the page content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->