### PR TITLE
feat(community): add VibeKit.bot to llms.txt hub

### DIFF
--- a/packages/content/data/websites/vibekit-bot-llms-txt.mdx
+++ b/packages/content/data/websites/vibekit-bot-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'VibeKit.bot'
+description: 'VibeKit gives every app its own persistent AI coding agent that builds, hosts, and keeps improving the app over time — database and a live domain included — driven from your phone, Telegram, or CLI.'
+website: 'https://vibekit.bot'
+llmsUrl: 'https://vibekit.bot/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-06-28'
+---
+
+# VibeKit.bot
+
+VibeKit gives every app its own persistent AI coding agent that builds, hosts, and keeps improving the app over time — database and a live domain included — driven from your phone, Telegram, or CLI. BYOK for Claude/OpenAI or pay-as-you-go.


### PR DESCRIPTION
Adds **VibeKit.bot** to the directory.

- **Website:** https://vibekit.bot
- **llms.txt:** https://vibekit.bot/llms.txt (also served at `/.well-known/llms.txt`) — both return `200`
- **Category:** developer-tools

VibeKit gives every app its own persistent AI coding agent that builds, hosts, and keeps improving the app over time (database + live domain included), driven from phone, Telegram, or CLI. Listed as "VibeKit.bot" to disambiguate from the unrelated `vibekit` npm SDK.

Entry file follows the existing `packages/content/data/websites/*-llms-txt.mdx` format.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new website entry for VibeKit.bot with published metadata and a public-facing description page.
  * Included links to the site and its AI-readable content location for easier discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->