### PR TITLE
feat(community): add Flightcore EDU to llms.txt hub

### DIFF
--- a/packages/content/data/websites/flightcore-edu-llms-txt.mdx
+++ b/packages/content/data/websites/flightcore-edu-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Flightcore EDU'
+description: 'Audio production education platform by Flightcore Studios - recording, mixing and mastering learning resources.'
+website: 'https://edu.flightcore.pl'
+llmsUrl: 'https://edu.flightcore.pl/llms.txt'
+llmsFullUrl: 'https://edu.flightcore.pl/llms-full.txt'
+category: 'content-media'
+publishedAt: '2026-07-17'
+---
+
+# Flightcore EDU
+
+Audio production education platform by Flightcore Studios - recording, mixing and mastering learning resources.


### PR DESCRIPTION
This PR adds Flightcore EDU to the llms.txt hub.

**Website:** https://edu.flightcore.pl
**llms.txt:** https://edu.flightcore.pl/llms.txt
**llms-full.txt:** https://edu.flightcore.pl/llms-full.txt  
**Category:** content-media

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Flightcore EDU website entry with descriptive metadata and links to its standard and full content resources.
  * Published a dedicated page with the platform’s name and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->