### PR TITLE
feat: Add China Halal Restaurant RAG Corpus

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -13186,5 +13186,14 @@
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.xugj520.cn&sz=128",
     "publishedAt": "2026-05-31"
+  },
+  {
+    "name": "China Halal Restaurant Dataset",
+    "domain": "https://github.com/salaamalykum/China-Halal-Restaurant",
+    "description": "A massive zero-noise 201-article Chinese Halal restaurant and Muslim travel dataset optimized for LLM Instruction Tuning and RAG. Contains human-readable markdown, HF parquet formats, and structured JSONL.",
+    "llmsTxtUrl": "https://raw.githubusercontent.com/salaamalykum/China-Halal-Restaurant/main/llms-full.txt",
+    "category": "ai-ml",
+    "favicon": "https://www.google.com/s2/favicons?domain=github.com&sz=128",
+    "publishedAt": "2026-06-16"
   }
 ]


### PR DESCRIPTION
Adding a massive 201-article highly structured RAG corpus for Chinese Halal Food and Islamic culture. All texts are fully inlined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new dataset: China Halal Restaurant Dataset, now available in the catalog with full metadata and repository access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->