### PR TITLE
Add Use AI For

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -11928,6 +11928,15 @@
     "publishedAt": "2026-05-31"
   },
   {
+    "name": "Use AI For",
+    "domain": "https://use-ai-for.com",
+    "description": "AI tools directory organized by profession — helps non-technical professionals find the right AI tools for their specific job role",
+    "llmsTxtUrl": "https://use-ai-for.com/llms.txt",
+    "category": "ai-ml",
+    "favicon": "https://www.google.com/s2/favicons?domain=use-ai-for.com&sz=128",
+    "publishedAt": "2026-07-12"
+  },
+  {
     "name": "useapi.net",
     "domain": "https://useapi.net",
     "description": "Experimental API for popular AI services by useapi.net.",


### PR DESCRIPTION
Adds [Use AI For](https://use-ai-for.com) to `data/websites.json`, inserted alphabetically between UpTime Web Hosting and useapi.net.

Use AI For publishes an `llms.txt` file at https://use-ai-for.com/llms.txt. It's an AI tools directory organized by profession (accountants, lawyers, plumbers, nurses, etc.), which makes it a good match for the hub.

Entry fields:
- **category**: `ai-ml`
- **publishedAt**: `2026-07-12`

Disclosure: I represent the site.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Use AI For” to the website directory, including its description, category, favicon, and AI-readable information link.
  * The new listing is dated July 12, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->