### PR TITLE
Add AnswerLens llms.txt entry

### DIFF
--- a/packages/content/data/websites/answerlens-llms-txt.mdx
+++ b/packages/content/data/websites/answerlens-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'AnswerLens'
+description: 'AnswerLens audits the public evidence layer of B2B SaaS websites across pricing, docs, proof, comparison pages, buyer questions, freshness, and llms.txt.'
+website: 'https://app.sfdj.net/'
+llmsUrl: 'https://app.sfdj.net/llms.txt'
+category: 'developer-tools'
+priority: 'medium'
+publishedAt: '2026-07-04'
+---
+
+# AnswerLens
+
+AnswerLens audits the public evidence layer of B2B SaaS websites and turns visible gaps into source-backed validation, monitoring, recovery, or implementation reports.
+
+## Key Focus Areas
+
+- B2B SaaS public evidence audits
+- AI search, AEO, and GEO readiness
+- Pricing, docs, proof, comparison pages, and buyer-question coverage
+- Sitemap, schema, canonicals, freshness, and llms.txt checks
+
+## About llms.txt Implementation
+
+AnswerLens provides an `llms.txt` file with AI-readable information about its public pages, use cases, commercial terms, and access boundaries.


### PR DESCRIPTION
## Summary

Adds AnswerLens to the llms.txt hub website data.

AnswerLens audits the public evidence layer of B2B SaaS websites and exposes an AI-readable `llms.txt` file at `https://app.sfdj.net/llms.txt`.

## Verification

- `curl -I https://app.sfdj.net/llms.txt` returns `200`
- `pnpm check:websites` parsed `2502` website entries, including this new MDX file, but the command exits non-zero because of two pre-existing duplicate `llmsUrl` entries unrelated to this PR:
  - `https://llmstxt.studio/llms.txt`: `help-ai-find-you-llms-txt.mdx`, `llmstxt-studio-llms-txt.mdx`
  - `https://www.ibsaudio.com.br/llms.txt`: `ibs-audio-llms-txt.mdx`, `ibs-audio-premium-llms-txt.mdx`

No generated `data/websites.json` file was edited.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new page for AnswerLens with basic listing details and a short product description.
  * Included information about its AI-search readiness and `llms.txt` coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->