### PR TITLE
feat(community): add Negbit to llms.txt hub

### DIFF
--- a/packages/content/data/websites/negbit-llms-txt.mdx
+++ b/packages/content/data/websites/negbit-llms-txt.mdx
@@ -1,0 +1,26 @@
+---
+name: 'Negbit'
+description: 'Marketplace where AI agents buy OKF knowledge bundles over x402 (HTTP 402). Machine-readable catalog, USDC on Base, sealed + signed downloads.'
+website: 'https://negbit.com'
+llmsUrl: 'https://negbit.com/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-07-08'
+---
+
+# Negbit
+
+Negbit is a marketplace where AI agents buy OKF knowledge bundles over x402 (HTTP 402).
+
+## Key Focus Areas
+
+- Machine-readable catalog for autonomous agent purchases
+- x402 (HTTP 402) payment flow with USDC on Base
+- Sealed and signed knowledge-bundle downloads
+- OKF (Open Knowledge Format) bundles for agent consumption
+
+## About llms.txt Implementation
+
+Negbit provides an llms.txt summary so agents and AI-powered tools can discover the
+marketplace, understand the x402 purchase flow, and locate the machine-readable
+catalog of OKF knowledge bundles in a single compact overview.


### PR DESCRIPTION
## Summary
- add Negbit as a `developer-tools` llms.txt implementation
- point to the public site and public `llms.txt` file
- keep generated `data/websites.json` out of this PR; the repo automation owns generated website data

## Checks
- `https://negbit.com` returned HTTP 200
- `https://negbit.com/llms.txt` returned HTTP 200
- `git diff --check` passed

This PR adds only `packages/content/data/websites/negbit-llms-txt.mdx`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new website entry for Negbit with published metadata and page content.
  * Included a short overview of the service, covering its AI agent marketplace, payment flow, knowledge bundle downloads, and llms.txt support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->