### PR TITLE
Add Forward (getforward.xyz)

### DIFF
--- a/packages/content/data/websites/forward-llms-txt.mdx
+++ b/packages/content/data/websites/forward-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Forward'
+description: 'Pay-per-result growth for agents and humans: qualified leads, sales meetings, SEO content, and verified ad conversions — billed only for results that pass your acceptance criteria.'
+website: 'https://getforward.xyz'
+llmsUrl: 'https://getforward.xyz/llms.txt'
+llmsFullUrl: 'https://getforward.xyz/llms-full.txt'
+category: 'marketing-sales'
+publishedAt: '2026-06-12'
+---
+
+# Forward
+
+Forward is an autonomous, pay-per-result growth company built to be bought by AI agents. Describe who you want as customers; a fleet of agents delivers qualified leads, held sales meetings, published SEO content, and verified ad conversions. Charges fire only for results that pass your acceptance criteria — hard-capped, itemized, idempotent, reversible. Remote MCP server at https://getforward.xyz/mcp with self-provisioning signup ($25 free starter credits); plain HTTP via the OpenAPI contract; payment rails: prepaid credits, x402, Stripe ACP.


### PR DESCRIPTION
Adds Forward to the websites directory (category: marketing-sales).

Forward is an autonomous, pay-per-result growth service designed to be operated and purchased by AI agents. Its llms.txt / llms-full.txt cover the full commerce surface — products, acceptance criteria, payment rails (credits / x402 / Stripe ACP), and the remote MCP endpoint — so an agent can complete a purchase end to end from the docs alone.

- llms.txt: https://getforward.xyz/llms.txt
- llms-full.txt: https://getforward.xyz/llms-full.txt
- Site: https://getforward.xyz

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Forward, a pay-per-result growth platform for agents and humans, to the available resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->