### PR TITLE
Add posthell (marketing-sales)

### DIFF
--- a/packages/content/data/websites/posthell-llms-txt.mdx
+++ b/packages/content/data/websites/posthell-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'posthell'
+description: 'Social media scheduler for busy founders and AI agents. Write once, tailor per network, publish to 15 networks; agents draft into a human-approval queue over a hosted MCP server.'
+website: 'https://www.posthell.com'
+llmsUrl: 'https://www.posthell.com/llms.txt'
+llmsFullUrl: 'https://www.posthell.com/llms-full.txt'
+category: 'marketing-sales'
+publishedAt: '2026-07-10'
+---
+
+# posthell
+
+Social media scheduler for busy founders and AI agents. Write once, tailor per network, publish to 15 networks; agents draft into a human-approval queue over a hosted MCP server.


### PR DESCRIPTION
Adds posthell (https://www.posthell.com), a social media scheduler for founders and AI agents.

- llms.txt: https://www.posthell.com/llms.txt
- llms-full.txt: https://www.posthell.com/llms-full.txt (full facts, MCP tool reference, per-client setup, 20 Q&As in one fetch)

Both are SSR'd from the same config as the site's pricing/FAQ so they cannot drift.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Posthell webpage entry with metadata, website links, and a concise description.
  * Included references to the available LLMS endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->