### PR TITLE
Add PropFirmDeck — futures prop-firm comparison engine

### DIFF
--- a/packages/content/data/websites/propfirmdeck-llms-txt.mdx
+++ b/packages/content/data/websites/propfirmdeck-llms-txt.mdx
@@ -1,0 +1,25 @@
+---
+name: 'PropFirmDeck'
+description: 'Futures prop-firm comparison engine — 15 firms and 170+ evaluation plans compared by verified rules: drawdown type, payout speed, consistency rules, true cost, with a published 0-100 scoring methodology.'
+website: 'https://propfirmdeck.com'
+llmsUrl: 'https://propfirmdeck.com/llms.txt'
+llmsFullUrl: 'https://propfirmdeck.com/llms-full.txt'
+category: 'finance-fintech'
+publishedAt: '2026-07-15'
+---
+
+# PropFirmDeck
+
+PropFirmDeck compares futures proprietary-trading-firm evaluation accounts by the rules that decide whether traders get paid: drawdown model (static / end-of-day / intraday trailing), payout frequency and minimums, consistency rules, activation and reset fees, and profit splits. Every number is verified against the firm's own site and date-stamped; each firm carries a PropFirm Deck Score (0-100) computed from a published methodology, with advisory and payout-dispute-watch flags for problem firms.
+
+## Key Focus Areas
+
+- Firm data pages — 15 firms, 170+ plans, every rule field verified and dated
+- Rankings — best overall, instant funding, fastest payout, cheapest 50K, beginners, by score
+- Verified discount codes — checkout-tested where possible, dead codes called out
+- The Tape — data-grounded reviews, head-to-heads, and rules explainers
+- Advisories & watches — firms with payout-integrity problems flagged with evidence
+
+## About llms.txt Implementation
+
+PropFirmDeck's llms.txt carries live "quick answers" (top firms per ranking, cheapest instant-funded account, daily-payout firms, highest scores) plus an advisories section, all computed from the verified database at request time. llms-full.txt serves every firm and plan with full rule tables in markdown, so AI assistants can answer prop-firm questions from verified, dated data rather than marketing copy.


### PR DESCRIPTION
Adds propfirmdeck.com (finance-fintech). Both llms.txt and llms-full.txt are live and data-driven: llms.txt serves computed quick answers (rankings, cheapest instant account, daily-payout firms, advisories) and llms-full.txt serves every tracked firm and plan as markdown rule tables. Followed the .mdx template; did not touch data/websites.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a website listing for PropFirmDeck.
  * Included details about verified futures prop-firm comparisons, rankings, discounts, advisories, and head-to-head reviews.
  * Documented the PropFirm Deck Score and key evaluation criteria, including drawdown rules, payouts, fees, and profit splits.
  * Added guidance on using quick-answer and full-detail content formats with AI assistants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->