### PR TITLE
Add Block Lottos llms.txt implementation

### DIFF
--- a/packages/content/data/websites/block-lottos-llms-txt.mdx
+++ b/packages/content/data/websites/block-lottos-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Block Lottos'
+description: 'Agent-friendly Web3 referral and advertising APIs with llms.txt, agents.txt, OpenAPI, and public JSON endpoints.'
+website: 'https://blocklottos.com'
+llmsUrl: 'https://blocklottos.com/llms.txt'
+llmsFullUrl: ''
+category: 'marketing-sales'
+publishedAt: '2026-05-13'
+---
+
+# Block Lottos
+
+Block Lottos publishes an llms.txt file for AI systems and autonomous agents that need factual context about its public Web3 marketing, referral, advertising, and API surfaces.
+
+## Key Focus Areas
+
+- Agent-readable Web3 service discovery
+- Referral and affiliate workflow documentation
+- Public JSON endpoints and OpenAPI documentation
+- Bot-friendly advertising and marketing automation surfaces
+
+## About llms.txt Implementation
+
+The Block Lottos llms.txt implementation links agents to public docs, referral details, advertising APIs, safety guidance, and machine-readable endpoints. It is paired with agents.txt and an OpenAPI spec so bots can understand the service without scraping or guessing.


### PR DESCRIPTION
## Summary
- Adds Block Lottos to the llms.txt Hub website registry.
- Positions it as an agent-readable Web3 referral / marketing / public API surface.
- Uses the live `https://blocklottos.com/llms.txt` implementation.

## Verification
- `https://blocklottos.com/llms.txt` returns HTTP 200.
- `https://blocklottos.com/agents.txt` and `https://blocklottos.com/openapi.json` also return HTTP 200.
- Added only the generated-content source `.mdx` file under `packages/content/data/websites/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Block Lottos service documentation with llms.txt integration to enable improved discoverability and interaction with AI agents and language models.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thedaviddias/llms-txt-hub/pull/1020)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->