### PR TITLE
feat(content): add Tura

### DIFF
--- a/packages/content/data/websites/tura-llms-txt.mdx
+++ b/packages/content/data/websites/tura-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Tura'
+description: 'Open-source coding agent for turning intent into verified repository changes with persistent execution state and auditable benchmark evidence.'
+website: 'https://turaai.net/'
+llmsUrl: 'https://turaai.net/llms.txt'
+llmsFullUrl: 'https://turaai.net/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-16'
+---
+
+# Tura
+
+Tura is a local, open-source coding agent for long-running repository work. It combines persistent execution state, terminal and graphical interfaces, and evidence-backed verification to help developers turn intent into reviewed changes.
+
+## Key Focus Areas
+
+- Persistent goals and explicit execution state for resumable work
+- Terminal UI, graphical UI, and command-line workflows
+- Public benchmark methodology with task, token, turn, cost, and verifier evidence
+- AGPL-3.0-or-later source code and the public `tura-ai` npm package
+
+## About llms.txt Implementation
+
+Tura's llms.txt identifies its canonical website, documentation, source repositories, benchmark methodology, and evidence policy. The expanded llms-full.txt provides additional architecture, installation, citation, and benchmark context for language models.


### PR DESCRIPTION
## Summary

- add Tura to the Developer Tools directory
- link its public `llms.txt` and `llms-full.txt` resources
- describe the project's documented coding-agent interfaces and evidence policy

## Why

Tura is an actively maintained, open-source coding agent and both machine-readable files are publicly available from its canonical website.

## Verification

- `https://turaai.net/`: HTTP 200
- `https://turaai.net/llms.txt`: HTTP 200, `text/plain`
- `https://turaai.net/llms-full.txt`: HTTP 200, `text/plain`
- `pnpm check:frontmatter tura-llms-txt.mdx`: passed
- isolated filename, category, URL-shape, required-field, and duplicate-`llmsUrl` validation: passed
- `git diff --check`: passed
- full website validator reached all 2,564 entries; it reports five unrelated pre-existing filename/duplicate-URL errors in existing entries and no Tura error

I am affiliated with the Tura project. I used AI assistance to research the repository rules, draft this focused entry, and run the checks; I reviewed the final content and links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a documentation page for Tura.
  * Included links to Tura’s `llms.txt` and `llms-full.txt` resources.
  * Documented Tura’s focus on persistent execution state, terminal and graphical workflows, and benchmark evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->