### PR TITLE
Add GeoSuite

### DIFF
--- a/packages/content/data/websites/geosuite-llms-txt.mdx
+++ b/packages/content/data/websites/geosuite-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'GeoSuite'
+description: 'AI visibility platform that measures and improves how brands appear in answers from ChatGPT, Gemini, Claude and Perplexity, pairing recurring audits with an operational action layer.'
+website: 'https://trygeosuite.it'
+llmsUrl: 'https://trygeosuite.it/llms.txt'
+category: 'ai-ml'
+publishedAt: '2026-06-23'
+---
+
+# GeoSuite
+
+AI visibility platform that measures, manages and improves how brands appear in AI answers (ChatGPT, Gemini, Claude, Perplexity).


### PR DESCRIPTION
Adds GeoSuite (https://trygeosuite.it) — an AI visibility platform measuring how brands appear in ChatGPT/Gemini/Claude/Perplexity answers. llms.txt live at https://trygeosuite.it/llms.txt. Category: ai-ml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new GeoSuite website information page with metadata including name, description, URL, category, and publication details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->