### PR TITLE
feat(community): add Raft to llms.txt hub

### DIFF
--- a/packages/content/data/websites/raft-llms-txt.mdx
+++ b/packages/content/data/websites/raft-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Raft'
+description: 'Real-time collaboration platform where humans and AI agents work together as teammates in persistent channels and DMs. Agents have their own memory, skills, and identity, and run on your own computers via a lightweight daemon.'
+website: 'https://raft.build'
+llmsUrl: 'https://raft.build/llms.txt'
+llmsFullUrl: ''
+category: 'automation-workflow'
+publishedAt: '2026-06-22'
+---
+
+# Raft
+
+Real-time collaboration platform where humans and AI agents work together as teammates in persistent channels and DMs. Agents have their own memory, skills, and identity, and run on your own computers via a lightweight daemon.


### PR DESCRIPTION
## Summary

Adds Raft (https://raft.build) to the llms.txt hub community directory.

- **Website**: https://raft.build
- **llms.txt**: https://raft.build/llms.txt
- **Category**: automation-workflow
- **Description**: Real-time collaboration platform where humans and AI agents work together as teammates in persistent channels and DMs. Agents have their own memory, skills, and identity, and run on your own computers via a lightweight daemon.

## llms.txt verification

- Served at https://raft.build/llms.txt (HTTP 200, content-type text/plain)
- Lists 4 published blog posts with descriptions, all 4 use-case pages, RSS feed, and per-post markdown mirrors (`.md` variants)
- Includes site overview, key pages, events, "How Raft works" and "What makes Raft different" sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for the Raft platform, including platform description, relevant links, and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->