### PR TITLE
feat: add GetValetParking

### DIFF
--- a/packages/content/data/websites/getvaletparking-llms-txt.mdx
+++ b/packages/content/data/websites/getvaletparking-llms-txt.mdx
@@ -1,0 +1,8 @@
+---
+name: 'GetValetParking'
+description: 'National directory of US valet parking operators covering weddings, corporate events, restaurants, hotels, hospitals, and major venues.'
+website: 'https://getvaletparking.com'
+llmsUrl: 'https://getvaletparking.com/llms.txt'
+category: 'agency-services'
+publishedAt: '2026-07-06'
+---


### PR DESCRIPTION
Adds GetValetParking.com — a national directory of US valet parking operators (weddings, corporate events, restaurants, hotels, hospitals, major venues).

- Website: https://getvaletparking.com
- llms.txt: https://getvaletparking.com/llms.txt (live, llmstxt.org format)
- Category: agency-services

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new website entry for GetValetParking with display name, description, website link, `llms.txt` link, category, and publish date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->