### PR TITLE
Add TomHow (tomhow.co.uk)

### DIFF
--- a/packages/content/data/websites/tomhow-llms-txt.mdx
+++ b/packages/content/data/websites/tomhow-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'TomHow'
+description: 'UK SEO and AI-search visibility consultancy tracking how brands appear in Google and AI assistants.'
+website: 'https://tomhow.co.uk'
+llmsUrl: 'https://tomhow.co.uk/llms.txt'
+category: 'agency-services'
+publishedAt: '2026-07-13'
+---
+
+# TomHow
+
+UK SEO and AI-search visibility consultancy. TomHow audits AI-search readiness, tracks brand citations across ChatGPT, Claude, Perplexity and Gemini, and maintains a curated llms.txt kept aligned with its sitemap.


### PR DESCRIPTION
Adds TomHow, a UK SEO and AI-search visibility consultancy, to the websites directory.

- Website: https://tomhow.co.uk
- llms.txt: https://tomhow.co.uk/llms.txt (curated, aligned with the sitemap)
- Category: agency-services

Follows the .mdx template under packages/content/data/websites/; data/websites.json untouched per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a directory entry for TomHow, including its website details and description.
  * Documented the consultancy’s focus on UK SEO and AI-search visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->