### PR TITLE
Add AgentsCamp

### DIFF
--- a/packages/content/data/websites/agentscamp-llms-txt.mdx
+++ b/packages/content/data/websites/agentscamp-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'AgentsCamp'
+description: 'A curated hub for everything AI — agents, skills, guides, tools, and commands for building with AI coding agents'
+website: 'https://agentscamp.com'
+llmsUrl: 'https://agentscamp.com/llms.txt'
+llmsFullUrl: 'https://agentscamp.com/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-06-16'
+---
+
+# AgentsCamp
+
+AgentsCamp is a curated content hub for building with AI coding agents — a directory of copy-paste, installable Claude Code agents, skills, and slash commands, plus long-form guides, an AI tools directory, and a glossary.
+
+## Key Focus Areas
+
+- AI Coding Agents (Claude Code)
+- Agent Skills & Slash Commands
+- AI Developer Tools & MCP Servers
+
+## About llms.txt Implementation
+
+AgentsCamp serves both /llms.txt and /llms-full.txt. Every page also has a clean Markdown twin at the same URL with a `.md` suffix, so agents can fetch any agent, skill, command, guide, or glossary term as plain Markdown.


### PR DESCRIPTION
This PR adds **AgentsCamp** to the llms.txt hub.

- Website: https://agentscamp.com
- llms.txt: https://agentscamp.com/llms.txt
- llms-full.txt: https://agentscamp.com/llms-full.txt
- Category: developer-tools

AgentsCamp is a curated hub for building with AI coding agents — installable Claude Code agents, skills, and slash commands, plus guides, an AI tools directory, and a glossary. Both llms.txt and llms-full.txt are live, and every page has a clean Markdown twin at the same URL with a `.md` suffix.

New file added under `packages/content/data/websites/` per CONTRIBUTING; `data/websites.json` left untouched (auto-generated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new AgentsCamp documentation page describing its llms.txt and llms-full.txt implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->