### PR TITLE
feat(community): add USNow.app to llms.txt hub

### DIFF
--- a/packages/content/data/websites/usnow-app-llms-txt.mdx
+++ b/packages/content/data/websites/usnow-app-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'USNow.app'
+description: 'UsNow — public knowledge for perspective & focus in today''s noisy world. Start anywhere. Go anywhere. No algorithm. No ads. No agenda. Human made. AI assisted.'
+website: 'https://usnow.app'
+llmsUrl: 'https://usnow.app/llms.txt'
+llmsFullUrl: 'https://usnow.app/llms-full.txt'
+category: 'international'
+publishedAt: '2026-05-08'
+---
+
+# USNow.app
+
+UsNow — public knowledge for perspective & focus in today's noisy world. Start anywhere. Go anywhere. No algorithm. No ads. No agenda. Human made. AI assisted.


### PR DESCRIPTION
This PR adds USNow.app to the llms.txt hub.

**Website:** https://usnow.app
**llms.txt:** https://usnow.app/llms.txt
**llms-full.txt:** https://usnow.app/llms-full.txt  
**Category:** international

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about USNow.app to the platform documentation, including metadata and service description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->