### PR TITLE
feat(community): add turva.dev to llms.txt hub

### DIFF
--- a/packages/content/data/websites/turva-dev-llms-txt.mdx
+++ b/packages/content/data/websites/turva-dev-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'turva.dev'
+description: 'Agent-readiness audits and advisory. Signed llms.txt, a public read-only MCP server and an open-source Cloudflare Worker reference build.'
+website: 'https://turva.dev'
+llmsUrl: 'https://turva.dev/llms.txt'
+llmsFullUrl: 'https://turva.dev/llms-full.txt'
+category: 'agency-services'
+publishedAt: '2026-07-03'
+---
+
+# turva.dev
+
+Agent-readiness audits and advisory. Signed llms.txt, a public read-only MCP server and an open-source Cloudflare Worker reference build.


### PR DESCRIPTION
This PR adds turva.dev to the llms.txt hub.

**Website:** https://turva.dev
**llms.txt:** https://turva.dev/llms.txt
**llms-full.txt:** https://turva.dev/llms-full.txt  
**Category:** agency-services

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new page entry for turva.dev with complete metadata and visible page content.
  * Included a title and description text to support display and indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->