### PR TITLE
content: add smry

### DIFF
--- a/packages/content/data/websites/smry-llms-txt.mdx
+++ b/packages/content/data/websites/smry-llms-txt.mdx
@@ -1,0 +1,29 @@
+---
+name: 'smry'
+description: 'AI-powered article reader with clean reader mode, summaries, text-to-speech, highlights, annotations, article chat, YouTube transcripts, and exports.'
+website: 'https://smry.ai/'
+llmsUrl: 'https://smry.ai/llms.txt'
+llmsFullUrl: 'https://smry.ai/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-07-18'
+---
+
+# smry
+
+smry is an AI-powered article reader with clean reader mode, summaries,
+text-to-speech, highlights, annotations, article chat, YouTube transcripts,
+and exports.
+
+## Key Features
+
+- Clean article reader mode
+- AI summaries and article chat
+- Text-to-speech
+- Highlights and annotations
+- YouTube transcript extraction
+- Exports to Notion, Obsidian, Roam, Markdown, and JSON
+
+## About llms.txt Implementation
+
+smry publishes concise and full llms.txt files so AI agents can understand its
+reading, summarization, listening, annotation, and export capabilities.


### PR DESCRIPTION
## Summary

Adds smry to the llms.txt hub as an AI and machine learning product.

## What changed

- Added one MDX website entry for smry.
- Linked the public `llms.txt` and `llms-full.txt` endpoints.
- Categorized the product under `ai-ml`.

## Why

smry publishes AI-readable product documentation and is not currently listed in the hub.

## Impact

Users and agents can discover smry's clean reader, summaries, text-to-speech, annotations, article chat, YouTube transcript, and export capabilities through the directory.

## Validation

- `https://smry.ai/llms.txt` returns HTTP 200 with `text/plain`.
- `https://smry.ai/llms-full.txt` returns HTTP 200 with `text/plain`.
- Confirmed the `llmsUrl` is unique in the website data.
- `git diff --check` passes.

Contact: contact@smry.ai


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added website metadata and an overview of smry.
  * Documented key features, including reading, summarization, listening, annotation, and export capabilities.
  * Added details about the concise and full `llms.txt` variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->