### PR TITLE
feat(community): add GeoPromptTracker to llms.txt hub

### DIFF
--- a/packages/content/data/websites/geoprompttracker-llms-txt.mdx
+++ b/packages/content/data/websites/geoprompttracker-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'GeoPromptTracker'
+description: 'Free micro-tools for Generative Engine Optimization (GEO/AEO): llms.txt generators, AI crawler checkers, schema generators, and AI-readiness audits.'
+website: 'https://geoprompttracker.com/'
+llmsUrl: 'https://geoprompttracker.com/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-07-17'
+---
+
+# GeoPromptTracker
+
+Free micro-tools for Generative Engine Optimization (GEO/AEO): llms.txt generators, AI crawler checkers, schema generators, and AI-readiness audits.


### PR DESCRIPTION
This PR adds GeoPromptTracker to the llms.txt hub.

**Website:** https://geoprompttracker.com/
**llms.txt:** https://geoprompttracker.com/llms.txt

**Category:** developer-tools

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new directory page for GeoPromptTracker.
  * Included website metadata, categorization, publication date, and a brief description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->