### PR TITLE
feat(community): add SaaSDossier to llms.txt hub

### DIFF
--- a/packages/content/data/websites/saasdossier-llms-txt.mdx
+++ b/packages/content/data/websites/saasdossier-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'SaaSDossier'
+description: 'SaaSDossier records vendor-published SaaS security evidence across 55 fields, with source links, hash seals, and buyer-ready follow-up questions.'
+website: 'https://saasdossier.com'
+llmsUrl: 'https://saasdossier.com/llms.txt'
+llmsFullUrl: 'https://saasdossier.com/llms-full.txt'
+category: 'security-identity'
+publishedAt: '2026-07-20'
+---
+
+# SaaSDossier
+
+SaaSDossier records vendor-published SaaS security evidence across 55 fields, with source links, hash seals, and buyer-ready follow-up questions.


### PR DESCRIPTION
This PR adds SaaSDossier to the llms.txt hub.

**Website:** https://saasdossier.com
**llms.txt:** https://saasdossier.com/llms.txt
**llms-full.txt:** https://saasdossier.com/llms-full.txt  
**Category:** security-identity

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new SaaSDossier directory page with its description, website links, category, and publication date.
  * Included access to both standard and full LLMS resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->