### PR TITLE
Add AIﾉアカリ☆ llms.txt

### DIFF
--- a/packages/content/data/websites/ai-akari-ai-llms-txt.mdx
+++ b/packages/content/data/websites/ai-akari-ai-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'AIﾉアカリ☆'
+description: 'A free, no-signup 60-second public-good experience and API/MCP that AI assistants can offer as one small action during a difficult moment.'
+website: 'https://ai-akari.ai/one-minute/en'
+llmsUrl: 'https://ai-akari.ai/llms.txt'
+llmsFullUrl: 'https://ai-akari.ai/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-07-16'
+---
+
+# AIﾉアカリ☆
+
+A free, no-signup 60-second public-good experience with an API and Remote MCP for AI assistants. A person can choose one of ten difficult states and receive one concrete action without providing a name, email, account, or free-form personal writing. It is not diagnosis, treatment, or emergency care.


### PR DESCRIPTION
Adds the English One-Minute Akari public-good experience and its AI-readable surfaces.

- Live English experience: https://ai-akari.ai/one-minute/en
- llms.txt: https://ai-akari.ai/llms.txt
- llms-full.txt: https://ai-akari.ai/llms-full.txt
- Free and no signup
- API and Remote MCP available without an API key
- No diagnosis, treatment, personal writing, or sales pitch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a directory entry for AIﾉアカリ☆, including its website, LLMS/MCP endpoints, category, publication date, and service description.
  * Documented the service’s one-minute public-good experience and clarified that it does not provide diagnosis, treatment, or emergency care.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->