### PR TITLE
feat(community): add Aperture to llms.txt hub

### DIFF
--- a/packages/content/data/websites/aperture-llms-txt.mdx
+++ b/packages/content/data/websites/aperture-llms-txt.mdx
@@ -1,0 +1,25 @@
+---
+name: 'Aperture'
+description: 'A markdown-first wiki and life system for agent-native work. Turn raw notes into a browsable knowledge graph with semantic trails, source provenance, and agent APIs.'
+website: 'https://aperture-daq.pages.dev'
+llmsUrl: 'https://aperture-daq.pages.dev/llms.txt'
+llmsFullUrl: 'https://aperture-daq.pages.dev/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-05-06'
+priority: 'high'
+---
+
+# Aperture
+
+Aperture is a web reader for LLM-compiled personal wikis. It transforms raw markdown notes into a browsable knowledge graph with source provenance, semantic trails, and agent-native APIs.
+
+## Key Focus Areas
+
+- Markdown-First Wiki System
+- Semantic Knowledge Graph
+- Agent-Native Architecture
+- Source Provenance Tracking
+
+## About llms.txt Implementation
+
+Aperture's llms.txt documentation outlines the project's approach to AI-readable knowledge management, including design principles, feature documentation, and agent interaction patterns.


### PR DESCRIPTION
Aperture is a markdown-first wiki and life system for agent-native work.

- Website: https://aperture-daq.pages.dev
- llms.txt: https://aperture-daq.pages.dev/llms.txt
- llms-full.txt: https://aperture-daq.pages.dev/llms-full.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new Aperture documentation page featuring information about llms.txt implementation, key focus areas, and website details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->