### PR TITLE
Add otwarteAPI.pl

### DIFF
--- a/packages/content/data/websites/otwarteapi-pl-llms-txt.mdx
+++ b/packages/content/data/websites/otwarteapi-pl-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'otwarteAPI.pl'
+description: 'Directory of Polish and EU public government APIs (VAT registry, company registers, statistics, weather data) for humans and AI agents, publishing an ai-catalog.json (ARD) manifest.'
+website: 'https://otwarteapi.pl'
+llmsUrl: 'https://otwarteapi.pl/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-07-19'
+---
+
+# otwarteAPI.pl
+
+Directory of Polish and European Union public government APIs, described so both humans and AI agents can discover and call them directly.


### PR DESCRIPTION
Adding otwarteAPI.pl — a directory of Polish and EU public government APIs (VAT registry, company registers, GUS statistics, NBP exchange rates, ECB, Eurostat, EUR-Lex, weather data, and more), aimed at both humans and AI agents.

- llms.txt: https://otwarteapi.pl/llms.txt
- Also publishes an ai-catalog.json manifest per the new Agentic Resource Discovery (ARD) spec: https://otwarteapi.pl/.well-known/ai-catalog.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an entry for otwarteAPI.pl to the website directory, including its description, links, category, and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->