### PR TITLE
feat(websites): add Smart Shope

### DIFF
--- a/packages/content/data/websites/smartshope-llms-txt.mdx
+++ b/packages/content/data/websites/smartshope-llms-txt.mdx
@@ -1,0 +1,40 @@
+---
+name: 'Smart Shope'
+description: 'Brazilian online store for audio, video and lighting: speakers, amplifiers, cables, power supplies, lighting and electronic components. Nationwide shipping, PIX/boleto/card checkout.'
+website: 'https://www.smartshope.com.br'
+llmsUrl: 'https://www.smartshope.com.br/llms.txt'
+llmsFullUrl: 'https://www.smartshope.com.br/llms-full.txt'
+category: 'ecommerce-retail'
+publishedAt: '2026-07-04'
+priority: 'medium'
+featured: false
+---
+
+# Smart Shope
+
+Smart Shope is a Brazilian e-commerce store specializing in audio, video and
+lighting products. It sells acoustic speakers, amplifiers, HDMI and optical
+audio cables, power supplies, electronic components and lighting fixtures, with
+nationwide shipping across Brazil and checkout via PIX, boleto and credit card
+(with installments).
+
+## Product Lines
+
+- **Acoustic Speakers:** ceiling/surface speakers, coaxial in-wall speakers, full-range cubes and 70V line systems.
+- **Cables:** HDMI (up to 8K), Toslink optical audio, P2/RCA adapters.
+- **Lighting:** directional spot rails and universal mounting brackets.
+- **Components:** digital amplifier ICs (TPA3118), 70V line transformers, connectors.
+- **Power Supplies:** 12V and 24V switching power supplies for general use.
+
+## llms.txt Implementation
+
+Both `/llms.txt` (concise product index grouped by category with prices and short
+descriptions) and `/llms-full.txt` (full catalog with complete descriptions,
+per-variant pricing and institutional pages) are generated from a single source
+of truth at build time and served as `text/plain`.
+
+## About
+
+- Location: São Paulo, Brazil
+- Industry: Consumer electronics e-commerce (audio, video, lighting)
+- Shipping: Nationwide (Brazil)


### PR DESCRIPTION
## Adding Smart Shope

Brazilian online store for **audio, video and lighting** products — speakers, amplifiers, HDMI/optical cables, power supplies, lighting fixtures and electronic components. Nationwide shipping across Brazil.

- **Website:** https://www.smartshope.com.br
- **llms.txt:** https://www.smartshope.com.br/llms.txt
- **llms-full.txt:** https://www.smartshope.com.br/llms-full.txt
- **Category:** `ecommerce-retail`

### Verification
- [x] `/llms.txt` returns HTTP 200 as `text/plain` (concise product index + institutional links)
- [x] `/llms-full.txt` returns HTTP 200 as `text/plain` (full catalog with descriptions and per-variant pricing)
- [x] Follows the standard (`# Title` + `> summary` blockquote + `## Section` links)
- [x] Single `.mdx` added under `packages/content/data/websites/`, no edits to auto-generated files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Smart Shope store page with store details, product highlights, and AI-focused content.
  * Included information about the site’s `llms.txt` and `llms-full.txt` files, helping surface available content for AI tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->