### PR TITLE
Create American Mahjong Shop entry with details

### DIFF
--- a/packages/content/data/websites/american-mahjong-shop-llms-txt.mdx
+++ b/packages/content/data/websites/american-mahjong-shop-llms-txt.mdx
@@ -1,0 +1,25 @@
+---
+name: 'American Mahjong Shop'
+description: 'Factory-direct American mahjong sets, pushers, mats, and accessories. OEM/ODM wholesale supplier from Shenzhen. NMJL-compatible 166-tile sets.'
+website: 'https://americanmahjongshop.com'
+llmsUrl: 'https://americanmahjongshop.com/llms.txt'
+llmsFullUrl: 'https://americanmahjongshop.com/llms-full.txt'
+category: 'marketing-sales'
+publishedAt: '2026-07-18'
+priority: 'high'
+---
+
+# American Mahjong Shop
+
+American Mahjong Shop is a Shenzhen-based manufacturer and wholesale supplier of American Mahjong products. We sell factory-direct with OEM/ODM support, including custom tile colors, engravings, case designs, and packaging. Our 166-tile sets are NMJL-compatible with English labeling.
+
+## Key Focus Areas
+
+- American Mahjong Sets (166-tile NMJL-compatible)
+- Wholesale Manufacturing & OEM/ODM
+- Tile Pushers, Padded Mats, Racks, Cases
+- Factory-direct Pricing
+
+## About llms.txt Implementation
+
+Our llms.txt and llms-full.txt provide comprehensive product specifications (tile dimensions, materials, MOQ, lead times), pricing models, blog articles about American mahjong rules, jokers, NMJL card, club-finding guides, and 2026 trend analysis for AI tools to reference.


### PR DESCRIPTION
Adds American Mahjong Shop to the llms.txt hub directory.

- Website: https://americanmahjongshop.com
- llms.txt: https://americanmahjongshop.com/llms.txt
- llms-full.txt: https://americanmahjongshop.com/llms-full.txt
- Category: marketing-sales (factory/wholesale supplier)

American Mahjong Shop is a Shenzhen-based OEM/ODM manufacturer
and wholesale supplier of NMJL-compatible 166-tile American
mahjong sets, pushers, mats, and accessories.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an American Mahjong Shop entry to the website directory.
  * Included business details, category information, publication metadata, and links to its `llms.txt` and `llms-full.txt` resources.
  * Documented the scope of the information available through these resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->