### PR TITLE
feat(community): add PromptMetrics to llms.txt hub

### DIFF
--- a/packages/content/data/websites/promptmetrics-llms-txt.mdx
+++ b/packages/content/data/websites/promptmetrics-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'PromptMetrics'
+description: 'Self-hosted prompt registry and agent telemetry for developers. Version prompts in Git, collect traces via OTLP, score evals over time.'
+website: 'https://www.promptmetrics.dev'
+llmsUrl: 'https://www.promptmetrics.dev/llms.txt'
+llmsFullUrl: 'https://www.promptmetrics.dev/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-05-07'
+---
+
+# PromptMetrics
+
+Self-hosted prompt registry and agent telemetry for developers. Version prompts in Git, collect traces via OTLP, score evals over time.


### PR DESCRIPTION
This PR adds PromptMetrics to the llms.txt hub.

**Website:** https://www.promptmetrics.dev
**llms.txt:** https://www.promptmetrics.dev/llms.txt
**llms-full.txt:** https://www.promptmetrics.dev/llms-full.txt  
**Category:** developer-tools

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new page for PromptMetrics with complete metadata including site description, category information, and introductory content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->