### PR TITLE
Add Ownkube to llms.txt directory

### DIFF
--- a/packages/content/data/websites/ownkube-llms-txt.mdx
+++ b/packages/content/data/websites/ownkube-llms-txt.mdx
@@ -1,0 +1,28 @@
+---
+name: 'Ownkube'
+description: 'A Heroku in your cloud. The developer experience you love, running on your own AWS or GCP account, with AI-powered operations from day one.'
+website: 'https://ownkube.io'
+llmsUrl: 'https://ownkube.io/llms.txt'
+llmsFullUrl: 'https://ownkube.io/llms-full.txt'
+category: 'infrastructure-cloud'
+publishedAt: '2026-04-25'
+---
+
+# Ownkube
+
+Ownkube is a developer platform that gives teams a Heroku-style experience on their own AWS or GCP account. It combines one-click deploys, ephemeral preview environments on a Cloudflare-backed domain, and AI-powered operations that detect errors, explain crashes in plain English, and surface cost optimizations.
+
+## Key Focus Areas
+
+- One-click app, database, and worker deploys
+- Ephemeral per-PR preview environments on a Cloudflare subdomain
+- AI-powered error detection, root cause analysis, and cost optimization
+- k3s mode for indie developers and small teams ($10/month flat)
+- EKS mode for scaling teams (usage-based: $10/vCPU + $5/GB RAM)
+- Cloudflare edge protections (DDoS, bot, scrape) included
+- Compatible with AWS Activate and GCP for Startups credits
+- Zero vendor lock-in: vanilla infrastructure, disconnect anytime
+
+## About llms.txt Implementation
+
+Ownkube publishes both `llms.txt` (concise index of pages and docs) and `llms-full.txt` (full content of the marketing site and blog), generated from the Astro content collection at build time and served from the same origin as the public site.


### PR DESCRIPTION
## Summary

Adds Ownkube (https://ownkube.io) to the llms.txt directory under `infrastructure-cloud`.

Ownkube is a developer platform that delivers a Heroku-style experience on the user's own AWS or GCP account, with AI-powered operations and ephemeral preview environments.

- llms.txt: https://ownkube.io/llms.txt
- llms-full.txt: https://ownkube.io/llms-full.txt

Both files are generated from the site's content collection at build time and served from the same origin.

Only adds a new `.mdx` file under `packages/content/data/websites/`. No changes to `data/websites.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for Ownkube platform detailing service capabilities including preview environments, AI-powered operations, and AI service discovery support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->