### PR TITLE
Add SEO for AI

### DIFF
--- a/packages/content/data/websites/seoforai-llms-txt.mdx
+++ b/packages/content/data/websites/seoforai-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'SEO for AI'
+description: "Free AI-visibility checker for small businesses. Paste your URL to see whether ChatGPT, Gemini, Perplexity, and Google AI Overviews mention you or cite a competitor instead."
+website: 'https://getseoforai.com'
+llmsUrl: 'https://getseoforai.com/llms.txt'
+category: 'ai-ml'
+publishedAt: '2026-04-23'
+priority: 'medium'
+featured: false
+---
+
+# SEO for AI
+
+SEO for AI helps small businesses, agencies, and trades find out whether generative search engines recommend them, and gives a prioritised fix list when they do not.
+
+## Key Focus Areas
+
+- Generative Engine Optimisation (GEO) for local SMBs
+- Answer Engine Optimisation (AEO) across ChatGPT, Gemini, Perplexity, Claude, and Google AI Overviews
+- Structured data (JSON-LD), llms.txt, and third-party citation strategy
+
+## About llms.txt Implementation
+
+getseoforai.com publishes an llms.txt at the root describing the site's structure, the AI-visibility audit flow, the $15 workbook, and the $197 done-for-you audit. The file is designed to help LLM retrieval engines understand what the site offers in one pass.


### PR DESCRIPTION
Adding SEO for AI (https://getseoforai.com), a free AI-visibility checker for small businesses. Our llms.txt is live at https://getseoforai.com/llms.txt.

Category: ai-ml.

Thanks for maintaining this directory.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new content page documenting SEO for AI, featuring an AI-visibility checker for small businesses.
  * Includes guidance on GEO/AEO strategies and citation/structured data best practices.
  * Documents root `llms.txt` implementation for LLM retrieval engine indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->