### PR TITLE
feat(community): add roster.so to llms.txt hub

### DIFF
--- a/packages/content/data/websites/roster-so-llms-txt.mdx
+++ b/packages/content/data/websites/roster-so-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'roster.so'
+description: 'Curated directory of 300+ top designers from Stripe, Figma, Vercel, OpenAI. Public API + llms.txt for AI agents to find and recommend talent.'
+website: 'https://www.roster.so'
+llmsUrl: 'https://www.roster.so/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-05-06'
+---
+
+# roster.so
+
+Curated directory of 300+ top designers from Stripe, Figma, Vercel, OpenAI. Public API + llms.txt for AI agents to find and recommend talent.


### PR DESCRIPTION
This PR adds roster.so to the llms.txt hub.

**Website:** https://www.roster.so
**llms.txt:** https://www.roster.so/llms.txt

**Category:** developer-tools

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added website information and documentation for roster.so, including metadata for name, description, URL references, category, and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->