### PR TITLE
Add Alibaba Cloud, Alibaba Cloud China, Qwen Cloud, Qwen Cloud China llms.txt entries

### DIFF
--- a/packages/content/data/websites/alibaba-cloud-cn-llms-txt.mdx
+++ b/packages/content/data/websites/alibaba-cloud-cn-llms-txt.mdx
@@ -1,0 +1,35 @@
+---
+name: 'Alibaba Cloud China'
+description: "China-region Alibaba Cloud documentation covering 300+ cloud products with Chinese-language guides, API references, and compliance docs."
+website: 'https://help.aliyun.com'
+llmsUrl: 'https://help.aliyun.com/zh/llms.txt'
+llmsFullUrl: ''
+category: 'infrastructure-cloud'
+publishedAt: '2026-07-13'
+---
+
+# Alibaba Cloud China (阿里云中国站)
+
+China-region documentation for Alibaba Cloud (阿里云) services. The China site covers 300+ products — more than the international site — including Apsara Stack (专有云) and China-specific compliance services.
+
+## Key Focus Areas
+
+- Elastic Compute (ECS, ECI)
+- Object Storage (OSS)
+- Databases (RDS, PolarDB, AnalyticDB, Lindorm, Tair/Redis)
+- Serverless (Function Compute, SAE)
+- AI & Large Models (PAI, Model Studio / 百炼, Qwen)
+- Container Service (ACK)
+- Apsara Stack (专有云, China-site exclusive)
+- Big Data (MaxCompute, DataWorks, Flink)
+
+## Key Differences from International Site
+
+- 300+ products vs 200+ on international site
+- Apsara Stack (专有云) category — not available internationally
+- China-region compliance and regulatory documentation (等保, 密评, ICP)
+- Bilingual support (Chinese primary, English available)
+
+## About llms.txt Implementation
+
+Per-product sub-indexes are available at `https://help.aliyun.com/zh/{product}/llms.txt`. The international English version is at `https://www.alibabacloud.com/help/en/llms.txt`.

--- a/packages/content/data/websites/alibaba-cloud-llms-txt.mdx
+++ b/packages/content/data/websites/alibaba-cloud-llms-txt.mdx
@@ -1,0 +1,37 @@
+---
+name: 'Alibaba Cloud'
+description: "Alibaba Cloud provides 200+ cloud services including compute, storage, database, AI, and serverless, with structured llms.txt indexes for each product."
+website: 'https://www.alibabacloud.com'
+llmsUrl: 'https://www.alibabacloud.com/help/en/llms.txt'
+llmsFullUrl: ''
+category: 'infrastructure-cloud'
+publishedAt: '2026-07-13'
+---
+
+# Alibaba Cloud
+
+Alibaba Cloud (阿里云) is a leading global cloud computing platform providing infrastructure, database, AI/ML, and developer services for businesses worldwide.
+
+## Key Focus Areas
+
+- Elastic Compute (ECS, ECI)
+- Object Storage (OSS)
+- Databases (RDS, PolarDB, AnalyticDB, Lindorm, Tair/Redis)
+- Serverless (Function Compute, SAE)
+- AI & Large Models (PAI, Model Studio, Qwen)
+- Container Service (ACK)
+- Networking (VPC, SLB, CDN)
+- Security (WAF, Anti-DDoS, KMS)
+
+## Core Features
+
+- Full-stack cloud infrastructure across 30+ regions and 100+ availability zones worldwide
+- Per-product llms.txt sub-indexes with direct `.md` source links
+- Multilingual documentation (English, Chinese, Japanese, Indonesian)
+- API references, user guides, and best practices for each service
+
+## About llms.txt Implementation
+
+Alibaba Cloud's llms.txt is organized by product category. Each entry links to a product-specific llms.txt sub-index at `https://www.alibabacloud.com/help/en/{product}/llms.txt`, containing the full documentation tree with Markdown source file links optimized for AI agent consumption.
+
+A separate Chinese site index is available at `https://help.aliyun.com/zh/llms.txt` for China-region products and compliance documentation.

