### PR TITLE
feat(community): add Word Journey to llms.txt hub

### DIFF
--- a/packages/content/data/websites/word-journey-llms-txt.mdx
+++ b/packages/content/data/websites/word-journey-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Word Journey'
+description: 'Word Journey is a Korean self-reflection quiz that narrows value words to five core values and offers an optional AI-written interpretation.'
+website: 'https://wordjourney.site/'
+llmsUrl: 'https://wordjourney.site/llms.txt'
+llmsFullUrl: ''
+category: 'personal'
+publishedAt: '2026-07-14'
+---
+
+# Word Journey
+
+Word Journey is a Korean self-reflection quiz that narrows value words to five core values and offers an optional AI-written interpretation.


### PR DESCRIPTION
This PR adds Word Journey to the llms.txt hub.

**Website:** https://wordjourney.site/
**llms.txt:** https://wordjourney.site/llms.txt
**Category:** personal

The llms.txt URL is publicly reachable and returns Markdown as text/plain.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Word Journey” website entry with its name, description, URL, category, publication date, and related AI-readable content link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->