### PR TITLE
feat: add Edition Architecture (edition.nz)

### DIFF
--- a/packages/content/data/websites/edition-nz-llms-txt.mdx
+++ b/packages/content/data/websites/edition-nz-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'Edition Architecture'
+description: 'Licensed architecture practice in Auckland, New Zealand — AI-assisted design and building consent documentation.'
+website: 'https://edition.nz'
+llmsUrl: 'https://edition.nz/llms.txt'
+category: 'design'
+publishedAt: '2026-06-13'
+---
+
+# Edition Architecture
+
+Licensed architecture practice in Auckland, New Zealand. The practice has rebuilt internal workflows around AI automation — from feasibility and design through to building consent documentation. AI pre-lodgement review audits consent packages before lodgement, cutting typical approval timelines from months to days.


### PR DESCRIPTION
## New Website Submission

This PR adds **Edition Architecture** to the llms.txt hub.

- **Website:** https://edition.nz
- **llms.txt:** https://edition.nz/llms.txt
- **Category:** design

## About

Edition Architecture is a licensed architecture practice in Auckland, New Zealand. The practice has rebuilt internal workflows around AI automation — covering feasibility, design, and building consent documentation. AI pre-lodgement review audits consent packages before lodgement, cutting typical approval timelines from months to days.

Key results: building consent lodged in 9 working days; 8 building consents approved within 30 days across a single documentation batch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new content page for Edition Architecture, an Auckland-based practice utilizing AI-assisted workflows for building consent documentation featuring an AI pre-lodgement review process that reduces approval timelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->