### PR TITLE
feat(community): add intelica-intel-api to llms.txt hub

### DIFF
--- a/packages/content/data/websites/intelica-intel-api-llms-txt.mdx
+++ b/packages/content/data/websites/intelica-intel-api-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'intelica-intel-api'
+description: 'Competitive intelligence API for autonomous AI agents. Pay-per-call via x402 with USDC. 10 analysis modes, MCP server, 8 languages.'
+website: 'https://api.intelica.dev'
+llmsUrl: 'https://api.intelica.dev/llms.txt'
+llmsFullUrl: 'https://api.intelica.dev/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-06-11'
+---
+
+# intelica-intel-api
+
+Competitive intelligence API for autonomous AI agents. Pay-per-call via x402 with USDC. 10 analysis modes, MCP server, 8 languages.


### PR DESCRIPTION
This PR adds intelica-intel-api to the llms.txt hub.

**Website:** https://api.intelica.dev
**llms.txt:** https://api.intelica.dev/llms.txt
**llms-full.txt:** https://api.intelica.dev/llms-full.txt  
**Category:** ai-ml

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Intelica Intel API has been added to the LLMs directory, providing access to this service through the platform's website listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->