### PR TITLE
feat(community): add GEO知识库 to llms.txt hub

### DIFF
--- a/packages/content/data/websites/geo-llms-txt.mdx
+++ b/packages/content/data/websites/geo-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'GEO知识库'
+description: '使用GEO生成式引擎相关优化方法记录对 AI 搜索引擎行为的追踪、实测与思考，并记录我们做了什么和收集整理了什么.'
+website: 'https://geoz.com.cn'
+llmsUrl: 'https://geoz.com.cn/llms.txt'
+llmsFullUrl: 'https://geoz.com.cn/llms-full.txt'
+category: 'data-analytics'
+publishedAt: '2026-06-29'
+---
+
+# GEO知识库
+
+使用GEO生成式引擎相关优化方法记录对 AI 搜索引擎行为的追踪、实测与思考，并记录我们做了什么和收集整理了什么.


### PR DESCRIPTION
This PR adds GEO知识库 to the llms.txt hub.

**Website:** https://geoz.com.cn
**llms.txt:** https://geoz.com.cn/llms.txt
**llms-full.txt:** https://geoz.com.cn/llms-full.txt  
**Category:** data-analytics

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new content page for “GEO知识库” with metadata and a short Chinese description.
  * Published information now includes the site name, links, category, and date for easier browsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->