### PR TITLE
feat: add Bike4Mind

### DIFF
--- a/packages/content/data/websites/bike4mind-llms-txt.mdx
+++ b/packages/content/data/websites/bike4mind-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Bike4Mind'
+description: 'Open-core AI workbench — 60+ models behind one interface, autonomous agents, RAG, voice, and in-browser code; run hosted or deploy in your own AWS.'
+website: 'https://bike4mind.com'
+llmsUrl: 'https://bike4mind.com/llms.txt'
+llmsFullUrl: 'https://bike4mind.com/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-07-09'
+---
+
+# Bike4Mind
+
+Open-core AI workbench — 60+ models behind one interface, autonomous agents, RAG, voice, and in-browser code; run hosted or deploy the full source in your own AWS.


### PR DESCRIPTION
Adds **Bike4Mind** (bike4mind.com) — open-core AI workbench — via a new `.mdx` under `packages/content/data/websites/` per CONTRIBUTING Option 2 (did not touch the auto-generated `data/websites.json`).

Both files are live and were verified before this PR:
- https://bike4mind.com/llms.txt (agent-facing preamble + structured site map)
- https://bike4mind.com/llms-full.txt (~547 KB full corpus)

Related agent surfaces, in case useful for review: `/.well-known/ai-capabilities.json`, public MCP server at `bike4mind.com/api/mcp`.

Disclosure: PR prepared by an AI agent (Claude Code) on behalf of the Bike4Mind team.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Bike4Mind page with metadata and publish information.
  * Included a title and short description to make the page more informative and easier to browse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->