### PR TITLE
feat(community): add GenColoring AI to llms.txt hub

### DIFF
--- a/packages/content/data/websites/gencoloring-ai-llms-txt.mdx
+++ b/packages/content/data/websites/gencoloring-ai-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'GenColoring AI'
+description: 'GenColoring AI turns photos, prompts, and names into printable coloring pages and includes themed collections plus an online coloring editor.'
+website: 'https://gencoloring.ai/'
+llmsUrl: 'https://gencoloring.ai/llms.txt'
+llmsFullUrl: ''
+category: 'ai-ml'
+publishedAt: '2026-07-14'
+---
+
+# GenColoring AI
+
+GenColoring AI turns photos, prompts, and names into printable coloring pages and includes themed collections plus an online coloring editor.


### PR DESCRIPTION
This PR adds GenColoring AI to the llms.txt hub.

**Website:** https://gencoloring.ai/
**llms.txt:** https://gencoloring.ai/llms.txt
**Category:** ai-ml

The llms.txt URL is publicly reachable and returns Markdown as text/plain.

Please review and merge if appropriate.