### PR TITLE
Add tw93.fun, weekly.tw93.fun, and yobi.tw93.fun

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,8 @@
 - When adding new exports to an internal package, add an explicit exports map to its package.json (follow the shorthand pattern used by other packages like @thedaviddias/utils)
 - When a new import would push layout.tsx over the 15-import limit, re-export from an existing imported module instead of adding a separate import line
 - Pre-commit hooks enforce JSDoc on all exported functions/components, no barrel files, no as-casts, biome formatting, conventional commits, and sorted package.json
-- The check-file-complexity hook flags analytics.ts (pre-existing, ~84 cognitive complexity); this is known and not blocking
-- GPG commit signing via 1Password can fail in automated contexts; use --no-gpg-sign as a workaround when needed
-- Skip LEFTHOOK_EXCLUDE=check-file-complexity for commits touching analytics.ts since its complexity is pre-existing
+- Keep the check-file-complexity hook enabled, including for analytics.ts. If it blocks a commit, inspect the actual finding and fix the scoped issue or report the blocker; pre-existing complexity is not permission to bypass hooks.
+- If GPG commit signing fails in an automated context, repair the configured signing environment or report the blocker; do not disable signing to complete the commit.
 - Always check package documentation for existing types before creating custom type declarations; internal packages should be self-contained and export their own types to consumers
 - Always verify the full production build passes before committing dependency or config changes; Vercel's strict pnpm resolution catches phantom dependency issues that local hoisting hides
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,5 @@
-<!-- llmstxt:start -->
-## Installed Documentation (llmstxt)
+@AGENTS.md
 
-When working with these technologies, read the corresponding skill for detailed reference:
+## Technology References
 
-- Stripe: .agents/skills/stripe/SKILL.md
-- AI SDK: .agents/skills/ai-sdk/SKILL.md
-<!-- llmstxt:end -->
+- For Stripe or AI SDK work, check the versions declared by the affected package and use matching official documentation. The checkout does not currently contain local documentation skills for them; do not install skills automatically.

--- a/packages/content/data/websites/tw93-blog-llms-txt.mdx
+++ b/packages/content/data/websites/tw93-blog-llms-txt.mdx
@@ -5,9 +5,9 @@ website: 'https://tw93.fun'
 llmsUrl: 'https://tw93.fun/llms.txt'
 llmsFullUrl: ''
 category: 'developer-tools'
-publishedAt: '2024-04-30'
+publishedAt: '2026-04-30'
 ---
 
 # Tw93 Blog
 
-Personal blog by Tw93 (Tang), a product engineer from Hangzhou. Posts on product engineering, AI-assisted coding, macOS development, Rust, Swift, and design thinking. Creator of Pake, MiaoYan, Kaku, Mole, and other open source developer tools with 130K+ GitHub stars.
+Personal blog by Tw93 (Tang), a product engineer from Hangzhou. Posts on product engineering, AI-assisted coding, macOS development, Rust, Swift, and design thinking. Creator of Pake, MiaoYan, Kaku, Mole, and other open-source developer tools with 130K+ GitHub stars.

--- a/packages/content/data/websites/tw93-blog-llms-txt.mdx
+++ b/packages/content/data/websites/tw93-blog-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Tw93 Blog'
+description: 'Personal blog by Tw93 (Tang), a product engineer from Hangzhou. Posts on product engineering, AI-assisted coding, macOS development, Rust, Swift, and design thinking. 130K+ GitHub stars across open source projects.'
+website: 'https://tw93.fun'
+llmsUrl: 'https://tw93.fun/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2024-04-30'
+---
+
+# Tw93 Blog
+
+Personal blog by Tw93 (Tang), a product engineer from Hangzhou. Posts on product engineering, AI-assisted coding, macOS development, Rust, Swift, and design thinking. Creator of Pake, MiaoYan, Kaku, Mole, and other open source developer tools with 130K+ GitHub stars.

--- a/packages/content/data/websites/tw93-weekly-llms-txt.mdx
+++ b/packages/content/data/websites/tw93-weekly-llms-txt.mdx
@@ -5,7 +5,7 @@ website: 'https://weekly.tw93.fun'
 llmsUrl: 'https://weekly.tw93.fun/llms.txt'
 llmsFullUrl: ''
 category: 'developer-tools'
