### PR TITLE
Add RankAgent to the llms.txt hub

### DIFF
--- a/packages/content/data/websites/rankagent-llms-txt.mdx
+++ b/packages/content/data/websites/rankagent-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'RankAgent'
+description: 'An AI-powered SEO and GEO (Generative Engine Optimization) tool that audits a whole site across technical, on-page, content, Core Web Vitals and AI visibility, then writes the exact plain-English fix for every issue.'
+website: 'https://www.therankagent.com'
+llmsUrl: 'https://www.therankagent.com/llms.txt'
+category: 'marketing-sales'
+priority: 'medium'
+publishedAt: '2026-07-02'
+---
+
+# RankAgent
+
+> RankAgent is an AI-powered SEO and GEO (Generative Engine Optimization) tool. It runs the full audit a human SEO agency would — technical health, on-page setup, structured data, content, Core Web Vitals and AI/GEO visibility — then gives the exact, plain-English fix for every issue and helps apply it with AI. It serves small SEO agencies and freelancers (white-label client reports, portfolio, prospect audits) as well as small business owners fixing their own site.
+
+## Key Focus Areas
+
+- Free SEO Scorecard and per-domain audit report cards
+- Free AI and SEO tools (AI visibility checker, llms.txt generator, schema generator, AI crawler status, share-of-voice, citation finder, entity gap analyzer)
+- SEO guides by industry and by platform
+- White-label client reports and agency workflows
+
+## About llms.txt Implementation
+
+RankAgent publishes an `llms.txt` file that lists its free tools, guides, and product pages so AI assistants can understand and reference the site.


### PR DESCRIPTION
RankAgent (therankagent.com) is an AI-powered SEO + GEO tool that audits a whole site and writes the plain-English fix for every issue. It publishes an llms.txt at https://www.therankagent.com/llms.txt.

## Summary

This PR only adds one file:
`packages/content/data/websites/rankagent-llms-txt.mdx` (category `marketing-sales`). 

Relevant to this project: 
RankAgent also ships a free **llms.txt generator & validator** (https://www.therankagent.com/tools/llms-txt-generator) that helps site owners create and check the exact file this hub catalogs.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new website listing for RankAgent with key details like description, category, priority, and publish date.
  * Included a short overview of RankAgent’s AI-powered SEO/GEO offerings, free tools, guides, and agency workflows.
  * Added a reference to its `llms.txt` resource for easier discovery of available content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->