### PR TITLE
Add Stasht llms.txt entry

### DIFF
--- a/packages/content/data/websites/stasht-llms-txt.mdx
+++ b/packages/content/data/websites/stasht-llms-txt.mdx
@@ -1,0 +1,17 @@
+---
+name: 'Stasht'
+description: 'AI-powered app for saving social media and web content into searchable maps, calendars, reminders, and collections.'
+website: 'https://stasht.app'
+llmsUrl: 'https://stasht.app/llms.txt'
+llmsFullUrl: 'https://stasht.app/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-06-28'
+---
+
+# Stasht
+
+Stasht is a free app for saving social media and web content from Instagram, TikTok, YouTube, X, Safari, Chrome, and more. It uses AI enrichment to pull out places, dates, categories, visible text, and other details, then organizes saves into searchable maps, calendars, reminders, and collections.
+
+## About llms.txt Implementation
+
+Stasht provides an `llms.txt` file with AI-readable product context, core pages, use cases, app links, and support resources. A full `llms-full.txt` resource is also available for deeper context.


### PR DESCRIPTION
## Summary\n- Add Stasht as an llms.txt implementation\n- Include both https://stasht.app/llms.txt and https://stasht.app/llms-full.txt\n- Categorize under AI & Machine Learning due to Stasht's AI-powered enrichment of saved social and web content\n\n## Validation\n- Verified Stasht is not already present in existing website data\n- Ran targeted frontmatter and URL shape validation for the new Stasht MDX entry\n- Ran `tsx scripts/validate-websites.ts --warn-descriptions`; the new Stasht entry was not flagged, but the repo currently has pre-existing duplicate URL errors unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new content page for the Stasht website.
  * Included key website details such as name, description, links, category, and publication date.
  * Added introductory information about Stasht and its `llms.txt` / `llms-full.txt` resources, including an implementation overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->