### PR TITLE
Add Longevity World Cup

### DIFF
--- a/packages/content/data/websites/longevity-world-cup-llms-txt.mdx
+++ b/packages/content/data/websites/longevity-world-cup-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Longevity World Cup'
+description: 'Open-source longevity sport platform with public rankings, athlete profiles, events, biological-age calculators, and AI-readable resources.'
+website: 'https://longevityworldcup.com/'
+llmsUrl: 'https://longevityworldcup.com/llms.txt'
+llmsFullUrl: 'https://longevityworldcup.com/llms-full.txt'
+category: 'other'
+publishedAt: '2026-05-30'
+---
+
+# Longevity World Cup
+
+Open-source longevity sport platform with public rankings, athlete profiles, events, biological-age calculators, and AI-readable resources.


### PR DESCRIPTION
## Summary
- Adds Longevity World Cup to the llms.txt hub website directory.
- Includes working llms.txt and llms-full.txt URLs.

## Checks
- Verified https://longevityworldcup.com/llms.txt returns HTTP 200.
- Verified https://longevityworldcup.com/llms-full.txt returns HTTP 200.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new content entry for Longevity World Cup, including platform information and metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/thedaviddias/llms-txt-hub/pull/1112?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->