### PR TITLE
Mention the free llms.txt validator in the turva.dev entry

### DIFF
--- a/packages/content/data/websites/turva-dev-llms-txt.mdx
+++ b/packages/content/data/websites/turva-dev-llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
 name: 'turva.dev'
-description: 'Agent-readiness audits and advisory. Signed llms.txt, a public read-only MCP server and an open-source Cloudflare Worker reference build.'
+description: 'Agent-readiness audits and advisory. Signed llms.txt, a free llms.txt validator hosted and as an npm CLI, a public read-only MCP server and an open-source Cloudflare Worker reference build.'
 website: 'https://turva.dev'
 llmsUrl: 'https://turva.dev/llms.txt'
 llmsFullUrl: 'https://turva.dev/llms-full.txt'
@@ -10,4 +10,4 @@ publishedAt: '2026-07-03'
 
 # turva.dev
 
-Agent-readiness audits and advisory. Signed llms.txt, a public read-only MCP server and an open-source Cloudflare Worker reference build.
+Agent-readiness audits and advisory. Signed llms.txt, a free llms.txt validator hosted and as an npm CLI, a public read-only MCP server and an open-source Cloudflare Worker reference build.


### PR DESCRIPTION
## Summary

Updates the existing turva.dev entry to mention the free llms.txt validator the site publishes: hosted at https://turva.dev/llms-txt-validator and as an MIT-licensed npm CLI, https://www.npmjs.com/package/turva-llms-txt-validator.

Only the description sentence changed, in the frontmatter and the body. Edits only the .mdx file under packages/content/data/websites/, nothing auto-generated touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the turva.dev page description and visible content to mention agent-readiness audits and advisory services.
  * Improved punctuation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->