### PR TITLE
feat(community): add TrustBoost PII Sanitizer to llms.txt hub

### DIFF
--- a/packages/content/data/websites/trustboost-pii-sanitizer-llms-txt.mdx
+++ b/packages/content/data/websites/trustboost-pii-sanitizer-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'TrustBoost PII Sanitizer'
+description: 'TrustBoost sanitizes PII from text before it reaches LLMs. Blockchain-verified, x402 native, 8 languages, EU AI Act compliant.'
+website: 'https://api.trustboost.dev'
+llmsUrl: 'https://api.trustboost.dev/llms.txt'
+llmsFullUrl: 'https://api.trustboost.dev/llms-full.txt'
+category: 'security-identity'
+publishedAt: '2026-06-11'
+---
+
+# TrustBoost PII Sanitizer
+
+TrustBoost sanitizes PII from text before it reaches LLMs. Blockchain-verified, x402 native, 8 languages, EU AI Act compliant.


### PR DESCRIPTION
This PR adds TrustBoost PII Sanitizer to the llms.txt hub.

**Website:** https://api.trustboost.dev
**llms.txt:** https://api.trustboost.dev/llms.txt
**llms-full.txt:** https://api.trustboost.dev/llms-full.txt  
**Category:** security-identity

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.