### PR TITLE
feat(community): add Sports AI Hub

### DIFF
--- a/packages/content/data/websites/sports-ai-hub-llms-txt.mdx
+++ b/packages/content/data/websites/sports-ai-hub-llms-txt.mdx
@@ -1,0 +1,25 @@
+---
+name: 'Sports AI Hub'
+description: 'Open-source sports AI tools hub for builders working on sports analysis, prediction, training, scouting, media, operations, and fan-experience products.'
+website: 'https://sports-ai-hub.pages.dev/'
+llmsUrl: 'https://sports-ai-hub.pages.dev/llms.txt'
+category: 'ai-ml'
+publishedAt: '2026-06-27'
+---
+
+# Sports AI Hub
+
+Sports AI Hub is the web app for the awesome-sports-ai ecosystem, curating AI tools, datasets, APIs, prototypes, and builder paths for sports services.
+
+## Key Focus Areas
+
+- Sports analysis and prediction tools
+- Athlete training workflows
+- Match intelligence and scouting
+- Sports media generation
+- Team operations and fan experiences
+- 2026 FIFA World Cup Match Center
+
+## About llms.txt Implementation
+
+Sports AI Hub publishes an AI-readable `llms.txt` manifest with links to the live app, Match Center, GitHub repository, source directory, World Cup coverage plan, assistant toolkit, and source-backed World Cup data.


### PR DESCRIPTION
## Summary

Adds Sports AI Hub to the llms.txt Hub directory.

**Website:** https://sports-ai-hub.pages.dev/
**llms.txt:** https://sports-ai-hub.pages.dev/llms.txt
**Category:** ai-ml

## Verification

- Confirmed the entry passes targeted frontmatter validation.
- Ran `scripts/validate-websites.ts`; the Sports AI Hub entry passes URL/category checks. The command still reports two pre-existing duplicate URL errors on current main: `https://llmstxt.studio/llms.txt` and `https://www.ibsaudio.com.br/llms.txt`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Sports AI Hub content page with site details and launch metadata.
  * Introduced an AI-readable manifest overview that links to the live app, Match Center, GitHub, source materials, and World Cup-related resources.
  * Expanded the page content to highlight the platform’s main areas, including analysis, training, scouting, media generation, fan experience, and 2026 World Cup coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->