### PR TITLE
feat(community): add localmodel.run to llms.txt hub

### DIFF
--- a/packages/content/data/websites/localmodel-run-llms-txt.mdx
+++ b/packages/content/data/websites/localmodel-run-llms-txt.mdx
@@ -1,0 +1,22 @@
+---
+name: 'localmodel.run'
+description: 'Free API and site that tells you whether a device can run a given local AI model, and how much memory it needs, across 153 models and 40 devices.'
+website: 'https://localmodel.run'
+llmsUrl: 'https://localmodel.run/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-10'
+---
+
+# localmodel.run
+
+localmodel.run is a free, no-auth reference for local AI model hardware fit. It covers 153 models (text, image, video, audio) across 40 devices, with every memory figure sourced against vendor specs, Ollama, and HuggingFace GGUF repos.
+
+## Key Focus Areas
+
+- Device fit checks - will a given model run on a given Mac, PC, or phone, and at what quantization
+- OpenAPI 3.1 spec at /api/openapi.json for programmatic access, CORS-open
+- Sourced data - every model and device entry cites its source, no estimated numbers
+
+## About llms.txt Implementation
+
+localmodel.run publishes llms.txt listing all 153 models with sizes and context lengths, so agents can answer "can I run X locally" without scraping the site.


### PR DESCRIPTION
Adds localmodel.run under developer-tools.

Free reference for local AI hardware fit: 153 models (text, image, video, audio) across 40 devices, every memory figure sourced. llms.txt at https://localmodel.run/llms.txt (llms-full.txt also available). New .mdx only, data/websites.json untouched per the contributing guide.

Disclosure: I am the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new reference page for localmodel.run.
  * Provides hardware compatibility guidance for running AI models locally.
  * Highlights device fit checks, OpenAPI 3.1 access, cited data sources, and llms.txt support.
  * Includes site metadata and publication details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->