### PR TITLE
Add @geosuite/llms-txt-generator to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ We organize projects into primary categories (🤖 **AI & ML**, 💻 **Developer
 | ⚡ **Raycast Extension**  | Search and explore llms.txt files directly in Raycast           | [Raycast Store](https://www.raycast.com/thedaviddias/llms-txt)                                                |
 | ⚡ **LLMs.txt Generator** | Generate llms.txt from sitemap, crawled pages and AI            | [LLMs.txt Generator](https://llmstxtgenerator.co/)                                                            |
 | 🛠 **llmstxt-cli**        | Install llms.txt docs as skills into 35+ AI coding agents       | [npm](https://www.npmjs.com/package/llmstxt-cli) · [README](packages/cli/README.md)                           |
+| 📄 **@geosuite/llms-txt-generator** | Zero-dependency CLI + GitHub Action: turn a site's `sitemap.xml` into an `llms.txt` (open source, MIT) | [GitHub](https://github.com/TryGeoSuite/llms-txt-generator) · [npm](https://www.npmjs.com/package/@geosuite/llms-txt-generator) |
 
 <!-- LLMS-LIST:START - Do not remove or modify this section -->
 ## LLM Tools and Resources


### PR DESCRIPTION
## Summary

Adds `@geosuite/llms-txt-generator` to the **Developer Tools** table — a zero-dependency CLI + GitHub Action that turns a site's `sitemap.xml` into an `llms.txt` (the llmstxt.org standard). Open source (MIT).

Single-line addition to the static Developer Tools table only — it does **not** touch `data/websites.json` or the auto-generated `LLMS-LIST` section.

- npm: https://www.npmjs.com/package/@geosuite/llms-txt-generator
- repo: https://github.com/TryGeoSuite/llms-txt-generator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the **`@geosuite/llms-txt-generator`** tool to the Developer Tools documentation, including its description and links to GitHub and npm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->