### PR TITLE
feat(community): add pocket skills for dev to llms.txt hub

### DIFF
--- a/packages/content/data/websites/pocket-skills-for-dev-llms-txt.mdx
+++ b/packages/content/data/websites/pocket-skills-for-dev-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'pocket skills for dev'
+description: 'Structured AI coding workflows — from idea to reviewed, shipped code: planning, subagent delegation, bug hunting, and code review. - rfxlamia/pocketto.'
+website: 'https://github.com/rfxlamia/pocketto'
+llmsUrl: 'https://github.com/rfxlamia/pocketto/blob/main/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-06-05'
+---
+
+# pocket skills for dev
+
+Structured AI coding workflows — from idea to reviewed, shipped code: planning, subagent delegation, bug hunting, and code review. - rfxlamia/pocketto.


### PR DESCRIPTION
This PR adds pocket skills for dev to the llms.txt hub.

**Website:** https://github.com/rfxlamia/pocketto
**llms.txt:** https://github.com/rfxlamia/pocketto/blob/main/llms.txt

**Category:** developer-tools

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added new content page for "Pocket Skills for Dev" with comprehensive descriptions, repository references, and organized metadata for improved resource discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->