### PR TITLE
Add Ophis (intent-based DEX aggregator / MCP server)

### DIFF
--- a/packages/content/data/websites/ophis-llms-txt.mdx
+++ b/packages/content/data/websites/ophis-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Ophis'
+description: 'Intent-based DEX aggregator with a natural-language layer and a keyless MCP server for AI agents. Non-custodial, gasless, and MEV-protected, with surplus returned to the trader.'
+website: 'https://docs.ophis.fi'
+llmsUrl: 'https://docs.ophis.fi/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-06-18'
+---
+
+# Ophis
+
+Intent-based DEX aggregator with a natural-language layer and a keyless MCP server for AI agents. Non-custodial, gasless, and MEV-protected, with surplus returned to the trader.


### PR DESCRIPTION
This adds Ophis to the directory. Ophis is an intent-based DEX aggregator with a natural-language layer and a keyless MCP server for AI agents; it is non-custodial, gasless, and MEV-protected, with surplus returned to the trader.

The entry follows the existing `.mdx` format in `packages/content/data/websites/` and points `llmsUrl` at https://docs.ophis.fi/llms.txt (verified returning 200). `llmsFullUrl` is left empty because Ophis does not publish an llms-full.txt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new Ophis documentation page with metadata and reference materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->