### PR TITLE
Add OpenPencil to llms.txt directory

### DIFF
--- a/packages/content/data/websites/openpencil-llms-txt.mdx
+++ b/packages/content/data/websites/openpencil-llms-txt.mdx
@@ -1,0 +1,26 @@
+---
+name: 'OpenPencil'
+description: 'Open-source, AI-native design editor and toolkit for Figma .fig files, programmable design automation, MCP, CLI, and Vue SDK workflows.'
+website: 'https://openpencil.dev'
+llmsUrl: 'https://openpencil.dev/llms.txt'
+llmsFullUrl: 'https://openpencil.dev/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-05-22'
+priority: 'high'
+---
+
+# OpenPencil
+
+OpenPencil is an open-source design editor and programmable design toolkit. It opens Figma `.fig` files, provides a scriptable scene graph, and includes automation surfaces for CLI workflows, MCP clients, AI agents, JSX/Tailwind export, and custom Vue editor shells.
+
+## Key Focus Areas
+
+- Open-source design editing
+- Figma `.fig` file compatibility
+- Design automation and AI-assisted editing
+- MCP server and CLI workflows
+- Headless Vue SDK for custom editors
+
+## About llms.txt Implementation
+
+OpenPencil's llms.txt provides a compact map of the documentation for agents, including user guides, automation docs, CLI commands, MCP integration, Vue SDK APIs, scene graph references, file format notes, and development documentation. The full documentation bundle is available in llms-full.txt, with per-page Markdown files generated from the VitePress docs.


### PR DESCRIPTION
Adds [OpenPencil](https://openpencil.dev) to the directory.

- **Website:** https://openpencil.dev
- **llms.txt:** https://openpencil.dev/llms.txt
- **llms-full.txt:** https://openpencil.dev/llms-full.txt
- **Category:** developer-tools

OpenPencil is an open-source, AI-native design editor and toolkit for Figma `.fig` files, programmable design automation, MCP, CLI, and Vue SDK workflows.

Adds a single `.mdx` file under `packages/content/data/websites/` per CONTRIBUTING.md; `data/websites.json` left untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new OpenPencil reference page documenting the project and its llms.txt implementation features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thedaviddias/llms-txt-hub/pull/1081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->