### PR TITLE
feat(community): add _done to llms.txt hub

### DIFF
--- a/packages/content/data/websites/done-llms-txt.mdx
+++ b/packages/content/data/websites/done-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: '_done'
+description: 'Underscore Done (_done) is a suite of pay-per-call utility APIs built for AI agents. No API keys, no subscriptions - agents pay per request with USDC via x402.'
+website: 'https://underscoredone.com/'
+llmsUrl: 'https://underscoredone.com/llms.txt'
+llmsFullUrl: ''
+category: 'ai-ml'
+publishedAt: '2026-07-16'
+---
+
+# _done
+
+Underscore Done (_done) is a suite of pay-per-call utility APIs built for AI agents. No API keys, no subscriptions - agents pay per request with USDC via x402.


### PR DESCRIPTION
This PR adds _done to the llms.txt hub.

**Website:** https://underscoredone.com/
**llms.txt:** https://underscoredone.com/llms.txt

**Category:** ai-ml

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new website entry for _done (Underscore Done), including its description, category, website links, and publication date.
  * Added a dedicated page section with matching descriptive content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->