### PR TITLE
feat(community): add Compute Linking to llms.txt hub

### DIFF
--- a/packages/content/data/websites/compute-linking-llms-txt.mdx
+++ b/packages/content/data/websites/compute-linking-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Compute Linking'
+description: 'DEPLOYMENT COMPLETE — Dwelling Sanctuary System Kit.'
+website: 'https://remotedesktop.google.com/access'
+llmsUrl: 'https://remotedesktop.google.com/llms.txt'
+llmsFullUrl: 'https://remotedesktop.google.com/llms-full.txt'
+category: 'automation-workflow'
+publishedAt: '2026-04-14'
+---
+
+# Compute Linking
+
+DEPLOYMENT COMPLETE — Dwelling Sanctuary System Kit.


### PR DESCRIPTION
This PR adds Compute Linking to the llms.txt hub.

**Website:** https://remotedesktop.google.com/access
**llms.txt:** https://remotedesktop.google.com/llms.txt
**llms-full.txt:** https://remotedesktop.google.com/llms-full.txt  
**Category:** automation-workflow

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new website entry for "Compute Linking" with complete metadata and deployment status information for user discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->