### PR TITLE
feat(community): add Trump Timer to llms.txt hub

### DIFF
--- a/packages/content/data/websites/trump-timer-llms-txt.mdx
+++ b/packages/content/data/websites/trump-timer-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Trump Timer'
+description: 'Trump Timer tracks the 2025-2029 U.S. presidential term with live countdowns, approval polling context, timelines, calculators, and topical explainers.'
+website: 'https://trumptimer.us/'
+llmsUrl: 'https://trumptimer.us/llms.txt'
+llmsFullUrl: ''
+category: 'content-media'
+publishedAt: '2026-07-14'
+---
+
+# Trump Timer
+
+Trump Timer tracks the 2025-2029 U.S. presidential term with live countdowns, approval polling context, timelines, calculators, and topical explainers.


### PR DESCRIPTION
This PR adds Trump Timer to the llms.txt hub.

**Website:** https://trumptimer.us/
**llms.txt:** https://trumptimer.us/llms.txt
**Category:** content-media

The llms.txt URL is publicly reachable and returns Markdown as text/plain.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new website entry for Trump Timer.
  * Included metadata, links, publication details, and an overview of its countdown, timeline, polling, calculator, and explainer content for the 2025–2029 U.S. presidential term.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->