### PR TITLE
feat(content): add TinyOps Studio

### DIFF
--- a/packages/content/data/websites/tinyops-studio-llms-txt.mdx
+++ b/packages/content/data/websites/tinyops-studio-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'TinyOps Studio'
+description: 'Fixed-scope workflow reviews, automation reliability audits, credential-free n8n harness customization, and self-serve automation resources.'
+website: 'https://ideals2201.github.io/ai-monkey-value-audit/services.html'
+llmsUrl: 'https://ideals2201.github.io/ai-monkey-value-audit/llms.txt'
+llmsFullUrl: ''
+category: 'agency-services'
+publishedAt: '2026-07-17'
+---
+
+# TinyOps Studio
+
+TinyOps Studio provides fixed-scope workflow reviews, automation reliability audits, credential-free n8n harness customization, and self-serve automation resources. Initial intake uses public, synthetic, or fully sanitized material.


### PR DESCRIPTION
## Summary

- add TinyOps Studio to the agency and services directory
- point to its public llms.txt and canonical service catalog
- describe only publicly documented, fixed-scope services

## Verification

- public llms.txt returns HTTP 200 with text/plain content
- pnpm check:frontmatter: passed
- git diff --check: passed
- full website validator reached all 2,563 entries; it reports five unrelated pre-existing filename/duplicate-URL errors in existing entries and no TinyOps Studio error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new TinyOps Studio directory page with service details.
  - Included website and llms.txt links, category information, publication date, and a brief description of the intake process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->