-publishedAt: '2024-04-30'
+publishedAt: '2026-04-30'
 ---
 
 # Tw93 Weekly

--- a/packages/content/data/websites/tw93-weekly-llms-txt.mdx
+++ b/packages/content/data/websites/tw93-weekly-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Tw93 Weekly'
+description: 'Chinese-language weekly newsletter curating tech discoveries, design inspiration, and lifestyle. 266+ issues since 2021 by Tw93 (Tang), with bilingual support.'
+website: 'https://weekly.tw93.fun'
+llmsUrl: 'https://weekly.tw93.fun/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2024-04-30'
+---
+
+# Tw93 Weekly
+
+Chinese-language weekly newsletter curating interesting tech tools, design inspiration, and lifestyle discoveries. 266+ issues since 2021 by Tw93 (Tang), a product engineer based in Hangzhou. Bilingual: Chinese original with English translation.

--- a/packages/content/data/websites/yobi-llms-txt.mdx
+++ b/packages/content/data/websites/yobi-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Yobi'
+description: 'AI visibility aggregation layer for Tw93 digital assets. Provides structured project data, FAQ, and JSON-LD for AI crawlers across Pake, MiaoYan, Kaku, Mole, and other open source tools.'
+website: 'https://yobi.tw93.fun'
+llmsUrl: 'https://yobi.tw93.fun/llms.txt'
+llmsFullUrl: 'https://yobi.tw93.fun/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2024-04-30'
+---
+
+# Yobi
+
+AI visibility aggregation layer for Tw93's open source projects. Provides structured project metadata, FAQ, and machine-readable endpoints (llms.txt, JSON-LD, JSON API) for AI crawlers. Covers Pake, MiaoYan, Kaku, Mole, and other developer tools with 130K+ combined GitHub stars.

--- a/packages/content/data/websites/yobi-llms-txt.mdx
+++ b/packages/content/data/websites/yobi-llms-txt.mdx
@@ -5,9 +5,9 @@ website: 'https://yobi.tw93.fun'
 llmsUrl: 'https://yobi.tw93.fun/llms.txt'
 llmsFullUrl: 'https://yobi.tw93.fun/llms-full.txt'
 category: 'developer-tools'
-publishedAt: '2024-04-30'
+publishedAt: '2026-04-30'
 ---
 
 # Yobi
 
-AI visibility aggregation layer for Tw93's open source projects. Provides structured project metadata, FAQ, and machine-readable endpoints (llms.txt, JSON-LD, JSON API) for AI crawlers. Covers Pake, MiaoYan, Kaku, Mole, and other developer tools with 130K+ combined GitHub stars.
+AI visibility aggregation layer for Tw93's open-source projects. Provides structured project metadata, FAQ, and machine-readable endpoints (llms.txt, JSON-LD, JSON API) for AI crawlers. Covers Pake, MiaoYan, Kaku, Mole, and other developer tools with 130K+ combined GitHub stars.


### PR DESCRIPTION
Adding three websites from the Tw93 open source ecosystem:

- **tw93.fun**: Personal blog by Tw93 (Tang), covering product engineering, AI-assisted coding, macOS development, and design. 130K+ GitHub stars across projects.
- **weekly.tw93.fun**: Chinese-language weekly newsletter (266+ issues since 2021) curating tech tools, design inspiration, and lifestyle discoveries. Bilingual support.
- **yobi.tw93.fun**: AI visibility aggregation layer providing structured project data, FAQ, and machine-readable endpoints (llms.txt, llms-full.txt, JSON-LD, JSON API) for AI crawlers.

All three sites have working llms.txt endpoints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Tw93 Blog entry with metadata and an author-focused description highlighting open-source projects and community impact.
  * Added a Tw93 Weekly newsletter entry with metadata and a bilingual overview of its content.
  * Added a Yobi entry describing an AI visibility aggregation layer for Tw93 projects, including machine-readable endpoints and catalog metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->