### PR TITLE
Add TCG API

### DIFF
--- a/packages/content/data/websites/tcg-api-llms-txt.mdx
+++ b/packages/content/data/websites/tcg-api-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'TCG API'
+description: '> Real-time pricing API for 89+ trading card games (Pokemon, Magic: The Gathering, Yu-Gi-Oh!, Lorcana, Flesh and Blood, One Piece, Riftbound, and more) sourced from TCGPlayer. Free tier 100 requests/day, paid tiers $9.99–$99.99/mo, plus x402 pay-per-request in USDC on Base or Solana.'
+website: 'https://tcgapi.dev'
+llmsUrl: 'https://tcgapi.dev/llms.txt'
+llmsFullUrl: 'https://tcgapi.dev/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-04-28'
+---
+
+# TCG API
+
+> Real-time pricing API for 89+ trading card games (Pokemon, Magic: The Gathering, Yu-Gi-Oh!, Lorcana, Flesh and Blood, One Piece, Riftbound, and more) sourced from TCGPlayer. Free tier 100 requests/day, paid tiers $9.99–$99.99/mo, plus x402 pay-per-request in USDC on Base or Solana.

--- a/packages/content/data/websites/tcg-api-llms-txt.mdx
+++ b/packages/content/data/websites/tcg-api-llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
 name: 'TCG API'
-description: '> Real-time pricing API for 89+ trading card games (Pokemon, Magic: The Gathering, Yu-Gi-Oh!, Lorcana, Flesh and Blood, One Piece, Riftbound, and more) sourced from TCGPlayer. Free tier 100 requests/day, paid tiers $9.99–$99.99/mo, plus x402 pay-per-request in USDC on Base or Solana.'
+description: '> Daily-updated pricing API for 89+ trading card games (Pokémon, Magic: The Gathering, Yu-Gi-Oh!, Lorcana, Flesh and Blood, One Piece, Riftbound, and more) sourced from TCGPlayer. Free tier 100 requests/day, paid tiers $9.99–$99.99/mo, plus x402 pay-per-request in USDC on Base or Solana.'
 website: 'https://tcgapi.dev'
 llmsUrl: 'https://tcgapi.dev/llms.txt'
 llmsFullUrl: 'https://tcgapi.dev/llms-full.txt'
@@ -10,4 +10,4 @@ publishedAt: '2026-04-28'
 
 # TCG API
 
-> Real-time pricing API for 89+ trading card games (Pokemon, Magic: The Gathering, Yu-Gi-Oh!, Lorcana, Flesh and Blood, One Piece, Riftbound, and more) sourced from TCGPlayer. Free tier 100 requests/day, paid tiers $9.99–$99.99/mo, plus x402 pay-per-request in USDC on Base or Solana.
+> Daily-updated pricing API for 89+ trading card games (Pokémon, Magic: The Gathering, Yu-Gi-Oh!, Lorcana, Flesh and Blood, One Piece, Riftbound, and more) sourced from TCGPlayer. Free tier 100 requests/day, paid tiers $9.99–$99.99/mo, plus x402 pay-per-request in USDC on Base or Solana.


### PR DESCRIPTION
## Summary

Adds [tcgapi.dev](https://tcgapi.dev) — pricing API for 89+ trading card games on TCGPlayer (Pokemon, MTG, Yu-Gi-Oh!, Lorcana, FAB, One Piece, Riftbound, etc.).

- `llms.txt`: https://tcgapi.dev/llms.txt
- `llms-full.txt`: https://tcgapi.dev/llms-full.txt (full machine-readable API reference)

Category: `developer-tools` (matches Apify, Abstract API, etc.).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a new MDX documentation page for the TCG API developer tool, including metadata and direct links to `llms.txt` and `llms-full.txt`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->