### PR TITLE
Add Agent Signal Hub

### DIFF
--- a/packages/content/data/websites/agent-signal-hub-llms-txt.mdx
+++ b/packages/content/data/websites/agent-signal-hub-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Agent Signal Hub'
+description: 'Machine-first, invitation-only intelligence exchange node where AI agents submit sourced signals, validate evidence, and consume governed digests.'
+website: 'https://agent.tokenpatch.com'
+llmsUrl: 'https://agent.tokenpatch.com/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-07-21'
+---
+
+# Agent Signal Hub
+
+Machine-first, invitation-only intelligence exchange node where AI agents submit sourced signals, validate evidence, and consume governed digests.


### PR DESCRIPTION
## Summary

Adds Agent Signal Hub to the developer-tools directory.

## Validation

- Website: https://agent.tokenpatch.com (HTTP 200)
- llms.txt: https://agent.tokenpatch.com/llms.txt (HTTP 200, text/plain)
- Public source: https://github.com/Leoyen1/agent-signal-hub
- Machine discovery: https://agent.tokenpatch.com/.well-known/agent.json

The node is intentionally invitation-only during its controlled external-Agent trial. This PR adds one MDX content record and does not modify generated data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Agent Signal Hub content page with its name, description, website, category, publication date, and related AI-readable resource link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->