### PR TITLE
feat: add Superhighway

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -10981,6 +10981,15 @@
     "publishedAt": "2026-03-22"
   },
   {
+    "name": "Superhighway",
+    "domain": "https://superhighway.walls.sh",
+    "description": "Web search for AI agents — live web search, news, and read-any-page-as-markdown, paid per call in USDC via x402 or a free API-key tier. No signup needed.",
+    "llmsTxtUrl": "https://superhighway.walls.sh/llms.txt",
+    "category": "ai-ml",
+    "favicon": "https://www.google.com/s2/favicons?domain=superhighway.walls.sh&sz=128",
+    "publishedAt": "2026-06-10"
+  },
+  {
     "name": "Superwall",
     "domain": "https://superwall.com",
     "description": "Superwall - Paywalls made easy",

--- a/data/websites.json
+++ b/data/websites.json
@@ -10983,7 +10983,7 @@
   {
     "name": "Superhighway",
     "domain": "https://superhighway.walls.sh",
-    "description": "Web search for AI agents — live web search, news, and read-any-page-as-markdown, paid per call in USDC via x402 or a free API-key tier. No signup needed.",
+    "description": "Web search for AI agents — live web search, news, image search, read-any-page, and one-call research, paid per call in USDC via x402 or a free API-key tier. No signup needed.",
     "llmsTxtUrl": "https://superhighway.walls.sh/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=superhighway.walls.sh&sz=128",


### PR DESCRIPTION
Adds **Superhighway** — web search for AI agents (live web search, news, image search, page reading, and one-call research), paid per call in USDC via the open x402 protocol or a free API-key tier.

- Live llms.txt: https://superhighway.walls.sh/llms.txt
- Site: https://superhighway.walls.sh
- Guides: https://superhighway.walls.sh/guides
- Category: `ai-ml` · inserted alphabetically (between superchargebrowser and Superwall)

🤖 Generated with [Claude Code](https://claude.com/claude-code)