### PR TITLE
feat: add Beyond Desk to websites directory

### DIFF
--- a/packages/content/data/websites/beyond-desk-llms-txt.mdx
+++ b/packages/content/data/websites/beyond-desk-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Beyond Desk'
+description: 'A ledger of real workspaces in the AI workday: real desk setups, a curated signal feed on agentic workstations, and the WDSF record.'
+website: 'https://beyond-desk.com'
+llmsUrl: 'https://beyond-desk.com/llms.txt'
+llmsFullUrl: 'https://beyond-desk.com/llms-full.txt'
+category: 'content-media'
+publishedAt: '2026-07-21'
+---
+
+# Beyond Desk
+
+A ledger of real workspaces in the AI workday — real desk setups, a curated signal feed on agentic workstations and workflows, and the Workspace Design Super Festival record. Machine outlets: a public read-only JSON API, RSS feeds, a full-text export of the curated signal layer, and an agent skill at /SKILL.md.


### PR DESCRIPTION
Adds Beyond Desk (https://beyond-desk.com) — a ledger of real workspaces in the AI workday: real desk setups, a curated signal feed on agentic workstations and workflows, and the Workspace Design Super Festival record.

- llms.txt: https://beyond-desk.com/llms.txt
- llms-full.txt: https://beyond-desk.com/llms-full.txt (full text of the curated signal layer, rebuilt on every deploy)
- Agent skill: https://beyond-desk.com/SKILL.md
- Category: content-media

Both llms URLs are live and return 200.

https://claude.ai/code/session_01TUGfwDHYFBqPn8cbYNdiiY

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added a new Beyond Desk directory entry with descriptive metadata.
  * Included links to its machine-readable, API, and feed endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->