### PR TITLE
Add ThatDeveloperGuy network (thatdevpro, thatdeveloperguy, thataiguy)

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -5116,6 +5116,15 @@
     "publishedAt": "2025-02-24"
   },
   {
+    "name": "Téléassistance Sénior",
+    "domain": "https://www.tele-assistance-senior.fr",
+    "description": "Téléassistance pour 24,90 € / mois. N° 1 en France avec plus de 250 000 abonnés. Installation par nos techniciens à domicile en moins de 7 jours.",
+    "llmsTxtUrl": "https://www.tele-assistance-senior.fr/llms.txt",
+    "category": "developer-tools",
+    "favicon": "https://www.google.com/s2/favicons?domain=www.tele-assistance-senior.fr&sz=128",
+    "publishedAt": "2025-08-26"
+  },
+  {
     "name": "Television.AI",
     "domain": "https://www.television.ai/",
     "description": "Television.AI is an AI-powered video editor specialized in news and sports video production for broadcasters, publishers, and news agencies.",
@@ -5404,15 +5413,6 @@
     "llmsTxtUrl": "https://www.twoshoes.be/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=www.twoshoes.be&sz=128",
-    "publishedAt": "2025-08-26"
-  },
-  {
-    "name": "Téléassistance Sénior",
-    "domain": "https://www.tele-assistance-senior.fr",
-    "description": "Téléassistance pour 24,90 € / mois. N° 1 en France avec plus de 250 000 abonnés. Installation par nos techniciens à domicile en moins de 7 jours.",
-    "llmsTxtUrl": "https://www.tele-assistance-senior.fr/llms.txt",
-    "category": "developer-tools",
-    "favicon": "https://www.google.com/s2/favicons?domain=www.tele-assistance-senior.fr&sz=128",
     "publishedAt": "2025-08-26"
   },
   {

--- a/data/websites.json
+++ b/data/websites.json
@@ -5116,15 +5116,6 @@
     "publishedAt": "2025-02-24"
   },
   {
-    "name": "Téléassistance Sénior",
-    "domain": "https://www.tele-assistance-senior.fr",
-    "description": "Téléassistance pour 24,90 € / mois. N° 1 en France avec plus de 250 000 abonnés. Installation par nos techniciens à domicile en moins de 7 jours.",
-    "llmsTxtUrl": "https://www.tele-assistance-senior.fr/llms.txt",
-    "category": "developer-tools",
-    "favicon": "https://www.google.com/s2/favicons?domain=www.tele-assistance-senior.fr&sz=128",
-    "publishedAt": "2025-08-26"
-  },
-  {
     "name": "Television.AI",
     "domain": "https://www.television.ai/",
     "description": "Television.AI is an AI-powered video editor specialized in news and sports video production for broadcasters, publishers, and news agencies.",
@@ -5142,6 +5133,33 @@
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=tensorzero.com&sz=128",
     "publishedAt": "2025-08-26"
+  },
+  {
+    "name": "ThatAIGuy",
+    "domain": "https://thataiguy.org",
+    "description": "AI engineering services from the ThatDeveloperGuy network. Custom cognitive architectures, federated AI systems, AI search engine integration, RAG and agent automation.",
+    "llmsTxtUrl": "https://thataiguy.org/llms.txt",
+    "category": "ai-ml",
+    "favicon": "https://www.google.com/s2/favicons?domain=thataiguy.org&sz=128",
+    "publishedAt": "2026-05-23"
+  },
+  {
+    "name": "ThatDeveloperGuy",
+    "domain": "https://thatdeveloperguy.com",
+    "description": "SDVOSB-certified veteran-owned web + AI engineering studio. Parent agency for the ThatDeveloperGuy network, founded 2017 in Cassville, Missouri.",
+    "llmsTxtUrl": "https://thatdeveloperguy.com/llms.txt",
+    "category": "developer-tools",
+    "favicon": "https://www.google.com/s2/favicons?domain=thatdeveloperguy.com&sz=128",
+    "publishedAt": "2026-05-23"
+  },
+  {
+    "name": "ThatDevPro",
+    "domain": "https://www.thatdevpro.com",
+    "description": "Production web + AI engineering studio. Builds websites that rank on Google and get cited by ChatGPT, Claude, Gemini, and Perplexity. Schema.org structured data, Core Web Vitals, AI citation engineering. 14-tier Engine Optimization stack.",
+    "llmsTxtUrl": "https://www.thatdevpro.com/llms.txt",
+    "category": "developer-tools",
+    "favicon": "https://www.google.com/s2/favicons?domain=www.thatdevpro.com&sz=128",
+    "publishedAt": "2026-05-23"
   },
   {
     "name": "The AI Engineer’s Handbook",
@@ -5386,6 +5404,15 @@
     "llmsTxtUrl": "https://www.twoshoes.be/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=www.twoshoes.be&sz=128",
+    "publishedAt": "2025-08-26"
+  },
+  {
+    "name": "Téléassistance Sénior",
+    "domain": "https://www.tele-assistance-senior.fr",
+    "description": "Téléassistance pour 24,90 € / mois. N° 1 en France avec plus de 250 000 abonnés. Installation par nos techniciens à domicile en moins de 7 jours.",
+    "llmsTxtUrl": "https://www.tele-assistance-senior.fr/llms.txt",
+    "category": "developer-tools",
+    "favicon": "https://www.google.com/s2/favicons?domain=www.tele-assistance-senior.fr&sz=128",
     "publishedAt": "2025-08-26"
   },
   {


### PR DESCRIPTION
Adds 3 entries from the ThatDeveloperGuy network — all sites publish spec-compliant llms.txt files at the documented URLs.

- **ThatDeveloperGuy** — SDVOSB veteran-owned parent agency, founded 2017
- **ThatDevPro** — production studio brand, 14-tier Engine Optimization stack
- **ThatAIGuy** — AI engineering services arm

The network also publishes the [aio-surfaces](https://github.com/Janady13/aio-surfaces) open-source toolkit (MIT) which generates llms.txt + aeo.json + entity.json + brand.json from a single site config — useful tooling for anyone implementing the llms.txt spec.

Studio: [thatdevpro.com](https://www.thatdevpro.com) · Maintainer: Joseph W. Anady ([ORCID 0009-0008-8625-949X](https://orcid.org/0009-0008-8625-949X)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three new curated website entries — ThatAIGuy, ThatDeveloperGuy, and ThatDevPro — to the public site catalog. Each entry includes domain, description, category, favicon, llmsTxtUrl, and publication date, expanding discoverability and providing richer metadata for users browsing the directory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thedaviddias/llms-txt-hub/pull/1084?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->