### PR TITLE
fix(content): correct Lydonia category and remove empty llmsFullUrl

### DIFF
--- a/packages/content/data/websites/lydonia-llms-txt.mdx
+++ b/packages/content/data/websites/lydonia-llms-txt.mdx
@@ -3,8 +3,7 @@ name: 'Lydonia'
 description: 'Lydonia AI offers cutting-edge AI automation, RPA services, and intelligent automation to optimize business performance and streamline operations.'
 website: 'https://lydonia.ai/'
 llmsUrl: 'https://lydonia.ai/llms.txt'
-llmsFullUrl: ''
-category: 'automation-workflow'
+category: 'ai-ml'
 publishedAt: '2026-04-17'
 ---
 


### PR DESCRIPTION
## Summary

Follow-up fix to [#910](https://github.com/thedaviddias/llms-txt-hub/pull/910), addressing CodeRabbit review feedback that was flagged but not resolved before merge.

- **Category:** changed from `automation-workflow` → `ai-ml`. The prior value was filtered out by the `PRIMARY_CATEGORIES` allowlist in [scripts/generate-websites.ts](https://github.com/thedaviddias/llms-txt-hub/blob/main/scripts/generate-websites.ts), so the entry never made it into the generated `data/websites.json`. Lydonia's positioning ("Bring AI to Life", AI-driven intelligent automation) fits `ai-ml` best among the primary categories.
- **Removed `llmsFullUrl: ''`** — the field is optional (`string | null`); an empty string doesn't match the type and CodeRabbit flagged it as a nit.

## Test plan

- [x] Frontmatter validates against the schema in `apps/web/lib/content-loader.ts`
- [x] `category` is now in `PRIMARY_CATEGORIES` so the entry will be included in the next `data/websites.json` regeneration
- [x] No other files touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated website categorization metadata for improved organization.
  * Cleaned up website metadata configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->