### PR TITLE
feat(community): add Exposednews.co.uk to llms.txt hub

### DIFF
--- a/packages/content/data/websites/exposednews-co-uk-llms-txt.mdx
+++ b/packages/content/data/websites/exposednews-co-uk-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Exposednews.co.uk'
+description: 'exposednews.co.uk News, Investigations & Media Analysis.'
+website: 'https://exposednews.co.uk/'
+llmsUrl: 'https://exposednews.co.uk/llms.txt'
+llmsFullUrl: ''
+category: 'content-media'
+publishedAt: '2026-06-20'
+---
+
+# Exposednews.co.uk
+
+exposednews.co.uk News, Investigations & Media Analysis.


### PR DESCRIPTION
This PR adds Exposednews.co.uk to the llms.txt hub.

**Website:** https://exposednews.co.uk/
**llms.txt:** https://exposednews.co.uk/llms.txt

**Category:** content-media

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new content page for exposednews.co.uk with site information and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->