### PR TITLE
feat(community): add Australian Tenders to llms.txt hub

### DIFF
--- a/packages/content/data/websites/australian-tenders-llms-txt.mdx
+++ b/packages/content/data/websites/australian-tenders-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Australian Tenders'
+description: 'Tender discovery platform for Australian and New Zealand opportunities, with tender search, alerts, categories, regions, pricing and tendering resources.'
+website: 'https://www.australiantenders.com.au/'
+llmsUrl: 'https://www.australiantenders.com.au/llms.txt'
+llmsFullUrl: ''
+category: 'business-operations'
+publishedAt: '2026-07-09'
+---
+
+# Australian Tenders
+
+Tender discovery platform for Australian and New Zealand opportunities, with tender search, alerts, categories, regions, pricing and tendering resources.


### PR DESCRIPTION
This PR adds Australian Tenders to the llms.txt hub.

**Website:** https://www.australiantenders.com.au/
**llms.txt:** https://www.australiantenders.com.au/llms.txt

**Category:** business-operations

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new page for the Australian Tenders website with a title, summary, and publishing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->