### PR TITLE
feat(community): add paas.build to llms.txt hub

### DIFF
--- a/packages/content/data/websites/paas-build-llms-txt.mdx
+++ b/packages/content/data/websites/paas-build-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'paas.build'
+description: 'Payments for AI-built apps — open a real merchant account through progressive KYB and accept payments on FCA-authorised rails (UK/EU/US), from a prompt via MCP or REST API.'
+website: 'https://paas.build'
+llmsUrl: 'https://paas.build/llms.txt'
+llmsFullUrl: 'https://paas.build/llms-full.txt'
+category: 'finance-fintech'
+publishedAt: '2026-07-10'
+---
+
+# paas.build
+
+paas.build lets AI coding agents (and the developers driving them) add real payments to an app in one session: identify the business, open a live merchant account through progressive KYB on UniPaaS (FCA-authorised, reference 929994), and create hosted checkouts. It ships an official MCP server (`@paasbuild/mcp` on npm, remote endpoints at `https://paas.build/mcp` and `https://paas.build/sse`) with three tools: `identify_business`, `go_live`, and `create_checkout`.
+
+## Key Focus Areas
+
+- Merchant onboarding — progressive KYB that returns a real, live merchant account, not a sandbox
+- Hosted checkout — create checkout sessions from a prompt or an API call
+- MCP-first integration — official npm server plus streamable HTTP and SSE remote endpoints
+- Regulated rails — payments processed on UniPaaS's FCA-authorised infrastructure (UK/EU/US)
+
+## About llms.txt Implementation
+
+paas.build publishes llms.txt and llms-full.txt so AI agents can discover the API surface, MCP tools, onboarding flow, and go-live requirements directly, without scraping the marketing site.


### PR DESCRIPTION
## What

Adds **paas.build** to the websites directory (Finance/Fintech).

- **Website:** https://paas.build
- **llms.txt:** https://paas.build/llms.txt (200 OK)
- **llms-full.txt:** https://paas.build/llms-full.txt (200 OK)
- **Category:** `finance-fintech`

## About

paas.build is a payments platform aimed at AI-built apps: an AI agent (or a developer) can open a real merchant account via progressive KYB on UniPaaS (FCA-authorised, ref 929994) and create hosted checkouts — via the official MCP server (`@paasbuild/mcp`, remote endpoints `https://paas.build/mcp` + `https://paas.build/sse`) or REST API.

Followed Option 2 (manual PR) from CONTRIBUTING.md: new `.mdx` under `packages/content/data/websites/` only, `data/websites.json` untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new `paas.build` documentation page.
  * Documented AI-agent payment onboarding, hosted checkout, MCP integration endpoints, and resources for agent discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->