--- a/packages/content/data/websites/qwen-cloud-cn-llms-txt.mdx
+++ b/packages/content/data/websites/qwen-cloud-cn-llms-txt.mdx
@@ -1,0 +1,35 @@
+---
+name: 'Qwen Cloud China'
+description: "China-region Qwen Cloud (千问云) MaaS platform with docs for Qwen text, vision, image, video, and speech models plus Qwen CLI, AI Skills, and Token Plan."
+website: 'https://www.qianwenai.com'
+llmsUrl: 'https://platform.qianwenai.com/llms.txt'
+llmsFullUrl: ''
+category: 'ai-ml'
+publishedAt: '2026-07-13'
+---
+
+# Qwen Cloud China (千问云开放平台)
+
+China-region deployment of Alibaba's Qwen model-as-a-service platform. Product surface is broader than the international site — it includes China-only capabilities (Qwen-Doc, Tongyi-Xiaomi dialogue analysis, GUI-Plus, virtual-model image generation, poster generation) alongside the shared Qwen family.
+
+## Key Focus Areas
+
+- Text generation: Qwen-Max / Plus / Turbo, Qwen-Long (10M-token context), Qwen-MT, Qwen-Character, Qwen-Doc, Qwen-Deep-Research, Tongyi-Intent-Detect
+- Visual understanding, OCR, video understanding
+- Image generation and editing: Wan 2.1 / 2.5 / 2.6 / 2.7, creative poster, virtual model, portrait restyle, shoe modeling
+- Video generation (text/image/reference-to-video, general video editing)
+- Speech (ASR / TTS / streaming / voice cloning / speech-to-speech)
+- Embeddings and reranking
+- Qwen CLI and Qwen AI Skills (agent-native skill packages)
+- Token Plan team subscription
+
+## Key Differences from International Site
+
+- Broader product catalog — 600+ documentation entries covering China-only features
+- Chinese-language primary docs (a growing subset offers bilingual pages)
+- Includes agent-tooling surfaces (Qwen CLI, AI Skills) not exposed on the international site
+- China-region compliance, billing (Token Plan RMB), and account model
+
+## About llms.txt Implementation
+
+The index at `https://platform.qianwenai.com/llms.txt` mirrors the international layout: every entry links to a `.md` source URL grouped by section (平台 / Token Plan 团队版 / 快速入门 / 模型 / 最佳实践 / API 参考). For the international English site see the separate entry at `docs.qwencloud.com`.

--- a/packages/content/data/websites/qwen-cloud-llms-txt.mdx
+++ b/packages/content/data/websites/qwen-cloud-llms-txt.mdx
@@ -1,0 +1,37 @@
+---
+name: 'Qwen Cloud'
+description: "Qwen Cloud offers OpenAI-, Anthropic-, and DashScope-compatible APIs for Qwen text, vision, image, video, and speech models with pay-as-you-go and Token Plan."
+website: 'https://www.qwencloud.com'
+llmsUrl: 'https://docs.qwencloud.com/llms.txt'
+llmsFullUrl: ''
+category: 'ai-ml'
+publishedAt: '2026-07-13'
+---
+
+# Qwen Cloud
+
+Qwen Cloud is Alibaba's international model-as-a-service (MaaS) platform, providing API access to the Qwen family of large language and multimodal models plus selected third-party models (DeepSeek, GLM, Kimi).
+
+## Key Focus Areas
+
+- Text generation (Qwen-Max, Qwen-Plus, Qwen-Turbo, Qwen-Long, Qwen-MT, Qwen-Character)
+- Visual understanding (Qwen-VL, OCR, video analysis)
+- Image generation and editing (Wan 2.1 / 2.5 / 2.6 / 2.7)
+- Video generation (text-to-video, image-to-video, reference-to-video, editing)
+- Speech (realtime ASR, file transcription, streaming TTS, voice cloning, speech-to-speech)
+- Embeddings and reranking
+- Third-party models: DeepSeek, GLM, Kimi
+- Token Plan (team subscription) and Coding Plan (per-seat AI coding subscription)
+
+## Core Features
+
+- OpenAI-, Anthropic-, and DashScope-compatible endpoints — most existing SDKs work with a base-URL swap
+- Function calling, structured output, and partial (prefix continuation) mode
+- Pay-as-you-go billing plus prepaid Token Plan / Coding Plan subscriptions
+- Built-in tools: web search, code interpreter, multimodal generation
+
+## About llms.txt Implementation
+
+The root index at `https://docs.qwencloud.com/llms.txt` lists every documentation page as a Markdown source URL (each entry appends `.md` to the human URL — e.g. `text-to-image.md`), grouped by product surface: Token Plan, Coding Plan, Getting Started, Models (text / vision / image / video / speech), API Reference. Agents can fetch any entry directly for the raw Markdown source, no HTML scraping required.
+
+For the China-region site (千问云), see the separate entry: `platform.qianwenai.com`.


### PR DESCRIPTION
## Summary

Adds four new `.mdx` entries under `packages/content/data/websites/` for Alibaba Cloud and Qwen Cloud (international + China-region variants), each pointing to an existing published llms.txt index.

## Changes

Adds four llms.txt entries in the standard mdx format:

- **Alibaba Cloud** (international) — https://www.alibabacloud.com/help/en/llms.txt
- **Alibaba Cloud China** (help.aliyun.com, 300+ products including Apsara Stack) — https://help.aliyun.com/zh/llms.txt
- **Qwen Cloud** (international MaaS, OpenAI/Anthropic/DashScope compatible) — https://docs.qwencloud.com/llms.txt
- **Qwen Cloud China** (千问云 platform.qianwenai.com, includes Qwen CLI + AI Skills) — https://platform.qianwenai.com/llms.txt

Each entry follows the existing frontmatter format (name / description / website / llmsUrl / llmsFullUrl / category / publishedAt) consistent with `4everland-llms-txt.mdx`.
