### PR TITLE
Add WebsiteReady llms.txt entry

### DIFF
--- a/packages/content/data/websites/websiteready-llms-txt.mdx
+++ b/packages/content/data/websites/websiteready-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'WebsiteReady'
+description: 'Free pre-launch website audit for indie makers and AI tool sites, with launch-readiness checks for SEO basics, crawlability, sitemap, robots.txt, analytics signals, security headers, and AI search readiness.'
+website: 'https://websiteready.org/'
+llmsUrl: 'https://websiteready.org/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+priority: 'medium'
+publishedAt: '2026-06-11'
+---
+
+# WebsiteReady
+
+> Free pre-launch website audit for indie makers and AI tool sites.
+
+## Key Focus Areas
+
+- Website launch readiness
+- SEO basics and crawlability checks
+- AI search readiness and llms.txt context
+
+## About llms.txt Implementation
+
+WebsiteReady provides an `llms.txt` file with AI-readable information about its public pages, audit endpoints, report limits, and product boundaries.


### PR DESCRIPTION
## Summary

Adds WebsiteReady to the llms.txt hub website list.

WebsiteReady provides a public `llms.txt` file at https://websiteready.org/llms.txt with AI-readable information about its public pages, audit endpoints, report limits, and product boundaries.

I did not edit `data/websites.json`; this PR only adds a new MDX website entry under `packages/content/data/websites/`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebsiteReady entry: a free pre-launch website audit service with detailed documentation covering key audit areas and platform implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->