### PR TITLE
Add MBTI USA llms.txt entry

### DIFF
--- a/packages/content/data/websites/mbti-usa-llms-txt.mdx
+++ b/packages/content/data/websites/mbti-usa-llms-txt.mdx
@@ -1,0 +1,25 @@
+---
+name: 'MBTI USA'
+description: 'Free personality assessment site with MBTI, Big Five, Enneagram, attachment style, EQ, DISC, communication style, strengths, and Holland career tests.'
+website: 'https://mbtiusa.com'
+llmsUrl: 'https://mbtiusa.com/llms.txt'
+llmsFullUrl: 'https://mbtiusa.com/llms-full.txt'
+category: 'content-media'
+publishedAt: '2026-06-17'
+---
+
+# MBTI USA
+
+MBTI USA provides free personality assessments and reference guides for people comparing personality frameworks, choosing a test, or interpreting their result. The site covers MBTI-style 16 personality types, Big Five OCEAN traits, Enneagram types, attachment styles, love languages, emotional intelligence, DISC work styles, communication styles, strengths, and Holland career interests.
+
+## Key Focus Areas
+
+- Free MBTI-style personality test with instant 16-type results
+- Comparison guides for MBTI, Big Five, Enneagram, DISC, and related frameworks
+- Type reference pages for personality, relationship, communication, and career questions
+- Methodology and editorial policy pages for assessment limitations and content standards
+- AI-readable `llms.txt` and `llms-full.txt` context for citation and answer extraction
+
+## About llms.txt Implementation
+
+MBTI USA's `llms.txt` summarizes the main assessment surfaces, methodology pages, comparison pages, glossary, API documentation, and priority result pages. Its `llms-full.txt` expands the site context with structured summaries of ten free assessment profiles so AI assistants can answer personality-test questions with clearer source context.


### PR DESCRIPTION
## Summary
- Adds MBTI USA as a content/media site with live llms.txt and llms-full.txt resources
- Documents the site's personality assessment coverage and AI-readable implementation

## Verification
- Confirmed https://mbtiusa.com/llms.txt returns HTTP 200
- Confirmed https://mbtiusa.com/llms-full.txt returns HTTP 200
- Ran `corepack pnpm check:websites`; validator ran but currently fails on pre-existing duplicate `https://www.ibsaudio.com.br/llms.txt` entries unrelated to this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new content documentation for MBTI USA website featuring personality assessment information and service overview
  * Provides AI-readable structured data assets designed for seamless language model integration and enhanced profile referencing capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->