### PR TITLE
fix(content): correct listing name to SRS Networks

### DIFF
--- a/packages/content/data/websites/nationwide-infrastructure-llms-txt.mdx
+++ b/packages/content/data/websites/nationwide-infrastructure-llms-txt.mdx
@@ -1,5 +1,5 @@
 ---
-name: 'Nationwide Infrastructure'
+name: 'SRS Networks'
 description: 'Nationwide structured cabling and IT infrastructure deployment across 48 US states since 1996. White-label channel partner for MSPs, VARs, and integrators.'
 website: 'https://srsnetworks.com'
 llmsUrl: 'https://srsnetworks.com/llms.txt'
@@ -8,6 +8,6 @@ category: 'business-operations'
 publishedAt: '2026-05-10'
 ---
 
-# Nationwide Infrastructure
+# SRS Networks
 
 Nationwide structured cabling and IT infrastructure deployment across 48 US states since 1996. White-label channel partner for MSPs, VARs, and integrators.


### PR DESCRIPTION
The listing added in #1001 was titled "Nationwide Infrastructure" — that is the company tagline, not the company name. The company is **SRS Networks** (srsnetworks.com), and the current title makes the listing undiscoverable via site search for "SRS".

This PR corrects only the `name` frontmatter field and the H1 to match. Website, llms.txt/llms-full.txt URLs, description, and category are unchanged and verified working. Filename/slug left as-is to avoid breaking the existing listing URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the website listing to reflect the new **SRS Networks** branding.
  * The visible page title and associated entry name now match the updated brand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->