### PR TITLE
Add SpryTools to llms.txt hub

### DIFF
--- a/packages/content/data/websites/sprytools-llms-txt.mdx
+++ b/packages/content/data/websites/sprytools-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'SpryTools'
+description: 'Free privacy-friendly browser utilities plus a self-serve REST API hub of 30+ developer tools, also available as an MCP server.'
+website: 'https://sprytools.com'
+llmsUrl: 'https://sprytools.com/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-06-29'
+---
+
+# SpryTools
+
+Free, privacy-friendly browser utilities (no signup, no upload) plus a self-serve REST API of 30+ developer/utility endpoints for developers and AI agents, also exposed as an MCP server.


### PR DESCRIPTION
Adds **SpryTools** to the llms.txt hub.

SpryTools offers free, privacy-friendly browser utilities (no signup, no upload) plus a self-serve REST API of 30+ developer/utility endpoints, also exposed as an MCP server.

- Website: https://sprytools.com
- llms.txt: https://sprytools.com/llms.txt
- Category: `developer-tools`

New file `packages/content/data/websites/sprytools-llms-txt.mdx` following the `<slug>-llms-txt.mdx` naming scheme; `data/websites.json` left untouched (auto-generated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new SpryTools page with site details and a short overview.
  * Included a link for the AI-friendly content page and key metadata such as category and publish date.
  * Highlighted SpryTools’ privacy-friendly browser utilities along with REST API and MCP availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->