### PR TITLE
feat(community): add Geomelon to llms.txt hub

### DIFF
--- a/packages/content/data/websites/geomelon-llms-txt.mdx
+++ b/packages/content/data/websites/geomelon-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Geomelon'
+description: 'A read-only geographic data API covering cities, countries, regions, and languages — with multilingual name support.'
+website: 'https://geomelon.dev/'
+llmsUrl: 'https://geomelon.dev/llms.txt'
+llmsFullUrl: ''
+category: 'data-analytics'
+publishedAt: '2026-07-14'
+---
+
+# Geomelon
+
+A read-only geographic data API covering cities, countries, regions, and languages — with multilingual name support.


### PR DESCRIPTION
This PR adds Geomelon to the llms.txt hub.

**Website:** https://geomelon.dev/
**llms.txt:** https://geomelon.dev/llms.txt

**Category:** data-analytics

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new website entry for Geomelon.
  * Included an overview of the Geomelon API and links to relevant site resources.
  * Added metadata to support categorization and publication in the website directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->