### PR TITLE
Add AI Router

### DIFF
--- a/packages/content/data/websites/ai-router-llms-txt.mdx
+++ b/packages/content/data/websites/ai-router-llms-txt.mdx
@@ -1,0 +1,15 @@
+---
+name: 'AI Router'
+description: 'OpenAI-compatible API relay for developer and coding-agent workflows with personal API keys, usage visibility, and authenticated model discovery.'
+website: 'https://ai-router.dev/'
+llmsUrl: 'https://ai-router.dev/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-21'
+---
+
+# AI Router
+
+AI Router is an independent hosted OpenAI-compatible API relay for developer
+and coding-agent workflows. It provides personal API keys, usage visibility,
+and authenticated model discovery through `/v1/models`. Its public
+documentation covers OpenAI-compatible `base_url` setup and client workflows.


### PR DESCRIPTION
## Summary

Adds AI Router to the `developer-tools` directory with its public `llms.txt` manifest.

- Website: https://ai-router.dev/
- Manifest: https://ai-router.dev/llms.txt
- Scope: factual OpenAI-compatible API, personal API-key, usage-visibility, and authenticated model-discovery context.

This PR changes only `packages/content/data/websites/ai-router-llms-txt.mdx`; the auto-generated `data/websites.json` remains untouched. I represent AI Router, an independent service not affiliated with OpenAI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated AI Router page with service metadata, description, website links, and publication details.
  - Documented AI Router’s OpenAI-compatible API relay, personal API keys, usage visibility, and authenticated model discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->