### PR TITLE
feat(community): add DictoGo to llms.txt hub

### DIFF
--- a/packages/content/data/websites/dictogo-llms-txt.mdx
+++ b/packages/content/data/websites/dictogo-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'DictoGo'
+description: 'A powerful tool designed specifically for English learners, combining a comprehensive dictionary with efficient methods to quickly improve your skills.'
+website: 'https://dictogo.app'
+llmsUrl: 'https://dictogo.app/llms.txt'
+llmsFullUrl: 'https://dictogo.app/llms-full.txt'
+category: 'content-media'
+publishedAt: '2026-06-28'
+---
+
+# DictoGo
+
+A powerful tool designed specifically for English learners, combining a comprehensive dictionary with efficient methods to quickly improve your skills.


### PR DESCRIPTION
This PR adds DictoGo to the llms.txt hub.

**Website:** https://dictogo.app
**llms.txt:** https://dictogo.app/llms.txt
**llms-full.txt:** https://dictogo.app/llms-full.txt  
**Category:** content-media

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new content entry for DictoGo, including its title, description, category, publish date, and links.
  * Included a matching page section with a headline and summary text for display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->