### PR TITLE
Add BankBridge

### DIFF
--- a/packages/content/data/websites/bankbridge-llms-txt.mdx
+++ b/packages/content/data/websites/bankbridge-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'BankBridge'
+description: 'Hosted MCP server that gives AI agents read-only access to your bank accounts, transactions, and investment holdings. Ask Claude, ChatGPT, Cursor, or Gemini about your real finances in plain English.'
+website: 'https://bankbridge.money'
+llmsUrl: 'https://bankbridge.money/llms.txt'
+llmsFullUrl: 'https://bankbridge.money/llms-full.txt'
+category: 'finance-fintech'
+publishedAt: '2026-07-10'
+---
+
+# BankBridge
+
+Hosted MCP server that gives AI agents read-only access to your bank accounts, transactions, and investment holdings. Ask Claude, ChatGPT, Cursor, or Gemini about your real finances in plain English.


### PR DESCRIPTION
## Summary

Adds **BankBridge** (`https://bankbridge.money`) to the directory under `finance-fintech`.

BankBridge is a hosted MCP (Model Context Protocol) server that gives AI agents read-only access to a user's bank accounts, transactions, and investment holdings. It ships hand-curated `llms.txt` and `llms-full.txt` at the site root — not sitemap dumps.

## Files touched

- `packages/content/data/websites/bankbridge-llms-txt.mdx` — new entry

I did **not** touch `data/websites.json` (per CONTRIBUTING.md — that file is auto-generated).

## Test plan

- [x] `llms.txt` returns 200 with valid `# BankBridge` markdown (`curl -sI https://bankbridge.money/llms.txt`)
- [x] `llms-full.txt` returns 200 (`curl -sI https://bankbridge.money/llms-full.txt`)
- [x] Frontmatter matches the format of neighbouring `finance-fintech` entries (e.g. `0xa1-llms-txt.mdx`)
- [x] Slug follows the `-llms-txt.mdx` convention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a complete BankBridge website entry with its description, URLs, category, and publication date.
  * Included links to the standard and full `llms.txt` resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->