### PR TITLE
Add Sourcey to the directory

### DIFF
--- a/packages/content/data/websites/sourcey-llms-txt.mdx
+++ b/packages/content/data/websites/sourcey-llms-txt.mdx
@@ -1,0 +1,20 @@
+---
+name: 'Sourcey'
+description: 'Multi-source documentation generator. Turns OpenAPI, MCP, Doxygen XML, godoc, and Markdown into one static HTML site. Open source, self-hosted, emits llms.txt and llms-full.txt natively.'
+website: 'https://sourcey.com'
+llmsUrl: 'https://sourcey.com/docs/llms.txt'
+llmsFullUrl: 'https://sourcey.com/docs/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-05-15'
+---
+
+# Sourcey
+
+Open-source documentation generator that produces a single static HTML site
+from OpenAPI, MCP server manifests, Doxygen XML, godoc, and Markdown.
+
+Every Sourcey-built site ships llms.txt and llms-full.txt as first-class
+build artefacts alongside the HTML output, so the same source produces
+docs for humans and structured context for AI agents in one build.
+
+AGPL-3.0 on the CLI. Self-host anywhere. https://github.com/sourcey/sourcey


### PR DESCRIPTION
Sourcey is an open-source documentation generator. Homepage: https://sourcey.com.

It produces a single static HTML site from OpenAPI, MCP server manifests, Doxygen XML, godoc, and Markdown sources. Every Sourcey-built site ships llms.txt and llms-full.txt as first-class build artefacts alongside the HTML output, so the same source produces docs for both humans and AI agents in one build.

- Project: https://sourcey.com
- llms.txt: https://sourcey.com/docs/llms.txt
- llms-full.txt: https://sourcey.com/docs/llms-full.txt
- Source: https://github.com/sourcey/sourcey
- License: AGPL-3.0

Submitted per the Manual Pull Request flow in CONTRIBUTING.md, with the .mdx file under packages/content/data/websites/.