### PR TITLE
Add 13F Insight to llms.txt directory

### DIFF
--- a/packages/content/data/websites/13f-insight-llms-txt.mdx
+++ b/packages/content/data/websites/13f-insight-llms-txt.mdx
@@ -1,0 +1,25 @@
+---
+name: '13F Insight'
+description: 'SEC institutional filings analysis for retail investors — 13F holdings, 13D/G activist filings, Form 4 insider trades, plus an embedded AI agent on every entity page.'
+website: 'https://13finsight.com'
+llmsUrl: 'https://13finsight.com/llms.txt'
+llmsFullUrl: 'https://13finsight.com/llms-full.txt'
+category: 'finance-fintech'
+publishedAt: '2026-05-09'
+---
+
+# 13F Insight
+
+13F Insight indexes SEC EDGAR institutional filings (380K+ 13F-HRs since 1999, 480K+ 13D/Gs since 1994, 4.37M+ Form 4 transactions since 2003) and surfaces them via cross-entity search, position-change diffs, and a tier-gated AI agent. Editorial hubs at /research, /learn, /news produce data-grounded articles.
+
+## Key Focus Areas
+
+- 13F Holdings filings — quarterly institutional position tracking
+- 13D/G Activist filings — major ownership and activist investor alerts
+- Form 4 Insider Transactions — real-time executive buy/sell tracking
+- AI Agent — embedded on every fund, filer, and ticker page
+- Research & Learn — data-grounded editorial content on SEC filings
+
+## About llms.txt Implementation
+
+13F Insight's llms.txt and llms-full.txt (33KB structured knowledge base) document the full product surface: data coverage, search API, AI agent capabilities, filing schemas, and editorial content — enabling AI assistants to accurately answer questions about institutional investing and SEC filings.

--- a/packages/content/data/websites/13f-insight-llms-txt.mdx
+++ b/packages/content/data/websites/13f-insight-llms-txt.mdx
@@ -23,3 +23,4 @@ publishedAt: '2026-05-09'
 ## About llms.txt Implementation
 
 13F Insight's llms.txt and llms-full.txt (33KB structured knowledge base) document the full product surface: data coverage, search API, AI agent capabilities, filing schemas, and editorial content — enabling AI assistants to accurately answer questions about institutional investing and SEC filings.
+


### PR DESCRIPTION
## Description

Add 13F Insight (https://13finsight.com) to the llms.txt hub directory.

13F Insight indexes SEC EDGAR institutional filings and surfaces them via cross-entity search, position-change diffs, and a tier-gated AI agent.

## Details

- **Website**: https://13finsight.com
- **llms.txt**: https://13finsight.com/llms.txt
- **llms-full.txt**: https://13finsight.com/llms-full.txt (33KB structured knowledge base)
- **Category**: finance-fintech
- **Description**: SEC institutional filings analysis for retail investors — 13F holdings, 13D/G activist filings, Form 4 insider trades, plus an embedded AI agent on every entity page.

## Checklist

- [x] Added .mdx file under packages/content/data/websites/
- [x] Followed existing entry format
- [x] Used existing category (finance-fintech)
- [x] llms.txt URL is live and accessible
- [x] Did not edit data/websites.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new content page for the “13F Insight” service, including full metadata and descriptive content. It documents which filings the service indexes (13F, 13D/G, Form 4), the service’s key focus areas, and explains the role and structure of its llms.txt / llms-full.txt knowledge-base outputs for discovery and integration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thedaviddias/llms-txt-hub/pull/993)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->