### PR TITLE
feat(community): add DailyGoal to llms.txt hub

### DIFF
--- a/packages/content/data/websites/dailygoal-fit-llms-txt.mdx
+++ b/packages/content/data/websites/dailygoal-fit-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'DailyGoal'
+description: 'Health, fitness, and nutrition tracking app combining calorie tracking, workout logging, progress monitoring, and daily habit goals in a single interface, with Apple Health sync and a free tier.'
+website: 'https://www.dailygoal.fit/'
+llmsUrl: 'https://www.dailygoal.fit/llms.txt'
+llmsFullUrl: 'https://www.dailygoal.fit/llms-full.txt'
+category: 'other'
+publishedAt: '2026-04-15'
+---
+
+# DailyGoal
+
+Health, fitness, and nutrition tracking app combining calorie tracking, workout logging, progress monitoring, and daily habit goals in a single interface, with Apple Health sync and a free tier.


### PR DESCRIPTION
Adds DailyGoal to the hub.

**Site**: https://www.dailygoal.fit
**llms.txt**: https://www.dailygoal.fit/llms.txt
**llms-full.txt**: https://www.dailygoal.fit/llms-full.txt

DailyGoal is a health, fitness, and nutrition tracking app (iOS + web; Android coming soon) that combines calorie and macro tracking, workout logging, progress monitoring, and daily habit goals in a single interface. Bidirectional Apple Health sync, a fully functional free tier, and an optional Pro subscription.

Followed the `Option 2: Manual Pull Request` flow in `CONTRIBUTING.md`:
- New `.mdx` file at `packages/content/data/websites/dailygoal-fit-llms-txt.mdx`
- Did not touch the auto-generated `data/websites.json`
- Category set to `other` — DailyGoal is a consumer health/fitness app and does not map cleanly onto any of the currently defined tool categories. Happy to re-categorize if a better fit exists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DailyGoal content entry with metadata and description to the platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->