### PR TITLE
Add InfraNode

### DIFF
--- a/packages/content/data/websites/infranode-llms-txt.mdx
+++ b/packages/content/data/websites/infranode-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'InfraNode'
+description: 'Free unified REST API for German city infrastructure data (weather, air quality, water levels, EV chargers, live public transport, demographics) from 35+ official sources'
+website: 'https://infranode.dev'
+llmsUrl: 'https://infranode.dev/llms.txt'
+llmsFullUrl: 'https://infranode.dev/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-06-13'
+---
+
+# InfraNode
+
+Free unified REST API for German city infrastructure data (weather, air quality, water levels, EV chargers, live public transport with GTFS-RT delays, demographics, boundaries) from 35+ official sources. 84 German cities, 48 endpoints, no API key required. Every record carries source license and attribution.


### PR DESCRIPTION
Adds infranode.dev to the websites list (new .mdx file under packages/content/data/websites/, per CONTRIBUTING.md; data/websites.json untouched).

- Website: https://infranode.dev
- llms.txt: https://infranode.dev/llms.txt
- llms-full.txt: https://infranode.dev/llms-full.txt
- Category: developer-tools

InfraNode is a free unified REST API for German city infrastructure data (weather, air quality, water levels, EV chargers, live public transport with GTFS-RT delays, demographics, boundaries) from 35+ official sources. 84 German cities, 48 endpoints, no API key required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added developer tool documentation for InfraNode, including API scope and licensing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->