### PR TITLE
feat(community): add SellerSprite-JP to llms.txt hub

### DIFF
--- a/packages/content/data/websites/sellersprite-jp-llms-txt.mdx
+++ b/packages/content/data/websites/sellersprite-jp-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'SellerSprite-JP'
+description: 'セラースプライト(SellerSprite)はビッグデータと人工知能技術に基づき、アマゾンの越境セラーにワン・サイトで商品リサーチ、市場分析、キーワード最適化、商品モニタリングなどのソフトウェアツールを提供し、アマゾンのセラーにニッチ市場、潜在力がある商品の発見に助けになります.'
+website: 'https://www.sellersprite.jp/'
+llmsUrl: 'https://www.sellersprite.jp/llms.txt'
+llmsFullUrl: 'https://www.sellersprite.jp/llms-full.txt'
+category: 'data-analytics'
+publishedAt: '2026-04-30'
+---
+
+# SellerSprite-JP
+
+セラースプライト(SellerSprite)はビッグデータと人工知能技術に基づき、アマゾンの越境セラーにワン・サイトで商品リサーチ、市場分析、キーワード最適化、商品モニタリングなどのソフトウェアツールを提供し、アマゾンのセラーにニッチ市場、潜在力がある商品の発見に助けになります.


### PR DESCRIPTION
This PR adds SellerSprite-JP to the llms.txt hub.

**Website:** https://www.sellersprite.jp/
**llms.txt:** https://www.sellersprite.jp/llms.txt
**llms-full.txt:** https://www.sellersprite.jp/llms-full.txt  
**Category:** data-analytics

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for SellerSprite-JP service with website details and product information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->