### PR TITLE
Add Vaaya

### DIFF
--- a/packages/content/data/websites/vaaya-llms-txt.mdx
+++ b/packages/content/data/websites/vaaya-llms-txt.mdx
@@ -1,0 +1,21 @@
+---
+name: 'Vaaya'
+description: 'The agent payment system: one MCP server that lets any agent call paid APIs — image/video gen, product demos, web search & scraping, deep/market research, lead enrichment, GTM, sandboxes, browser automation, email — pay-per-call, no API keys.'
+website: 'https://vaaya.ai'
+llmsUrl: 'https://vaaya.ai/llms.txt'
+llmsFullUrl: 'https://vaaya.ai/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-07-07'
+---
+
+# Vaaya
+
+Vaaya turns any MCP client (Claude Code, Cursor, Codex, Cline, …) into an agent that can buy what it needs. Instead of wiring a dozen vendor API keys, the agent asks Vaaya's `consult` tool for anything it can't do and runs the returned call with `use` — billed pay-per-call on success (x402 USDC on Base, Stripe MPP, or Tempo; the payment is the auth).
+
+## Key Focus Areas
+
+- Media & video generation, product demo videos
+- Web search & scraping, deep / market / competitive research
+- GTM & sales lead enrichment and outreach
+- Code sandboxes, browser automation, email, memory
+- Pay-per-call, no API keys (agents can self-serve signup)


### PR DESCRIPTION
Adds Vaaya to the llms.txt directory. Vaaya publishes an agent-readable llms.txt (https://vaaya.ai/llms.txt) and a full tool reference (https://vaaya.ai/llms-full.txt). It is the agent payment system — one MCP server that lets any AI agent call paid APIs pay-per-call with no API keys (media/video generation, research, web scraping, compute, browser automation, email). Added a new file under packages/content/data/websites/ per CONTRIBUTING.md; did not touch the auto-generated websites.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new website listing for Vaaya with an overview of its AI agent payment offering, website links, category, and publish date.
  * Included a short description of its main capabilities, such as media generation, web research, lead enrichment, browser automation, and self-serve access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->