### PR TITLE
Add Visacub to llms.txt directory

### DIFF
--- a/packages/content/data/websites/visacub-llms-txt.mdx
+++ b/packages/content/data/websites/visacub-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Visacub'
+description: 'U.S. immigration platform — self-file workflows, a $99 family green-card kit, and editorial guides for 21 visa categories with USCIS citations, timelines, and document checklists.'
+website: 'https://www.visacub.com'
+llmsUrl: 'https://www.visacub.com/llms.txt'
+category: 'other'
+priority: 'medium'
+publishedAt: '2026-06-11'
+---
+
+# Visacub
+
+Visacub is a U.S. immigration platform for petitioners who want to understand their visa path before deciding whether to hire counsel. It combines self-file case workflows with editorial guides covering 21 visa categories, each with process diagrams, eligibility checklists citing the USCIS Policy Manual, document lists, stage-by-stage timelines, and FAQs.
+
+## Key Focus Areas
+
+- $99 Family Self-File Kit for I-130 family-based green cards (marriage / parent / child / sibling)
+- Editorial guides for 21 visa categories with USCIS Policy Manual citations
+- Free tools: NIW Dhanasar three-prong assessment, document checklists, and timeline estimates
+- Trilingual content (English, Chinese, Spanish)
+
+## About llms.txt Implementation
+
+Visacub's `llms.txt` indexes the platform's product surface and editorial library — visa-category guides, self-file workflows, tools, and pricing — so AI assistants can accurately answer questions about U.S. immigration filing paths.


### PR DESCRIPTION
## Summary

Adds **Visacub** (https://www.visacub.com) — a U.S. immigration platform with self-file workflows, a $99 family green-card kit, and editorial guides for 21 visa categories.

- llms.txt: https://www.visacub.com/llms.txt (verified live, returns 200)
- New file: `packages/content/data/websites/visacub-llms-txt.mdx`, following the existing MDX schema and generator template
- Category: `other` (no closer match in the current category list for a legal/immigration platform)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Visacub's immigration platform to the indexed websites collection, making its product and editorial library discoverable through llms.txt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->