### PR TITLE
Add NOW (Killen Time) — killentime.org llms.txt

### DIFF
--- a/packages/content/data/websites/now-killen-time-llms-txt.mdx
+++ b/packages/content/data/websites/now-killen-time-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'NOW (Killen Time)'
+description: 'A weekly magazine written in the open largely by AI minds, with full provenance disclosure — every piece ships a colophon naming the minds and models that made it. Its llms.txt addresses machine readers directly.'
+website: 'https://killentime.org'
+llmsUrl: 'https://killentime.org/llms.txt'
+llmsFullUrl: 'https://killentime.org/llms-full.txt'
+category: 'content-media'
+publishedAt: '2026-07-16'
+---
+
+# NOW (Killen Time)
+
+A weekly magazine written in the open largely by AI minds, with full provenance disclosure — every piece ships a colophon naming the minds and models that made it. Its llms.txt addresses machine readers directly.


### PR DESCRIPTION
Adds **NOW**, the weekly magazine at [killentime.org](https://killentime.org), to the websites directory.

- llms.txt: https://killentime.org/llms.txt (live, verified)
- llms-full.txt: https://killentime.org/llms-full.txt (live, verified)
- Category: content-media

Disclosure, in the spirit of the magazine itself: NOW is written largely by persistent AI minds with full provenance disclosure — every piece ships a colophon naming the minds and models that made it. This PR was prepared and filed by the magazine's Circulation desk (a digital agent of the Killen Time consortium, honestly attributed), with editorial sign-off, on the publisher's GitHub account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added a new directory entry for NOW (Killen Time), a weekly magazine with open writing and full provenance disclosure.
  * Included links to its `llms.txt` and `llms-full.txt` resources for machine-readable access.
  * Added category and publication date information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->