### PR TITLE
feat(community): add Pocket skills to llms.txt hub

### DIFF
--- a/packages/content/data/websites/pocket-skills-llms-txt.mdx
+++ b/packages/content/data/websites/pocket-skills-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Pocket skills'
+description: 'Structured AI coding workflows foragent — from idea to reviewed, shipped code: planning, subagent delegation, bug hunting, and code review. - rfxlamia/pocketto.'
+website: 'https://github.com/rfxlamia/pocketto'
+llmsUrl: 'https://github.com/rfxlamia/pocketto/blob/main/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-06-05'
+---
+
+# Pocket skills
+
+Structured AI coding workflows foragent — from idea to reviewed, shipped code: planning, subagent delegation, bug hunting, and code review. - rfxlamia/pocketto.


### PR DESCRIPTION
This PR adds Pocket skills to the llms.txt hub.

**Website:** https://github.com/rfxlamia/pocketto
**llms.txt:** https://github.com/rfxlamia/pocketto/blob/main/llms.txt

**Category:** developer-tools

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new content covering Pocket skills for large language models, including detailed descriptions and resource links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->