### PR TITLE
Add Master CLI (mfn) — AI-agent-first CLI, llms.txt shipped inside the npm package

### DIFF
--- a/packages/content/data/websites/master-cli-llms-txt.mdx
+++ b/packages/content/data/websites/master-cli-llms-txt.mdx
@@ -1,0 +1,30 @@
+---
+name: 'Master CLI (mfn)'
+description: 'AI-agent-friendly CLI: 51 headless, JSON-first commands with a self-describing manifest, a built-in MCP server, and always-on security guardrails.'
+website: 'https://github.com/Master4Novice/master-cli'
+llmsUrl: 'https://raw.githubusercontent.com/Master4Novice/master-cli/master/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-06-11'
+---
+
+# Master CLI (mfn)
+
+Master CLI (`mfn`, npm: `@master4n/master-cli`) is a command-line toolkit designed
+for AI agents first: 51 headless commands that emit exactly one JSON object on
+stdout with stable exit codes, discoverable through a self-describing
+`mfn capabilities --json` manifest. The `llms.txt` ships inside the npm package
+itself, so agents get the full contract offline.
+
+## Key Focus Areas
+
+- Token savers: extract one JSON field, a line range, or a file outline instead of dumping whole files into context
+- Exact computation: BigInt math, semver, cron, timezones — verified answers instead of guesses
+- Built-in Model Context Protocol server (`mfn mcp`) for clients without shell access
+- Always-on security guardrails: sensitive-path refusal, secret redaction, reversible deletes — no bypass flags
+
+## About llms.txt Implementation
+
+The llms.txt documents the complete agent contract: zero-install `npx` usage,
+the `--json` output envelope, exit-code semantics, per-command flags and
+examples, and the security guardrails an agent can rely on.


### PR DESCRIPTION
Adds **Master CLI (`mfn`, npm: `@master4n/master-cli`)** to the directory.

Disclosure: I'm the author/maintainer of this tool.

- **llms.txt:** https://raw.githubusercontent.com/Master4Novice/master-cli/master/llms.txt (also ships *inside* the npm package, so agents get the contract offline)
- **What it is:** 51 headless, JSON-first commands for AI agents — one JSON object on stdout, stable exit codes (0/1/2), self-describing `mfn capabilities --json` manifest, built-in MCP server (`mfn mcp`), and always-on security guardrails (sensitive-path refusal, secret redaction, reversible deletes; no bypass flags).
- **Category:** developer-tools

Entry follows the template in `packages/content/data/websites/`. Happy to adjust anything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Master CLI (mfn) documentation highlighting AI-agent-first design, 51 JSON-first commands, offline availability, token optimization features, built-in security guardrails, and manifest contract capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->