### PR TITLE
Add sf-llms-context

### DIFF
--- a/packages/content/data/websites/sf-llms-context-llms-txt.mdx
+++ b/packages/content/data/websites/sf-llms-context-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'sf-llms-context'
+description: 'Curated Salesforce knowledge base for AI coding agents — stops LLMs from generating deprecated Apex, LWC, SOQL, and Flow patterns. Verified against Summer ''26 / API v67.0.'
+website: 'https://github.com/sf-llms-context/sf-llms-context'
+llmsUrl: 'https://sf-llms-context.github.io/llms.txt'
+llmsFullUrl: 'https://sf-llms-context.github.io/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-06-01'
+---
+
+# sf-llms-context
+
+Curated, opinionated Salesforce knowledge optimized for AI coding agents. Shows the deprecated pattern AI tends to generate next to the current one, with the governor-limit or security reason. Covers Apex, LWC, SOQL, Flow, governor limits, and API versions. Verified against the Summer '26 (API v67.0) docs.

--- a/packages/content/data/websites/sf-llms-context-llms-txt.mdx
+++ b/packages/content/data/websites/sf-llms-context-llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
 name: 'sf-llms-context'
-description: 'Curated Salesforce knowledge base for AI coding agents — stops LLMs from generating deprecated Apex, LWC, SOQL, and Flow patterns. Verified against Summer ''26 / API v67.0.'
+description: 'Curated Salesforce knowledge base for AI coding agents — stops LLMs from generating deprecated Apex, LWC, SOQL, and Flow patterns. Verified against Summer ''26 (API v67.0).'
 website: 'https://github.com/sf-llms-context/sf-llms-context'
 llmsUrl: 'https://sf-llms-context.github.io/llms.txt'
 llmsFullUrl: 'https://sf-llms-context.github.io/llms-full.txt'


### PR DESCRIPTION
Adds an entry for **sf-llms-context** — a curated Salesforce knowledge base in llms.txt format, optimized for AI coding agents.

It shows the deprecated Salesforce pattern AI tends to generate next to the current one, with the governor-limit or security reason. Covers Apex, LWC, SOQL, Flow, governor limits, and API versions. All numbers verified against the official Summer '26 (API v67.0) docs.

- llms.txt: https://sf-llms-context.github.io/llms.txt
- llms-full.txt: https://sf-llms-context.github.io/llms-full.txt
- Repo: https://github.com/sf-llms-context/sf-llms-context

Category: developer-tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new documentation page describing a curated Salesforce knowledge base for AI coding agents, including title, description, links, category and publication date.
  * Content verified against Summer ’26 / API v67.0 to ensure alignment with current platform behavior and references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->