### PR TITLE
Add DOS Kernel (AI-agent trust kernel) to websites

### DIFF
--- a/packages/content/data/websites/dos-kernel-llms-txt.mdx
+++ b/packages/content/data/websites/dos-kernel-llms-txt.mdx
@@ -1,0 +1,16 @@
+---
+name: 'DOS Kernel'
+description: 'Domain-free trust kernel for fleets of AI agents — verifies what agents actually shipped from git evidence, arbitrates concurrent file access with leases, and refuses with structured reasons.'
+website: 'https://github.com/anthony-chaudhary/dos-kernel'
+llmsUrl: 'https://raw.githubusercontent.com/anthony-chaudhary/dos-kernel/master/llms.txt'
+category: 'ai-ml'
+publishedAt: '2026-06-11'
+---
+
+# DOS Kernel
+
+DOS (the Dispatch Operating System) is a small, deterministic trust kernel for fleets of autonomous AI agents. It adjudicates ground truth across many unreliable, self-narrating workers: `dos verify` answers "did this actually ship?" from git ancestry, `dos arbitrate` serializes concurrent file access, and refusals carry structured, verifiable reasons — the kernel never believes what an agent says it did.
+
+## About llms.txt Implementation
+
+DOS Kernel ships an `llms.txt` at the repository root that indexes the README, FAQ, architecture contract, and agent-runtime integration guides for AI tools.


### PR DESCRIPTION
## What

Adds **DOS Kernel** (the Dispatch Operating System) to the websites directory under `ai-ml`.

DOS is a domain-free trust kernel for fleets of autonomous AI agents — it verifies what an agent actually shipped from git evidence, arbitrates concurrent file access with leases, and refuses with structured reasons, instead of believing agent self-reports.

## llms.txt

The `llms.txt` lives at the repository root and is kept link-rot-free by a test in the suite:
https://raw.githubusercontent.com/anthony-chaudhary/dos-kernel/master/llms.txt

It indexes the README, FAQ, architecture contract, and agent-runtime integration guides.

- One new `.mdx` under `packages/content/data/websites/` (did not touch `data/websites.json`, per the contributing guide)
- Frontmatter follows the existing entry template; `llmsUrl` resolves with HTTP 200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new DOS Kernel documentation page describing it as a deterministic trust kernel, including repository information and details about the llms.txt file used for documentation indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->