### PR TITLE
feat(community): add Gruzdevv.ru to llms.txt hub

### DIFF
--- a/packages/content/data/websites/gruzdevv-ru-llms-txt.mdx
+++ b/packages/content/data/websites/gruzdevv-ru-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Gruzdevv.ru'
+description: 'Find and compare best SaaS tools on the market, LLMs models, get the freshest marketing news.'
+website: 'https://gruzdevv.ru/'
+llmsUrl: 'https://gruzdevv.ru/llms.txt'
+llmsFullUrl: 'https://gruzdevv.ru/llms-full.txt'
+category: 'marketing-sales'
+publishedAt: '2026-06-02'
+---
+
+# Gruzdevv.ru
+
+Find and compare best SaaS tools on the market, LLMs models, get the freshest marketing news.


### PR DESCRIPTION
This PR adds Gruzdevv.ru to the llms.txt hub.

**Website:** https://gruzdevv.ru/
**llms.txt:** https://gruzdevv.ru/llms.txt
**llms-full.txt:** https://gruzdevv.ru/llms-full.txt  
**Category:** marketing-sales

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive information about the Gruzdevv.ru website, including metadata, descriptions, and resource URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->