### PR TITLE
feat(community): add Flow.OS to llms.txt hub

### DIFF
--- a/packages/content/data/websites/flow-os-llms-txt.mdx
+++ b/packages/content/data/websites/flow-os-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Flow.OS'
+description: 'A growth and AI-visibility consultancy helping brands earn citations across AI answer engines and search, spanning analytics, AEO/GEO, paid and organic media.'
+website: 'https://flowos.digital'
+llmsUrl: 'https://flowos.digital/llms.txt'
+llmsFullUrl: 'https://flowos.digital/llms-full.txt'
+category: 'marketing-sales'
+publishedAt: '2026-06-26'
+---
+
+# Flow.OS
+
+A growth and AI-visibility consultancy helping brands earn citations across AI answer engines and search, spanning analytics, AEO/GEO, paid and organic media.


### PR DESCRIPTION
This PR adds Flow.OS to the llms.txt hub.

**Website:** https://flowos.digital
**llms.txt:** https://flowos.digital/llms.txt
**llms-full.txt:** https://flowos.digital/llms-full.txt  
**Category:** marketing-sales

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new public-facing page for Flow.OS with site metadata, canonical links, category details, and a published date.
  * Included a matching page header and description text for consistent presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->