### PR TITLE
feat(websites): add Xcene Automação Residencial

### DIFF
--- a/packages/content/data/websites/xcene-automacao-residencial-llms-txt.mdx
+++ b/packages/content/data/websites/xcene-automacao-residencial-llms-txt.mdx
@@ -1,0 +1,45 @@
+---
+name: 'Xcene Automação Residencial'
+description: 'Brazilian premium residential automation: keypads, pushbuttons, relay modules and centrals for high-end projects. 23+ years of electronic engineering manufactured in São Paulo. Supports RS-485, UDP/TCP/HTTP, XNET, Alexa, Google Home and Home Assistant.'
+website: 'https://xcene.com.br'
+llmsUrl: 'https://xcene.com.br/llms.txt'
+llmsFullUrl: 'https://xcene.com.br/llms-full.txt'
+category: 'other'
+publishedAt: '2026-06-03'
+priority: 'medium'
+featured: false
+---
+
+# Xcene Automação Residencial
+
+Xcene is the residential automation brand of the Austhen Group, with over 23 years of electronic engineering manufactured in São Paulo. Serves integrators, architects and high-end marcenarias across Brazil.
+
+## Product Lines
+
+- **Keypads and pushbuttons** for premium residential installations
+- **Relay modules** for lighting and motorized loads
+- **Centrals** for full home automation orchestration
+- **Configurator** (online SPA): visual project planning tool for integrators
+
+## Protocols and Compatibility
+
+- RS-485 (native field bus for keypad/module communication)
+- UDP/TCP/HTTP for IP integration
+- XNET (proprietary protocol)
+- Voice assistants: Alexa, Google Home
+- Open-source ecosystem: Home Assistant
+
+## llms.txt Implementation
+
+The llms.txt at https://xcene.com.br/llms.txt provides:
+- Full product catalog organized by category
+- Protocol documentation and integration points
+- Application sectors (residential premium, hospitality, retail)
+- Configurator and dealer locator references
+
+## About
+
+- Brand of: Austhen Group (founded 2004)
+- Location: São Paulo, SP, Brazil
+- Industry: Premium residential automation hardware
+- Market: Integrators, architects, premium furniture makers across Brazil


### PR DESCRIPTION
## Add Xcene Automação Residencial to the directory

**Website:** https://xcene.com.br
**llms.txt:** https://xcene.com.br/llms.txt
**llms-full.txt:** https://xcene.com.br/llms-full.txt
**Category:** other (residential automation hardware brand)

### About
Xcene is the residential automation brand of the Austhen Group, with over 23 years of electronic engineering manufactured in São Paulo. Serves integrators, architects and high-end marcenarias across Brazil.

### Products
- Keypads and pushbuttons for premium residential installations
- Relay modules for lighting and motorized loads
- Centrals for full home automation orchestration
- Online Configurator (SPA) for integrators

### Protocols and Compatibility
- RS-485 (native field bus), UDP/TCP/HTTP, XNET (proprietary)
- Voice assistants: Alexa, Google Home
- Open-source ecosystem: Home Assistant

### Files changed
- `packages/content/data/websites/xcene-automacao-residencial-llms-txt.mdx` (new file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new comprehensive resource page detailing residential automation product offerings, including supported protocols, system compatibility information, and company details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->