### PR TITLE
feat(community): add Block Lottos to llms.txt hub

### DIFF
--- a/packages/content/data/websites/block-lottos-llms-txt.mdx
+++ b/packages/content/data/websites/block-lottos-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Block Lottos'
+description: 'On-chain lottery games on Polygon and Base with wallet-signed tickets, public draw data, OpenAPI docs, advertising routes, and AI-readable discovery files.'
+website: 'https://blocklottos.com/'
+llmsUrl: 'https://blocklottos.com/llms.txt'
+category: 'finance-fintech'
+priority: 'medium'
+publishedAt: '2026-07-10'
+---
+
+# Block Lottos
+
+Block Lottos is an on-chain lottery platform with public games on Polygon and Base. Players pick 6 numbers, review ticket transactions in their own wallet, and can inspect public draw, jackpot, history, advertising, and affiliate information.
+
+## Key Focus Areas
+
+- On-chain lottery games
+- Web3 wallet transaction preparation
+- Public jackpot and draw data
+- Advertising and affiliate discovery
+
+## About llms.txt Implementation
+
+Block Lottos provides an `llms.txt` file with AI-readable information about its games, public API docs, OpenAPI file, agent discovery routes, affiliate route, and advertising options.


### PR DESCRIPTION
This PR adds Block Lottos to the llms.txt hub.

Website: https://blocklottos.com/
llms.txt: https://blocklottos.com/llms.txt

Block Lottos is an on-chain lottery platform with public games on Polygon and Base, wallet-signed ticket transaction preparation, OpenAPI docs, public draw data, advertising routes, and AI-readable discovery files.