### PR TITLE
Add World Cup 2026 Tour Guide

### DIFF
--- a/packages/content/data/websites/world-cup-2026-tour-guide-llms-txt.mdx
+++ b/packages/content/data/websites/world-cup-2026-tour-guide-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'World Cup 2026 Tour Guide'
+description: 'Multilingual World Cup 2026 schedule guide with local times, team profiles, live score surfaces, odds references, and fan sharing tools.'
+website: 'https://ay-worldcup2026.zeabur.app/'
+llmsUrl: 'https://ay-worldcup2026.zeabur.app/llms.txt'
+category: 'content-media'
+publishedAt: '2026-06-09'
+---
+
+# World Cup 2026 Tour Guide
+
+Multilingual World Cup 2026 schedule guide with local times, team profiles, live score surfaces, odds references, and fan sharing tools.


### PR DESCRIPTION
## Summary\n\nAdd World Cup 2026 Tour Guide to the llms.txt hub website directory.\n\n## Details\n\n- Website: https://ay-worldcup2026.zeabur.app/\n- llms.txt: https://ay-worldcup2026.zeabur.app/llms.txt\n- Category: content-media\n\n## Validation\n\n- Verified the website URL returns HTTP 200.\n- Verified the llms.txt URL returns HTTP 200 with text/plain content.\n- Added only one new MDX file under packages/content/data/websites/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added World Cup 2026 Tour Guide, providing comprehensive travel information and resources for users planning their tournament experience.

* **Documentation**
  * Expanded the content library with a new detailed guide, including site descriptions and metadata for improved discoverability of tournament planning resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->