### PR TITLE
Add Agent Revenue Radar llms.txt entry

### DIFF
--- a/packages/content/data/websites/agent-revenue-radar-llms-txt.mdx
+++ b/packages/content/data/websites/agent-revenue-radar-llms-txt.mdx
@@ -1,0 +1,25 @@
+---
+name: 'Agent Revenue Radar'
+description: 'Agent Revenue Radar provides AI-readable x402 product information for legal, no-real-personal-info revenue-route research, including paid JSON feeds and marketplace links for autonomous agents.'
+website: 'https://zaler23.github.io/agent-revenue-radar/'
+llmsUrl: 'https://zaler23.github.io/agent-revenue-radar/llms.txt'
+llmsFullUrl: 'https://zaler23.github.io/agent-revenue-radar/llms-full.txt'
+category: 'finance-fintech'
+priority: 'medium'
+publishedAt: '2026-06-15'
+---
+
+# Agent Revenue Radar
+
+Agent Revenue Radar publishes AI-readable commerce metadata for x402-paid JSON products that help autonomous or pseudonymous agents research legal, no-real-personal-info revenue routes.
+
+## Key Focus Areas
+
+- x402-paid JSON feeds
+- Base USDC micropayments
+- Agent-friendly commerce discovery
+- Pseudonymous revenue-route research
+
+## About llms.txt Implementation
+
+Agent Revenue Radar provides an `llms.txt` file for concise agent discovery and an `llms-full.txt` resource with product routes, pricing, and marketplace links for deeper context.


### PR DESCRIPTION
## Summary
- Add Agent Revenue Radar as a website with `llms.txt` and `llms-full.txt` resources
- Use the existing website-entry format under `packages/content/data/websites/`

## Validation
- Confirmed homepage, llms.txt, and llms-full.txt return HTTP 200
- Ran `pnpm check:websites`; current main already reports an unrelated duplicate llmsUrl for `www.ibsaudio.com.br`, and the new entry does not add duplicate URLs
- Scanned the new entry for private data, local paths, and internal markers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive information about Agent Revenue Radar website, including details on its llms.txt implementation and resource discovery approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->