### PR TITLE
Add x402 Trust Oracle llms.txt entry

### DIFF
--- a/packages/content/data/websites/x402-trust-oracle-llms-txt.mdx
+++ b/packages/content/data/websites/x402-trust-oracle-llms-txt.mdx
@@ -1,0 +1,17 @@
+---
+name: 'x402 Trust Oracle'
+description: 'Pre-payment trust checks for x402 trading agents so they can avoid stale, slow, down, or payment-drifted endpoints before paying for market data.'
+website: 'https://x402oracle.com'
+llmsUrl: 'https://x402oracle.com/llms.txt'
+llmsFullUrl: ''
+category: 'finance-fintech'
+publishedAt: '2026-06-15'
+---
+
+# x402 Trust Oracle
+
+x402 Trust Oracle gives autonomous trading agents a pre-payment trust check before they pay x402 endpoints for market data, oracle data, price signals, funding data, or execution inputs.
+
+Primary paid trust route: `/v1/trade-check`.
+
+Endpoint: `https://api.x402oracle.com/v1/trade-check`.


### PR DESCRIPTION
## Summary
- Add x402 Trust Oracle to the llms.txt website catalog
- Point metadata to canonical https://x402oracle.com and live https://x402oracle.com/llms.txt
- Add the trading trust route context for /v1/trade-check without editing generated JSON

## Notes
- Endpoint documented by the llms.txt file: https://api.x402oracle.com/v1/trade-check
- No generated JSON files were edited

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the x402 Trust Oracle service, including details on the pre-payment trust check mechanism and corresponding API endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->