### PR TITLE
Add team.management to the websites directory

### DIFF
--- a/packages/content/data/websites/team-management-llms-txt.mdx
+++ b/packages/content/data/websites/team-management-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'team.management'
+description: 'An open-source workflow protocol engine for Claude Code: it enforces discussion-before-implementation (DAIC), runs development through JSON-defined protocols, manages persistent tasks and context, and tracks issues across GitLab, Jira, GitHub, and Gitea.'
+website: 'https://team.management'
+llmsUrl: 'https://team.management/llms.txt'
+llmsFullUrl: 'https://team.management/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-21'
+---
+
+# team.management
+
+An open-source workflow protocol engine for Claude Code: it enforces discussion-before-implementation (DAIC), runs development through JSON-defined protocols, manages persistent tasks and context, and tracks issues across GitLab, Jira, GitHub, and Gitea.


### PR DESCRIPTION
Adds **team.management** — an open-source workflow protocol engine for Claude Code — to the websites directory.

- Website: https://team.management
- llms.txt: https://team.management/llms.txt
- llms-full.txt: https://team.management/llms-full.txt
- Category: `developer-tools`

Adds a single new file, `packages/content/data/websites/team-management-llms-txt.mdx`, following the template format. Did not touch the auto-generated `data/websites.json`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new directory page for team.management, including its description, category, publication date, and links to available content files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->