### PR TITLE
feat(community): add Tree Ring Memory

### DIFF
--- a/packages/content/data/websites/tree-ring-memory-llms-txt.mdx
+++ b/packages/content/data/websites/tree-ring-memory-llms-txt.mdx
@@ -1,0 +1,27 @@
+---
+name: 'Tree Ring Memory'
+description: 'Framework-agnostic local-first memory lifecycle layer for AI agents.'
+website: 'https://terminallylazy.github.io/Tree-Ring-Memory/'
+llmsUrl: 'https://terminallylazy.github.io/Tree-Ring-Memory/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-07-07'
+---
+
+# Tree Ring Memory
+
+Tree Ring Memory is a framework-agnostic, local-first memory lifecycle layer for
+AI agents.
+
+## Key Focus Areas
+
+- Agent memory lifecycle management
+- Local-first SQLite/FTS recall
+- Audit, forgetting, redaction, and consolidation
+- Developer tooling for coding-agent workflows
+
+## About llms.txt Implementation
+
+Tree Ring Memory provides an llms.txt summary for agents and AI-powered
+developer tools that need a compact overview of the project, install path,
+public launch links, and memory lifecycle capabilities.


### PR DESCRIPTION
## Summary
- add Tree Ring Memory as a `developer-tools` llms.txt implementation
- point to the public project landing page and public `llms.txt` file
- keep generated `data/websites.json` out of this PR; the repo automation owns generated website data

## Checks
- Targeted frontmatter validation passed for `tree-ring-memory-llms-txt.mdx`
- `https://terminallylazy.github.io/Tree-Ring-Memory/` returned HTTP 200
- `https://terminallylazy.github.io/Tree-Ring-Memory/llms.txt` returned HTTP 200
- `git diff --check` passed

Note: `pnpm check:websites` currently fails on existing upstream entries unrelated to this addition: `llmstxt-generator.mdx`, `pilot-protocol.mdx`, and duplicate llmsUrl pairs for mycoastalwindows.com, llmstxt.studio, and ibsaudio.com.br. This PR adds only `packages/content/data/websites/tree-ring-memory-llms-txt.mdx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new documentation page for “Tree Ring Memory” with project details, links, category, and publication date.
  * Included an overview of the project, its key focus areas, and a description of its llms.txt setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->