### PR TITLE
Add wmcp.sh — turn any URL into agent-callable MCP tools

### DIFF
--- a/packages/content/data/websites/wmcp-sh-llms-txt.mdx
+++ b/packages/content/data/websites/wmcp-sh-llms-txt.mdx
@@ -1,0 +1,17 @@
+---
+name: 'wmcp.sh'
+description: 'Turn any URL into agent-callable MCP tools. 5-tier adapter chain (Shopify, JSON-LD, OpenAPI, providers, LLM-fallback) — hosted at the edge on Cloudflare Workers.'
+website: 'https://wmcp.sh'
+llmsUrl: 'https://wmcp.sh/llms.txt'
+llmsFullUrl: 'https://wmcp.sh/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-05-28'
+---
+
+# wmcp.sh
+
+A hosted Cloudflare Worker that extracts agent-callable MCP tools from any URL — Shopify storefronts (~4M live), OpenAPI specs, JSON-LD-tagged pages, known provider APIs (Stripe, GitHub, Slack, Notion, Linear, Discord, Google, Airtable), or a Claude 3.5 Haiku fallback for unstructured pages.
+
+Returns a JSON tool list in the Claude tool_use / OpenAI function_call / MCP shape — any agent can invoke. Sub-50ms on cache hit.
+
+Open-source MIT at [github.com/New1Direction/webmcp-anything](https://github.com/New1Direction/webmcp-anything). Live API: `curl 'https://wmcp.sh/api/v1/tools?url=<any-url>'`. Free public tier; paid `/managed` with custom adapters + verified directory listings.


### PR DESCRIPTION
Adds **wmcp.sh** to the developer-tools category.

- Website: https://wmcp.sh
- llms.txt: https://wmcp.sh/llms.txt (11 KB navigation index)
- llms-full.txt: https://wmcp.sh/llms-full.txt (~190 KB full corpus — every blog post body concatenated for one-shot LLM context-window ingestion)
- Repo: https://github.com/New1Direction/webmcp-anything (MIT, public)

**What it does:** Hosted Cloudflare Worker that extracts agent-callable MCP tools from any URL via a 5-tier adapter chain — Shopify (~4M storefronts), generic JSON-LD, OpenAPI compiler, known providers (Stripe/Slack/GitHub/Notion/Discord/Linear/Google/Airtable), and a Claude 3.5 Haiku fallback. Sub-50ms on cache hit.

74 SEO surfaces currently live including 24 long-form engineering blog posts (all in `/llms-full.txt`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for wmcp.sh service, including site metadata, service description, API specifications, JSON tool output details, and live API usage information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thedaviddias/llms-txt-hub/pull/1106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->