### PR TITLE
Add 5 thicket.sh content sites (calculators, news, trends)

### DIFF
--- a/packages/content/data/websites/calcfit-llms-txt.mdx
+++ b/packages/content/data/websites/calcfit-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'CalcFit'
+description: 'Evidence-based fitness calculators — TDEE, BMR, macros, body fat, and heart rate zones — plus research-backed articles citing PubMed studies.'
+website: 'https://fit.thicket.sh'
+llmsUrl: 'https://fit.thicket.sh/llms.txt'
+llmsFullUrl: 'https://fit.thicket.sh/llms-full.txt'
+category: 'content-media'
+publishedAt: '2026-04-20'
+---
+
+# CalcFit
+
+Evidence-based fitness calculators — TDEE, BMR, macros, body fat, and heart rate zones — plus research-backed articles citing PubMed studies.

--- a/packages/content/data/websites/etf-compare-llms-txt.mdx
+++ b/packages/content/data/websites/etf-compare-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'ETF Compare'
+description: 'Side-by-side ETF comparison tool covering expense ratios, holdings, and performance — plus comparison articles for common fund matchups.'
+website: 'https://etf.thicket.sh'
+llmsUrl: 'https://etf.thicket.sh/llms.txt'
+llmsFullUrl: 'https://etf.thicket.sh/llms-full.txt'
+category: 'finance-fintech'
+publishedAt: '2026-04-20'
+---
+
+# ETF Compare
+
+Side-by-side ETF comparison tool covering expense ratios, holdings, and performance — plus comparison articles for common fund matchups.

--- a/packages/content/data/websites/paycalc-llms-txt.mdx
+++ b/packages/content/data/websites/paycalc-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'PayCalc'
+description: 'Paycheck, raise, freelance-rate, and cost-of-living calculators for US workers — plus articles on salary negotiation and take-home pay.'
+website: 'https://pay.thicket.sh'
+llmsUrl: 'https://pay.thicket.sh/llms.txt'
+llmsFullUrl: 'https://pay.thicket.sh/llms-full.txt'
+category: 'finance-fintech'
+publishedAt: '2026-04-20'
+---
+
+# PayCalc
+
+Paycheck, raise, freelance-rate, and cost-of-living calculators for US workers — plus articles on salary negotiation and take-home pay.

--- a/packages/content/data/websites/thicket-news-llms-txt.mdx
+++ b/packages/content/data/websites/thicket-news-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Thicket News'
+description: 'Curated daily news summaries across technology, finance, and culture — concise briefings for readers who want signal over noise.'
+website: 'https://news.thicket.sh'
+llmsUrl: 'https://news.thicket.sh/llms.txt'
+llmsFullUrl: 'https://news.thicket.sh/llms-full.txt'
+category: 'content-media'
+publishedAt: '2026-04-20'
+---
+
+# Thicket News
+
+Curated daily news summaries across technology, finance, and culture — concise briefings for readers who want signal over noise.

--- a/packages/content/data/websites/trendwatch-llms-txt.mdx
+++ b/packages/content/data/websites/trendwatch-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'TrendWatch'
+description: 'Explainers for viral internet trends, Gen Z and Alpha slang, memes, and TikTok culture — updated as new trends emerge.'
+website: 'https://trends.thicket.sh'
+llmsUrl: 'https://trends.thicket.sh/llms.txt'
+llmsFullUrl: 'https://trends.thicket.sh/llms-full.txt'
+category: 'content-media'
+publishedAt: '2026-04-20'
+---
+
+# TrendWatch
+
+Explainers for viral internet trends, Gen Z and Alpha slang, memes, and TikTok culture — updated as new trends emerge.


### PR DESCRIPTION
## Summary

Adds 5 sites from the thicket.sh portfolio to the llms.txt directory. All five sites have live `/llms.txt` AND `/llms-full.txt` routes (verified via HTTP 200).

| Site | URL | Category | Focus |
|---|---|---|---|
| CalcFit | https://fit.thicket.sh | content-media | Evidence-based fitness calculators (TDEE, BMR, macros, body fat, HR zones) + 30+ PubMed-cited articles |
| TrendWatch | https://trends.thicket.sh | content-media | 64+ explainers for viral trends, Gen Z/Alpha slang, memes, TikTok culture |
| Thicket News | https://news.thicket.sh | content-media | 35+ curated daily news summaries across tech, finance, culture |
| PayCalc | https://pay.thicket.sh | finance-fintech | Paycheck, raise, freelance-rate, cost-of-living calculators for US workers + 11 articles |
| ETF Compare | https://etf.thicket.sh | finance-fintech | Side-by-side ETF comparison (expense ratios, holdings, performance) + 6 comparison articles |

All entries follow the standard frontmatter format in `packages/content/data/websites/*.mdx`. `data/websites.json` is not modified (auto-generated, per CONTRIBUTING).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five new website resources: CalcFit (fitness calculators and articles), ETF Compare (investment comparison tool), PayCalc (payroll calculator), Thicket News (news platform), and TrendWatch (trending information tracker).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->