### PR TITLE
feat(community): add Test-proxy-recorder to llms.txt hub

### DIFF
--- a/packages/content/data/websites/test-proxy-recorder-llms-txt.mdx
+++ b/packages/content/data/websites/test-proxy-recorder-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Test-proxy-recorder'
+description: 'VCR-style record & replay for Playwright. Capture real API responses once, replay them deterministically on CI without backend or manual mocks.'
+website: 'https://test-proxy-recorder.dev/'
+llmsUrl: 'https://test-proxy-recorder.dev/llms.txt'
+llmsFullUrl: 'https://test-proxy-recorder.dev/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-21'
+---
+
+# Test-proxy-recorder
+
+VCR-style record & replay for Playwright. Capture real API responses once, replay them deterministically on CI without backend or manual mocks.


### PR DESCRIPTION
This PR adds Test-proxy-recorder to the llms.txt hub.

**Website:** https://test-proxy-recorder.dev/
**llms.txt:** https://test-proxy-recorder.dev/llms.txt
**llms-full.txt:** https://test-proxy-recorder.dev/llms-full.txt  
**Category:** developer-tools

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new website entry for Test-proxy-recorder.
  * Included a description of its VCR-style record/replay capabilities for Playwright.
  * Added relevant metadata, resource links, category, and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->