### PR TITLE
Add Subscline (サブスクライン) — AI-driven LINE marketing CRM

### DIFF
--- a/packages/content/data/websites/subscline-llms-txt.mdx
+++ b/packages/content/data/websites/subscline-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Subscline (サブスクライン)'
+description: 'AI-driven LINE marketing CRM for restaurants, salons, clinics, gyms and retail stores in Japan. Subscription billing, LINE messaging, reservations, mobile ordering, point membership cards and AI-generated store pages in one platform.'
+website: 'https://subscline.com'
+llmsUrl: 'https://subscline.com/llms.txt'
+llmsFullUrl: 'https://subscline.com/llms-full.txt'
+category: 'marketing-sales'
+publishedAt: '2026-07-05'
+---
+
+# Subscline (サブスクライン)
+
+AI-driven LINE marketing CRM for restaurants, salons, clinics, gyms and retail stores in Japan. Subscription billing, LINE messaging, reservations, mobile ordering, point membership cards and AI-generated store pages in one platform. The admin manual is also available as an AI-ready bundle at https://app.subscline.jp/manual/llms-full.txt.


### PR DESCRIPTION
## Website submission

- **Name**: Subscline (サブスクライン)
- **Website**: https://subscline.com
- **llms.txt**: https://subscline.com/llms.txt
- **llms-full.txt**: https://subscline.com/llms-full.txt
- **Category**: marketing-sales

AI-driven LINE marketing CRM for restaurants, salons, clinics, gyms and retail stores in Japan. Subscription billing, LINE messaging, reservations, mobile ordering, point membership cards and AI-generated store pages in one platform.

The product admin manual is also published as an AI-ready bundle: https://app.subscline.jp/manual/llms-full.txt (index: https://app.subscline.jp/llms.txt).

Both llms.txt URLs are live and follow the llmstxt.org format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new website entry for Subscline, including metadata, document links, category, and publication date.
  * Included a short page heading and description for the Subscline product, with a link to the admin manual bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->