### PR TITLE
feat(community): add Flightcore Studios to llms.txt hub

### DIFF
--- a/packages/content/data/websites/flightcore-studios-llms-txt.mdx
+++ b/packages/content/data/websites/flightcore-studios-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Flightcore Studios'
+description: 'Recording studio in Warsaw, Poland - 17+ platinum records, 5000+ sessions. Three live rooms, a mastering room, 24/7 recording, mixing and mastering.'
+website: 'https://flightcore.pl'
+llmsUrl: 'https://flightcore.pl/llms.txt'
+llmsFullUrl: ''
+category: 'content-media'
+publishedAt: '2026-07-17'
+---
+
+# Flightcore Studios
+
+Recording studio in Warsaw, Poland - 17+ platinum records, 5000+ sessions. Three live rooms, a mastering room, 24/7 recording, mixing and mastering.


### PR DESCRIPTION
This PR adds Flightcore Studios to the llms.txt hub.

**Website:** https://flightcore.pl
**llms.txt:** https://flightcore.pl/llms.txt

**Category:** content-media

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new Flightcore Studios website profile with associated metadata.
  - Added a visible page title and description for the profile.

- **Documentation**
  - Published structured information about Flightcore Studios and its AI-readable content URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->