### PR TITLE
feat: add Xquik to llms.txt hub

### DIFF
--- a/packages/content/data/websites/xquik-llms-txt.mdx
+++ b/packages/content/data/websites/xquik-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Xquik'
+description: 'X automation platform with REST API, webhooks, MCP, and public SDKs.'
+website: 'https://xquik.com'
+llmsUrl: 'https://xquik.com/llms.txt'
+llmsFullUrl: 'https://xquik.com/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-06-23'
+---
+
+# Xquik
+
+Xquik provides AI-ready documentation for its X automation dashboard, REST API, signed webhooks, MCP endpoint, and public SDKs.


### PR DESCRIPTION
## Summary

Add Xquik as a developer-tools entry with its live `llms.txt` and `llms-full.txt` resources.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run check:websites` reached the validator and failed only on existing duplicate entries for `llmstxt.studio` and `ibsaudio.com.br`; the new Xquik entry is not involved.
- Focused frontmatter and URL-shape checks passed for `packages/content/data/websites/xquik-llms-txt.mdx`.
- Confirmed `https://xquik.com`, `https://xquik.com/llms.txt`, and `https://xquik.com/llms-full.txt` return HTTP 200.
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the Xquik website, including information about its AI-ready resources for dashboard, REST API, webhooks, MCP endpoint, and SDKs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->