### PR TITLE
Update team.management description

### DIFF
--- a/packages/content/data/websites/team-management-llms-txt.mdx
+++ b/packages/content/data/websites/team-management-llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
 name: 'team.management'
-description: 'An open-source workflow protocol engine for Claude Code: it enforces discussion-before-implementation (DAIC), runs development through JSON-defined protocols, manages persistent tasks and context, and tracks issues across GitLab, Jira, GitHub, and Gitea.'
+description: 'Your AI says it''s done — and a more capable model only says it more convincingly. team.management is an open-source protocol engine for Claude Code that puts your AI on rails it can''t leave: it blocks the shortcuts, shows the work, and hands you the proof. Free, and it runs on the subscription you already pay for.'
 website: 'https://team.management'
 llmsUrl: 'https://team.management/llms.txt'
 llmsFullUrl: 'https://team.management/llms-full.txt'
@@ -10,4 +10,4 @@ publishedAt: '2026-07-21'
 
 # team.management
 
-An open-source workflow protocol engine for Claude Code: it enforces discussion-before-implementation (DAIC), runs development through JSON-defined protocols, manages persistent tasks and context, and tracks issues across GitLab, Jira, GitHub, and Gitea.
+Your AI says it's done — and a more capable model only says it more convincingly. team.management is an open-source protocol engine for Claude Code that puts your AI on rails it can't leave: it blocks the shortcuts, shows the work, and hands you the proof. Free, and it runs on the subscription you already pay for.


### PR DESCRIPTION
Updates the `team.management` entry description to the project's current wording. Single file, description text only — category, URLs, and format unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the `team.management` website description to emphasize that AI shows its work and provides proof.
  - Retained the site’s positioning as an open-source protocol engine for Claude Code.
  - Applied the updated messaging consistently across the website metadata and page content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->