### PR TITLE
Add AI-First Scraper and AI-First Search to Developer Tools

### DIFF
--- a/packages/content/data/websites/ai-first-scraper-llms-txt.mdx
+++ b/packages/content/data/websites/ai-first-scraper-llms-txt.mdx
@@ -5,7 +5,7 @@ website: 'https://ai-first-scraper.onrender.com'
 llmsUrl: 'https://ai-first-scraper.onrender.com/llms.txt'
 llmsFullUrl: ''
 category: 'developer-tools'
-publishedAt: '2026-05-19'
+publishedAt: '2026-05-18'
 ---
 
 # AI-First Scraper

--- a/packages/content/data/websites/ai-first-scraper-llms-txt.mdx
+++ b/packages/content/data/websites/ai-first-scraper-llms-txt.mdx
@@ -1,0 +1,25 @@
+---
+name: 'AI-First Scraper'
+description: 'Ad-free Markdown extraction API designed for LLM and AI agent consumption. Fetches any URL or PDF, strips ads / nav / scripts / trackers, returns clean Markdown. Supports batch fetch (25 URLs in parallel) and per-page token budgets.'
+website: 'https://ai-first-scraper.onrender.com'
+llmsUrl: 'https://ai-first-scraper.onrender.com/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-05-19'
+---
+
+# AI-First Scraper
+
+Ad-free Markdown extraction API designed for LLM and AI agent consumption.
+URL in → clean Markdown out. Strips ads, navigation, scripts, trackers; supports
+HTML and PDF. Includes `/scrape` (JSON envelope), `/raw` (text/markdown), and
+`POST /batch` for up to 25 parallel URLs. Per-page `max_tokens` cap protects
+your prompt budget.
+
+Endpoints exposed for AI agents:
+
+- `GET /scrape?url=<url>&max_tokens=<int?>` → JSON
+- `GET /raw?url=<url>&max_tokens=<int?>` → `text/markdown`
+- `POST /batch` body `{"urls": [...up to 25...]}` → array
+- `GET /llms.txt` — self-describing spec
+- `GET /.well-known/ai-plugin.json` — ChatGPT plugin manifest

--- a/packages/content/data/websites/ai-first-search-llms-txt.mdx
+++ b/packages/content/data/websites/ai-first-search-llms-txt.mdx
@@ -5,7 +5,7 @@ website: 'https://ai-first-search.onrender.com'
 llmsUrl: 'https://ai-first-search.onrender.com/llms.txt'
 llmsFullUrl: ''
 category: 'developer-tools'
-publishedAt: '2026-05-19'
+publishedAt: '2026-05-18'
 ---
 
 # AI-First Search

--- a/packages/content/data/websites/ai-first-search-llms-txt.mdx
+++ b/packages/content/data/websites/ai-first-search-llms-txt.mdx
@@ -1,0 +1,19 @@
+---
+name: 'AI-First Search'
+description: 'Search-engine-backed multi-URL Markdown extraction API for LLM agents. Free OSS alternative to Tavily / Exa / Perplexity. Runs a real web search, fetches the top-N result pages in parallel, returns each as clean ad-free Markdown.'
+website: 'https://ai-first-search.onrender.com'
+llmsUrl: 'https://ai-first-search.onrender.com/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-05-19'
+---
+
+# AI-First Search
+
+Search-engine-backed multi-URL Markdown extraction API for LLM agents.
+Query in → top-N pages as clean Markdown out. Free OSS alternative to
+Tavily / Exa / Perplexity's search-and-read APIs.
+
+Endpoint: `GET /search?q=<query>&k=<1..10>&max_tokens=<int?>` →
+JSON `{query, k, scraper_url, results[]}`. Each result includes URL,
+title, snippet, and the cleaned Markdown body of the page.

--- a/packages/content/data/websites/ai-first-search-llms-txt.mdx
+++ b/packages/content/data/websites/ai-first-search-llms-txt.mdx
@@ -1,8 +1,8 @@
 ---
 name: 'AI-First Search'
 description: 'Search-engine-backed multi-URL Markdown extraction API for LLM agents. Free OSS alternative to Tavily / Exa / Perplexity. Runs a real web search, fetches the top-N result pages in parallel, returns each as clean ad-free Markdown.'
-website: 'https://ai-first-search.onrender.com'
-llmsUrl: 'https://ai-first-search.onrender.com/llms.txt'
+website: 'https://fingerdog50-ai-first-search.hf.space'
+llmsUrl: 'https://fingerdog50-ai-first-search.hf.space/llms.txt'
 llmsFullUrl: ''
 category: 'developer-tools'
 publishedAt: '2026-05-18'


### PR DESCRIPTION
Adding two related open-source APIs that ship a public \`llms.txt\` for AI agents to consume:

- **AI-First Scraper** — https://ai-first-scraper.onrender.com
  Ad-free Markdown extraction. URL (HTML or PDF) in → clean Markdown out. Includes \`/scrape\` (JSON), \`/raw\` (text/markdown), and \`POST /batch\` for up to 25 parallel URLs. Per-page \`max_tokens\` budget.

- **AI-First Search** — https://ai-first-search.onrender.com
  Search-engine-backed multi-URL Markdown extraction. Free OSS alternative to Tavily / Exa / Perplexity. Query → top-N pages already converted to Markdown.

Both serve:
- \`/llms.txt\` — self-describing usage spec
- \`/.well-known/ai-plugin.json\` — ChatGPT plugin manifest
- \`/openapi.json\` — full OpenAPI spec

Two \`.mdx\` files added under \`packages/content/data/websites/\`. Did not touch \`data/websites.json\` per CONTRIBUTING.md. Happy to adjust category or wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an AI-First Scraper page documenting ad-free Markdown extraction endpoints (/scrape, /raw, POST /batch, /llms.txt), AI plugin manifest, and batch/concurrency and max_tokens behavior.
  * Added an AI-First Search page documenting the GET /search endpoint (q, k, max_tokens) and its JSON response shape (query, k, scraper_url, results with URL, title, snippet, cleaned Markdown).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thedaviddias/llms-txt-hub/pull/1048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->