### PR TITLE
feat(community): add Flightcore Docs to llms.txt hub

### DIFF
--- a/packages/content/data/websites/flightcore-docs-llms-txt.mdx
+++ b/packages/content/data/websites/flightcore-docs-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Flightcore Docs'
+description: 'Official technical documentation for Flightcore Studios - recording technology, audio equipment and studio infrastructure.'
+website: 'https://docs.flightcore.pl'
+llmsUrl: 'https://docs.flightcore.pl/llms.txt'
+llmsFullUrl: 'https://docs.flightcore.pl/llms-full.txt'
+category: 'content-media'
+publishedAt: '2026-07-17'
+---
+
+# Flightcore Docs
+
+Official technical documentation for Flightcore Studios - recording technology, audio equipment and studio infrastructure.


### PR DESCRIPTION
This PR adds Flightcore Docs to the llms.txt hub.

**Website:** https://docs.flightcore.pl
**llms.txt:** https://docs.flightcore.pl/llms.txt
**llms-full.txt:** https://docs.flightcore.pl/llms-full.txt  
**Category:** content-media

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new Flightcore Docs documentation page.
  - Included links to the website and AI-readable documentation resources.
  - Added descriptive metadata and a brief overview of Flightcore Studios technical documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->