### PR TITLE
feat(community): add 8HAUS Arquitetura to llms.txt hub

### DIFF
--- a/packages/content/data/websites/8haus-arquitetura-llms-txt.mdx
+++ b/packages/content/data/websites/8haus-arquitetura-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: '8HAUS Arquitetura'
+description: 'Brazilian studio for high-end contemporary residential architecture, interiors and landscape design, serving clients worldwide.'
+website: 'https://8haus.arq.br/'
+llmsUrl: 'https://8haus.arq.br/llms.txt'
+llmsFullUrl: 'https://8haus.arq.br/llms-full.txt'
+category: 'agency-services'
+publishedAt: '2026-06-22'
+---
+
+# 8HAUS Arquitetura
+
+Brazilian studio for high-end contemporary residential architecture, interiors and landscape design, serving clients worldwide.


### PR DESCRIPTION
This PR adds 8HAUS Arquitetura to the llms.txt hub.

**Website:** https://8haus.arq.br/
**llms.txt:** https://8haus.arq.br/llms.txt
**llms-full.txt:** https://8haus.arq.br/llms-full.txt  
**Category:** agency-services

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added website information for 8HAUS Arquitetura, including studio description and metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->