### PR TITLE
Add Immersive Commons

### DIFF
--- a/packages/content/data/websites/immersive-commons-llms-txt.mdx
+++ b/packages/content/data/websites/immersive-commons-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Immersive Commons'
+description: 'Agent-native API for Floor 10 of Frontier Tower SF — one bearer token, three transports (REST, MCP, A2A), 138 tools.'
+website: 'https://www.immersivecommons.com'
+llmsUrl: 'https://www.immersivecommons.com/llms.txt'
+llmsFullUrl: 'https://www.immersivecommons.com/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-20'
+---
+
+# Immersive Commons
+
+Agent-native API for Floor 10 of Frontier Tower SF — one bearer token, three transports (REST, MCP, A2A), 138 tools.


### PR DESCRIPTION
Adds immersivecommons.com — the agent-native API for Immersive Commons, the members-run AI builder space on Floor 10 of Frontier Tower SF.

- llms.txt: https://www.immersivecommons.com/llms.txt
- llms-full.txt: https://www.immersivecommons.com/llms-full.txt

Both live; the surface behind them is 138 tools across REST, MCP (Streamable HTTP), and A2A with per-user device-code agent tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Immersive Commons” entry to the website directory.
  * Included its description, website links, category, publication date, and AI-readable content references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->