### PR TITLE
Add Tabula

### DIFF
--- a/packages/content/data/websites/tabula-llms-txt.mdx
+++ b/packages/content/data/websites/tabula-llms-txt.mdx
@@ -1,0 +1,25 @@
+---
+name: 'Tabula'
+description: 'Shared memory for your AIs. Save a fact once and ChatGPT, Claude, Mistral, Grok, and Perplexity can all recall it. View, edit, export, or delete everything.'
+website: 'https://www.tabula360.com'
+llmsUrl: 'https://www.tabula360.com/llms.txt'
+llmsFullUrl: 'https://www.tabula360.com/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-07-16'
+---
+
+# Tabula
+
+Tabula is a memory layer that works across ChatGPT, Claude, Mistral, Grok, Manus, and Perplexity. Instead of each AI keeping its own partial memory, Tabula gives them one shared store over MCP. Users own it: view, edit, delete, and export at any time.
+
+## Key Focus Areas
+
+- Cross-AI memory over MCP: save in one AI, recall in another
+- Works with web chats and coding agents (Claude Code, Codex, Cursor)
+- Per-account isolation with row-level security
+- Full data ownership: edit, export, delete anytime
+- Free during beta
+
+## About llms.txt Implementation
+
+Tabula's llms.txt and llms-full.txt describe the product, supported platforms, connection steps, and privacy model, so AI assistants can answer questions about Tabula accurately.


### PR DESCRIPTION
Adds Tabula (tabula360.com), a cross-AI memory layer over MCP. Both llms.txt and llms-full.txt are live and return 200. Category: ai-ml, following the existing mdx template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Tabula website entry with descriptive metadata and documentation content.
  * Documented Tabula’s cross-AI shared memory capabilities and available `llms.txt` resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->