### PR TITLE
feat(community): add Citeable to llms.txt hub

### DIFF
--- a/packages/content/data/websites/citeable-llms-txt.mdx
+++ b/packages/content/data/websites/citeable-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Citeable'
+description: 'Citeable is a GEO tool: paste your URL to generate the llms.txt + Q&A schema markup that make ChatGPT, Perplexity, Gemini & Claude cite your site.'
+website: 'https://citeable.eu'
+llmsUrl: 'https://citeable.eu/llms.txt'
+llmsFullUrl: 'https://citeable.eu/llms-full.txt'
+category: 'agency-services'
+publishedAt: '2026-07-06'
+---
+
+# Citeable
+
+Citeable is a GEO tool: paste your URL to generate the llms.txt + Q&A schema markup that make ChatGPT, Perplexity, Gemini & Claude cite your site.


### PR DESCRIPTION
This PR adds Citeable to the llms.txt hub.

**Website:** https://citeable.eu
**llms.txt:** https://citeable.eu/llms.txt
**llms-full.txt:** https://citeable.eu/llms-full.txt  
**Category:** agency-services

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new content page for Citeable with website details, AI-facing links, and publishing metadata.
  - Included a short description highlighting Citeable as a tool for generating `llms.txt` and Q&A schema markup for multiple AI assistants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->