### PR TITLE
feat(community): add TmpState llms.txt

### DIFF
--- a/packages/content/data/websites/tmpstate-llms-txt.mdx
+++ b/packages/content/data/websites/tmpstate-llms-txt.mdx
@@ -1,0 +1,30 @@
+---
+name: 'TmpState'
+description: 'Tokenless temporary JSON database for AI agents and prototypes.'
+website: 'https://tmpstate.dev'
+llmsUrl: 'https://tmpstate.dev/llms.txt'
+llmsFullUrl: ''
+category: 'infrastructure-cloud'
+publishedAt: '2026-07-04'
+priority: 'low'
+---
+
+# TmpState
+
+TmpState is a tokenless temporary JSON document store for AI agents and
+prototypes. One curl creates a disposable database, and the returned URL is the
+only credential.
+
+## Key Focus Areas
+
+- Temporary JSON storage
+- Agent prototyping
+- No-signup APIs
+- Capability URLs
+- OpenAPI documentation
+
+## About llms.txt Implementation
+
+TmpState's llms.txt documentation gives agents the API contract, data modeling
+guidance, quota details, security model, and lifecycle rules for using TmpState
+as invisible prototype infrastructure.


### PR DESCRIPTION
Adds TmpState's public llms.txt implementation to the hub.

Disclosure: I built TmpState.

Why it fits:
- TmpState serves https://tmpstate.dev/llms.txt.
- The entry follows the repository's MDX content format.
- Category is set to infrastructure-cloud because TmpState is temporary JSON database infrastructure for agents and prototypes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new documentation page for TmpState with site details, overview content, and links to its AI-readable documentation.
  * Expanded the public-facing description of the service, including its key focus areas and lifecycle guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->