### PR TITLE
feat(community): add Presspeech to llms.txt hub

### DIFF
--- a/packages/content/data/websites/parakey-llms-txt.mdx
+++ b/packages/content/data/websites/parakey-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Parakey'
+description: 'Free, native, local push-to-talk dictation app for Apple Silicon Macs targeting ~100ms key-release-to-paste latency with zero telemetry.'
+website: 'https://rcourtman.github.io/parakey'
+llmsUrl: 'https://rcourtman.github.io/parakey/llms.txt'
+llmsFullUrl: 'https://rcourtman.github.io/parakey/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-05-25'
+---
+
+# Parakey
+
+Free, native, local push-to-talk dictation app for Apple Silicon Macs targeting ~100ms key-release-to-paste latency with zero telemetry.

--- a/packages/content/data/websites/parakey-llms-txt.mdx
+++ b/packages/content/data/websites/parakey-llms-txt.mdx
@@ -1,7 +1,7 @@
 ---
 name: 'Parakey'
 description: 'Free, native, local push-to-talk dictation app for Apple Silicon Macs targeting ~100ms key-release-to-paste latency with zero telemetry.'
-website: 'https://rcourtman.github.io/parakey'
+website: 'https://rcourtman.github.io/parakey/'
 llmsUrl: 'https://rcourtman.github.io/parakey/llms.txt'
 llmsFullUrl: 'https://rcourtman.github.io/parakey/llms-full.txt'
 category: 'developer-tools'

--- a/packages/content/data/websites/presspeech-llms-txt.mdx
+++ b/packages/content/data/websites/presspeech-llms-txt.mdx
@@ -1,13 +1,13 @@
 ---
-name: 'Parakey'
+name: 'Presspeech'
 description: 'Free, native, local push-to-talk dictation app for Apple Silicon Macs targeting ~100ms key-release-to-paste latency with zero telemetry.'
-website: 'https://rcourtman.github.io/parakey/'
-llmsUrl: 'https://rcourtman.github.io/parakey/llms.txt'
-llmsFullUrl: 'https://rcourtman.github.io/parakey/llms-full.txt'
+website: 'https://rcourtman.github.io/presspeech/'
+llmsUrl: 'https://rcourtman.github.io/presspeech/llms.txt'
+llmsFullUrl: 'https://rcourtman.github.io/presspeech/llms-full.txt'
 category: 'developer-tools'
 publishedAt: '2026-05-25'
 ---
 
-# Parakey
+# Presspeech
 
 Free, native, local push-to-talk dictation app for Apple Silicon Macs targeting ~100ms key-release-to-paste latency with zero telemetry.


### PR DESCRIPTION
Adds Presspeech to the Developer Tools section.

Presspeech is a free, native, local push-to-talk dictation app for Apple Silicon Macs targeting about 100 ms key-release-to-paste latency with zero telemetry.

- Website: https://rcourtman.github.io/presspeech/
- Repository: https://github.com/rcourtman/presspeech
- llms.txt: https://rcourtman.github.io/presspeech/llms.txt
- llms-full.txt: https://rcourtman.github.io/presspeech/llms-full.txt
