### PR TITLE
feat(community): add Foxholm Financial to llms.txt hub

### DIFF
--- a/packages/content/data/websites/foxholm-financial-llms-txt.mdx
+++ b/packages/content/data/websites/foxholm-financial-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'Foxholm Financial'
+description: 'Fee-only fiduciary investment adviser in Georgia. Advice-only financial planning for STEM professionals. Guides, tools, and quantitative research.'
+website: 'https://foxholm.com'
+llmsUrl: 'https://foxholm.com/llms.txt'
+llmsFullUrl: 'https://foxholm.com/llms-full.txt'
+category: 'business-operations'
+publishedAt: '2026-04-13'
+---
+
+# Foxholm Financial
+
+Fee-only, fiduciary registered investment adviser serving STEM professionals across Georgia with advice-only financial planning and investment consulting.
+
+## Key Focus Areas
+
+- Advice-only financial planning and investment consulting
+- Tax-efficient strategies for Georgia residents
+- Quantitative investment research and educational guides
+
+## About llms.txt Implementation
+
+Foxholm Financial's llms.txt provides a structured overview of advisory services, 40+ educational guides, and quantitative research content. The full version includes detailed descriptions of all pages including the complete quantitative model library, glossary, and academic research reviews.


### PR DESCRIPTION
This PR adds Foxholm Financial to the llms.txt hub.

**Website:** https://foxholm.com
**llms.txt:** https://foxholm.com/llms.txt
**llms-full.txt:** https://foxholm.com/llms-full.txt

**Category:** business-operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Foxholm Financial website entry with llms.txt support, featuring information on their advice-only financial planning, tax-efficient strategies, quantitative research capabilities, and comprehensive educational guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->