### PR TITLE
Add agent-readiness-cli to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ We organize projects into primary categories (🤖 **AI & ML**, 💻 **Developer
 | ⚡ **Raycast Extension**  | Search and explore llms.txt files directly in Raycast           | [Raycast Store](https://www.raycast.com/thedaviddias/llms-txt)                                                |
 | ⚡ **LLMs.txt Generator** | Generate llms.txt from sitemap, crawled pages and AI            | [LLMs.txt Generator](https://llmstxtgenerator.co/)                                                            |
 | 🛠 **llmstxt-cli**        | Install llms.txt docs as skills into 35+ AI coding agents       | [npm](https://www.npmjs.com/package/llmstxt-cli) · [README](packages/cli/README.md)                           |
+| 🤖 **agent-readiness-cli**| Score any URL 0-100 for AI agent readiness (canonical, llms.txt, schema, hreflang, etc).          | [GitHub](https://github.com/sspoisk/agent-readiness-cli) · [PyPI](https://pypi.org/project/agent-readiness-cli/)                                |
 
 <!-- LLMS-LIST:START - Do not remove or modify this section -->
 ## LLM Tools and Resources


### PR DESCRIPTION
## What

Adds [`agent-readiness-cli`](https://github.com/sspoisk/agent-readiness-cli) to the **Developer Tools** table.

## Why it fits this list

`agent-readiness-cli` is a Python CLI that scores any URL on a 0–100 scale for AI agent (ChatGPT / Claude / Perplexity) readiness — and **`llms.txt` presence is one of the criteria** it checks (alongside canonical, robots, schema.org, hreflang, content density). It's directly aligned with this hub's mission of helping the `llms.txt` standard spread.

## Details

- **License:** MIT
- **Install:** `pip install agent-readiness-cli`
- **GitHub:** https://github.com/sspoisk/agent-readiness-cli
- **PyPI:** https://pypi.org/project/agent-readiness-cli/
- **Tests:** 13/13 passing, std-lib only, Python 3.10+
- **Usage:** `agent-readiness-cli https://example.com` → prints score + per-criterion breakdown

## Change

Single-line addition in the Developer Tools table, right after `llmstxt-cli` (sibling tool category).

Happy to adjust wording, emoji, or section placement if maintainer prefers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new developer tool entry (`agent-readiness-cli`) to the Developer Tools section, including GitHub and PyPI links for reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thedaviddias/llms-txt-hub/pull/1021)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->