### PR TITLE
Add mira to website directory

### DIFF
--- a/packages/content/data/websites/mira-llms-txt.mdx
+++ b/packages/content/data/websites/mira-llms-txt.mdx
@@ -1,0 +1,15 @@
+---
+name: 'mira'
+description: 'Turns structured output from an AI agent into a real, shareable web page. Name mira.cagdas.io in your prompt — no key, no signup. 29 block types, permanent URLs, PDF export.'
+website: 'https://mira.cagdas.io'
+llmsUrl: 'https://mira.cagdas.io/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-05-31'
+---
+
+# mira
+
+Turns structured output from an AI agent into a real, shareable web page. Name mira.cagdas.io in your prompt — no key, no signup. 29 block types, permanent URLs, PDF export.
+
+mira is agent-native: it publishes a machine-readable v1 contract at [/llms.txt](https://mira.cagdas.io/llms.txt) (also `/v1/spec.md`), so an agent can discover the schema, POST a structured payload, and get back a hosted page at a permanent URL.


### PR DESCRIPTION
Adds [mira](https://mira.cagdas.io) — turns an AI agent's structured output into a real, shareable web page (name mira.cagdas.io in your prompt; no key, no signup; 29 block types, permanent URLs, PDF export).

mira is agent-native and ships a machine-readable contract at https://mira.cagdas.io/llms.txt (also /v1/spec.md), so agents can discover the schema and POST a payload to render a hosted page.

- **llms.txt:** https://mira.cagdas.io/llms.txt
- **Category:** developer-tools
- No `llmsFullUrl` (not served), set to empty per the schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation page for mira detailing contract discovery through `/llms.txt` and `/v1/spec.md` endpoints, including information on hosted permanent URL behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->