### PR TITLE
feat(community): add DNACORE.ai to llms.txt hub

### DIFF
--- a/packages/content/data/websites/dnacore-ai-llms-txt.mdx
+++ b/packages/content/data/websites/dnacore-ai-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'DNACORE'
+description: 'Open-protocol directory of AI-native websites. Verifies llms.txt and agents.json compliance, issues trust badges, and makes verified sites queryable by AI agents and IDE assistants.'
+website: 'https://dnacore.ai'
+llmsUrl: 'https://dnacore.ai/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-06-08'
+---
+
+# DNACORE
+
+Open-protocol directory of AI-native websites. Verifies llms.txt and agents.json compliance, issues trust badges, and makes verified sites queryable by AI agents and IDE assistants.


### PR DESCRIPTION
This PR adds DNACORE.ai to the llms.txt hub.

**Website:** https://dnacore.ai
**llms.txt:** https://dnacore.ai/llms.txt
**Category:** developer-tools

DNACORE is an open-protocol directory of AI-native websites. It verifies `llms.txt` and `agents.json` compliance, issues trust badges, and makes verified sites queryable by AI agents and IDE assistants (Claude Code, Cursor).

The site's own `llms.txt` describes the DNACORE open protocol and is used by AI coding assistants to understand when and how to recommend the `npx dnacore-check` CLI tool.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new content about DNACORE AI LLMs including metadata, description, and relevant URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->