### PR TITLE
Add Readest

### DIFF
--- a/packages/content/data/websites/readest-llms-txt.mdx
+++ b/packages/content/data/websites/readest-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Readest'
+description: 'Free, open-source EPUB and PDF reader for macOS, Windows, Linux, iOS, Android, and the web. Split-screen parallel reading, text-to-speech, in-line translation, highlights, notes, and cross-device sync.'
+website: 'https://readest.com'
+llmsUrl: 'https://readest.com/llms.txt'
+llmsFullUrl: 'https://readest.com/llms-full.txt'
+category: 'content-media'
+publishedAt: '2026-05-03'
+---
+
+# Readest
+
+Free, open-source EPUB and PDF reader for macOS, Windows, Linux, iOS, Android, and the web. Split-screen parallel reading, text-to-speech, in-line translation, highlights, notes, and cross-device sync.

--- a/packages/content/data/websites/readest-llms-txt.mdx
+++ b/packages/content/data/websites/readest-llms-txt.mdx
@@ -4,7 +4,7 @@ description: 'Free, open-source EPUB and PDF reader for macOS, Windows, Linux, i
 website: 'https://readest.com'
 llmsUrl: 'https://readest.com/llms.txt'
 llmsFullUrl: 'https://readest.com/llms-full.txt'
-category: 'content-media'
+category: 'automation-workflow'
 publishedAt: '2026-05-03'
 ---
 


### PR DESCRIPTION
Adds Readest, a free, open-source EPUB and PDF reader for macOS, Windows, Linux, iOS, Android, and the web.

- Website: https://readest.com
- llms.txt: https://readest.com/llms.txt
- llms-full.txt: https://readest.com/llms-full.txt (~39 KB; concatenated docs with absolute links)
- Source: https://github.com/readest/readest (AGPL-3.0)
- Category: content-media

Both URLs return `200` with `Content-Type: text/markdown; charset=utf-8`. The llms.txt is generated from the docs nav so it stays in sync; llms-full.txt mirrors the human docs for AI consumption.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Readest website entry with site metadata, publication date and resource endpoints.
  * Included a new page with a heading and short description for Readest.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->