### PR TITLE
feat: add UiPath docs to registry

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -5409,6 +5409,15 @@
     "publishedAt": "2026-01-18"
   },
   {
+    "name": "UiPath",
+    "domain": "https://docs.uipath.com",
+    "description": "Complete reference documentation for UiPath automation platform — Orchestrator, Studio, Agents, Maestro, and 40+ products.",
+    "llmsTxtUrl": "https://docs.uipath.com/llms.txt",
+    "category": "developer-tools",
+    "favicon": "https://www.google.com/s2/favicons?domain=docs.uipath.com&sz=128",
+    "publishedAt": "2026-05-22"
+  },
+  {
     "name": "uminai MCP",
     "domain": "https://mcp.umin.ai",
     "description": "Curated collection of MCP Servers, MCP Clients including Awesome MCP Servers and workflow for LLM integration.",


### PR DESCRIPTION
Adds [UiPath](https://docs.uipath.com) documentation to the registry.

- **llms.txt**: https://docs.uipath.com/llms.txt
- **Category**: developer-tools
- **Coverage**: 41 product sub-indexes (`llms-<product>.txt`), each linking to per-page `.md` endpoints
- **Products**: Orchestrator, Studio, Agents, Maestro, Automation Cloud, and 35+ more

UiPath is an enterprise automation platform. The docs site serves LLM-friendly markdown at `<page-url>.md` and follows the llms.txt standard with a top-level index linking to per-product sub-indexes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UiPath documentation as a newly supported resource.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thedaviddias/llms-txt-hub/pull/1076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->