### PR TITLE
feat: add dualmark.dev

### DIFF
--- a/packages/content/data/websites/dualmark-llms-txt.mdx
+++ b/packages/content/data/websites/dualmark-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Dualmark'
+description: "Open-source AEO infrastructure that gives every page a markdown twin AI agents can read — same URL, two formats, picked at the edge by HTTP content negotiation."
+website: 'https://dualmark.dev'
+llmsUrl: 'https://dualmark.dev/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-05-12'
+---
+
+# Dualmark
+
+Open-source AEO (Answer Engine Optimization) infrastructure. Every page gets a markdown twin (e.g. `/pricing` and `/pricing.md`) picked by HTTP content negotiation, so AI bots (GPTBot, ClaudeBot, PerplexityBot, +16 more) get clean markdown while humans get HTML. Adapters for Astro, Next.js, and Cloudflare Workers.


### PR DESCRIPTION
Adds [dualmark.dev](https://dualmark.dev) to the hub.

**What it is:** Open-source AEO (Answer Engine Optimization) infrastructure. Every page gets a markdown twin AI agents can read — same URL, two formats, picked at the edge by HTTP content negotiation. Adapters for Astro, Next.js, and Cloudflare Workers. Apache 2.0.

- **llms.txt:** https://dualmark.dev/llms.txt
- **Repo:** https://github.com/dodopayments/dualmark
- **Category:** `developer-tools`

Followed the [CONTRIBUTING flow](https://github.com/thedaviddias/llms-txt-hub/blob/main/.github/CONTRIBUTING.md) — single `.mdx` under `packages/content/data/websites/`, didn't touch the auto-generated `data/websites.json`. Happy to adjust description or category if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dualmark website entry to the content library with enhanced accessibility for AI-powered search and integration capabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thedaviddias/llms-txt-hub/pull/1015)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->