### PR TITLE
feat(community): add react-mediadrop to llms.txt hub

### DIFF
--- a/packages/content/data/websites/react-mediadrop-llms-txt.mdx
+++ b/packages/content/data/websites/react-mediadrop-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'react-mediadrop'
+description: 'A hooks-first, headless file uploader for React - drag-and-drop, validation, and a pluggable upload queue with progress, retry, and cancel support.'
+website: 'https://www.mediadrop.dev'
+llmsUrl: 'https://www.mediadrop.dev/docs/llms.txt'
+llmsFullUrl: 'https://www.mediadrop.dev/docs/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-20'
+---
+
+# react-mediadrop
+
+A hooks-first, headless file uploader for React - drag-and-drop, validation, and a pluggable upload queue with progress, retry, and cancel support.


### PR DESCRIPTION
This PR adds react-mediadrop to the llms.txt hub.

**Website:** https://www.mediadrop.dev
**llms.txt:** https://www.mediadrop.dev/docs/llms.txt
**llms-full.txt:** https://www.mediadrop.dev/docs/llms-full.txt  
**Category:** developer-tools

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new content page for react-mediadrop, including product details, website links, and a brief description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->