### PR TITLE
Add nothumansearch.ai

### DIFF
--- a/packages/content/data/websites/not-human-search-llms-txt.mdx
+++ b/packages/content/data/websites/not-human-search-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Not Human Search'
+description: 'Search engine for AI agents. Indexes 300+ agent-first tools ranked by agentic readiness. API, MCP, and llms.txt support for programmatic discovery.'
+website: 'https://nothumansearch.ai'
+llmsUrl: 'https://nothumansearch.ai/llms.txt'
+llmsFullUrl: 'https://nothumansearch.ai/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-04-13'
+---
+
+# Not Human Search
+
+Search engine built for AI agents to discover tools and services ranked by agentic readiness.
+
+## Key Features
+
+- Indexes 300+ verified agent-first tools and APIs
+- Agentic readiness scoring based on 7 signals (llms.txt, OpenAPI, MCP, API, ai-plugin, robots.txt, schema.org)
+- REST API and MCP server for programmatic access
+- Full-text search with category and tag filtering
+
+## About llms.txt Implementation
+
+Not Human Search provides llms.txt for its own discoverability plus indexes and scores other sites' llms.txt implementations as part of its agentic readiness assessment.


### PR DESCRIPTION
Adds [Not Human Search](https://nothumansearch.ai) — a search engine for AI agents that indexes 300+ agent-ready websites and APIs, ranked by agentic readiness score (0-100).

- **llms.txt**: https://nothumansearch.ai/llms.txt
- **llms-full.txt**: https://nothumansearch.ai/llms-full.txt
- **Category**: ai-ml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Not Human Search" website entry to the content database. This entry describes a search engine for AI agents featuring indexing of 300+ agent-first tools, agentic readiness scoring based on multiple technical signals, REST API and MCP server support, full-text search with filtering, and integration of external llms.txt implementations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->