### PR TITLE
feat(community): add Alquis | AI-ready websites to llms.txt hub

### DIFF
--- a/packages/content/data/websites/alquis-ai-ready-websites-llms-txt.mdx
+++ b/packages/content/data/websites/alquis-ai-ready-websites-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Alquis | AI-ready websites'
+description: 'Alquis builds AI-ready websites, web apps, and AI web optimisation systems for startups and growing businesses in London, Warsaw, and Zürich.'
+website: 'https://alquis.com'
+llmsUrl: 'https://alquis.com/llms.txt'
+llmsFullUrl: 'https://alquis.com/llms-full.txt'
+category: 'agency-services'
+publishedAt: '2026-07-19'
+---
+
+# Alquis | AI-ready websites
+
+Alquis builds AI-ready websites, web apps, and AI web optimisation systems for startups and growing businesses in London, Warsaw, and Zürich.


### PR DESCRIPTION
This PR adds Alquis | AI-ready websites to the llms.txt hub.

**Website:** https://alquis.com
**llms.txt:** https://alquis.com/llms.txt
**llms-full.txt:** https://alquis.com/llms-full.txt  
**Category:** agency-services

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Alquis | AI-ready websites” entry to the website directory, including its description, category, publication date, and links to AI-readable content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->