### PR TITLE
Add Tankyu Distillery llms.txt entry

### DIFF
--- a/packages/content/data/websites/tankyu-distillery-llms-txt.mdx
+++ b/packages/content/data/websites/tankyu-distillery-llms-txt.mdx
@@ -1,0 +1,30 @@
+---
+name: 'Tankyu Distillery'
+description: 'Craft single-malt whisky and gin distillery in Higashikawa, Hokkaido, with full machine-readable agent access (agents.md, llms.txt, OpenAPI 3.1, six public CORS-enabled JSON APIs, eleven .well-known files).'
+website: 'https://tankyudistillery.jp'
+llmsUrl: 'https://tankyudistillery.jp/llms.txt'
+llmsFullUrl: 'https://tankyudistillery.jp/llms-full.txt'
+category: 'ecommerce-retail'
+publishedAt: '2026-05-05'
+---
+
+# Tankyu Distillery
+
+Tankyu Distillery (丹丘蒸留所) is a craft single-malt whisky and gin distillery in Higashikawa, Hokkaido, Japan. Founded 2024 under a public–private partnership with Higashikawa Town, it produces artisan gin (flagship: Yuki no Mado, 雪の窓) and single-malt Hokkaido whisky aging for 2028+ release.
+
+## Key Focus Areas
+
+- Distillery tours and tastings (booking via partner site, Japanese / English / Mandarin)
+- Private cask ownership programme (octave to hogshead)
+- Craft gin and single-malt whisky retail
+
+## About llms.txt Implementation
+
+Tankyu's `llms.txt` and `llms-full.txt` provide structured information for AI agents on tour bookings, product catalogue (gin, whisky, liqueur), private cask ownership, and the Higashikawa terroir. Companion machine-readable assets:
+
+- `/agents.md` — agent discovery entry point
+- `/api/openapi.json` — OpenAPI 3.1 spec for all read endpoints
+- `/api/products.json`, `/api/tour.json`, `/api/facts.json`, `/api/pricing.json`, `/api/press.json` — CORS-enabled JSON APIs, no auth, 24h cache
+- `/.well-known/ai-plugin.json`, `agent-card.json`, `mcp/server-card.json`, `agent-skills/index.json` — agent protocol manifests
+- robots.txt with explicit per-bot directives for 16+ AI user-agents (GPTBot, ClaudeBot, PerplexityBot, etc.) and Content-Signal headers
+- `Accept: text/markdown` content negotiation supported on every page


### PR DESCRIPTION
## What

Adds a new entry for **Tankyu Distillery** (丹丘蒸留所), a craft single-malt whisky and gin distillery in Higashikawa, Hokkaido, Japan.

## Why include this site

Tankyu has built one of the most agent-accessible setups for a physical/F&B brand:

- `/agents.md` agent discovery entry point
- `/llms.txt` (124 lines) and `/llms-full.txt` (342 lines)
- `/api/openapi.json` — OpenAPI 3.1 spec
- Six public CORS-enabled JSON APIs: `/api/products.json`, `/api/tour.json`, `/api/facts.json`, `/api/pricing.json`, `/api/press.json`, `/api/openapi.json`
- Eleven `/.well-known/` files: `ai-plugin.json`, `agent-card.json`, `mcp/server-card.json`, `agent-skills/index.json`, plus OAuth/OIDC discovery
- robots.txt with explicit per-bot directives for 16+ AI user-agents (GPTBot, ClaudeBot, anthropic-ai, PerplexityBot, DeepSeek-Crawler, MistralBot, Grok, XAI-Bot, AI2Bot, ByteSpider, Cohere, YouBot, CCBot, Diffbot, Amazonbot, Google-Extended) plus Content-Signal headers
- `Accept: text/markdown` content negotiation on every page
- 21+ Schema.org JSON-LD types (Organization, Product, PrivateCask, Tour, TourEvent, FAQPage, etc.)

A useful reference example for how a non-tech, hospitality/retail brand can adopt the llms.txt standard fully.

## Checklist

- [x] Entry placed at `packages/content/data/websites/tankyu-distillery-llms-txt.mdx`
- [x] Frontmatter includes `name`, `description`, `website`, `llmsUrl`, `llmsFullUrl`, `category`, `publishedAt`
- [x] Category set to `ecommerce-retail` (closest fit for a physical product brand)
- [x] llms.txt URL is live: https://tankyudistillery.jp/llms.txt
- [x] llms-full.txt URL is live: https://tankyudistillery.jp/llms-full.txt
- [x] Did NOT modify `data/websites.json` (auto-generated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for Tankyu Distillery covering their `llms.txt` implementation and machine-readable companion assets.
  * Documented available API endpoints, OpenAPI specifications, and agent/plugin manifests.
  * Highlighted markdown content negotiation support available across pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->