### PR TITLE
Create nitten-marketing-spA-llms-txt.mdx

### DIFF
--- a/packages/content/data/websites/nitten-marketing-spA-llms-txt.mdx
+++ b/packages/content/data/websites/nitten-marketing-spA-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Nitten Marketing SpA'
+description: 'Boutique digital marketing agency specializing in AEO, GEO and SAGEO — AI generative engine optimization methodology. Based in Santiago, Chile.'
+website: 'https://nittenmkt.cl'
+llmsUrl: 'https://nittenmkt.cl/llms.txt'
+llmsFullUrl: 'https://nittenmkt.cl/llms-full.txt'
+category: 'other'
+publishedAt: '2026-06-02'
+---
+
+# Nitten Marketing SpA
+
+Boutique digital marketing agency specializing in AEO, GEO and SAGEO — AI generative engine optimization methodology. Based in Santiago, Chile.


### PR DESCRIPTION
Adding Nitten Marketing SpA, a boutique digital marketing agency from Santiago, Chile, specializing in AEO, GEO and SAGEO methodology. llms.txt available at https://nittenmkt.cl/llms.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new website documentation for Nitten Marketing SpA, including business name, detailed description, and reference URLs for discovery and indexing. This entry enhances the platform's content library with essential information, making the website more accessible to users searching for relevant business resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->