### PR TITLE
feat(community): add admintoolkit.io to llms.txt hub

### DIFF
--- a/packages/content/data/websites/admintoolkit-io-llms-txt.mdx
+++ b/packages/content/data/websites/admintoolkit-io-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'admintoolkit.io'
+description: 'Browser-based, read-only infrastructure diagnostics for DNS, email authentication, TLS, HTTP headers, certificates, subnets, and agent-readiness checks.'
+website: 'https://admintoolkit.io/'
+llmsUrl: 'https://admintoolkit.io/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-20'
+---
+
+# admintoolkit.io
+
+Browser-based, read-only infrastructure diagnostics for DNS, email authentication, TLS, HTTP headers, certificates, subnets, and agent-readiness checks.


### PR DESCRIPTION
## Summary

Adds admintoolkit.io to the `developer-tools` category. It provides browser-based, read-only infrastructure diagnostics and publishes a live `llms.txt`.

## Validation

- `https://admintoolkit.io/`: HTTP 200
- `https://admintoolkit.io/llms.txt`: HTTP 200, `text/markdown`
- one new `.mdx` file under `packages/content/data/websites/`
- `data/websites.json` unchanged

Maintainer disclosure: I maintain admintoolkit.io.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new directory entry for admintoolkit.io, including its title, description, website URL, category, and llms.txt link.
  * Added publication metadata and a rendered description for the new entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->