### PR TITLE
feat(community): add Cerulea to llms.txt hub

### DIFF
--- a/packages/content/data/websites/cerulea-llms-txt.mdx
+++ b/packages/content/data/websites/cerulea-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Cerulea'
+description: 'No-code blockchain platform. Deploy public or private blockchain networks with governance, validators, and APIs, without writing any code.'
+website: 'https://cerulea.io'
+llmsUrl: 'https://cerulea.io/llms.txt'
+llmsFullUrl: 'https://cerulea.io/llms-full.txt'
+category: 'infrastructure-cloud'
+publishedAt: '2026-07-12'
+---
+
+# Cerulea
+
+No-code blockchain platform. Deploy public or private blockchain networks with governance, validators, and APIs, without writing any code.


### PR DESCRIPTION
This PR adds Cerulea to the llms.txt hub.

**Website:** https://cerulea.io
**llms.txt:** https://cerulea.io/llms.txt
**llms-full.txt:** https://cerulea.io/llms-full.txt  
**Category:** infrastructure-cloud

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Cerulea website entry with descriptive metadata and links to its `llms.txt` and `llms-full.txt` resources.
  - Added a dedicated page heading and description for Cerulea.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->