### PR TITLE
feat(content): add Latchshot

### DIFF
--- a/packages/content/data/websites/latchshot-llms-txt.mdx
+++ b/packages/content/data/websites/latchshot-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Latchshot'
+description: 'Guarded screenshot and PDF rendering API for public web pages, with a recurring Free plan, OpenAPI contract, and hosted MCP endpoint.'
+website: 'https://latchshot.fly.dev'
+llmsUrl: 'https://latchshot.fly.dev/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-19'
+---
+
+# Latchshot
+
+Latchshot turns a public HTTP or HTTPS page into a PNG, JPEG, or PDF artifact through one bounded API request. It is designed for reports, link previews, QA evidence, social images, and archives that do not require browser sessions or private-network access.
+
+## Key Focus Areas
+
+- Public-page screenshot and PDF rendering
+- Bounded dimensions, delays, deadlines, concurrency, and queue depth
+- Bearer-authenticated REST, OpenAPI, and hosted MCP interfaces
+- Private and special-use network blocking
+- Successful-render quota accounting
+
+## About llms.txt Implementation
+
+Latchshot's `llms.txt` links the canonical API contract, documentation, data-handling boundary, integration recipes, client examples, migration guides, and current beta evidence so AI assistants can distinguish supported public-page rendering from unsupported browser scripting, authenticated sessions, proxy rotation, and anti-bot bypass.


### PR DESCRIPTION
## Summary

- add one `developer-tools` entry for Latchshot;
- point the entry at the live product and canonical `llms.txt` resource;
- describe the public-page rendering boundary and documented REST, OpenAPI, and MCP interfaces.

Direct-maintainer disclosure: I maintain Latchshot.

## Validation

- `pnpm check:frontmatter` passes;
- the repository website validator processes 2,580 entries and adds no error beyond the five already present on upstream `main` (normalized baseline and changed outputs have identical SHA-256);
- both `https://latchshot.fly.dev` and `https://latchshot.fly.dev/llms.txt` return HTTP 200;
- `git diff --check` passes;
- `data/websites.json` is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Latchshot documentation page with site metadata and an overview of its screenshot and PDF rendering API.
  * Included key focus areas and details about the `llms.txt` implementation to help AI assistants understand the service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->