### PR TITLE
feat(community): add Live Tennis API

### DIFF
--- a/packages/content/data/websites/live-tennis-api-llms-txt.mdx
+++ b/packages/content/data/websites/live-tennis-api-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'Live Tennis API'
+description: 'Real-time tennis scores, players, fixtures and model win-probability for ATP, WTA, Challenger and ITF, over REST and WebSocket.'
+website: 'https://livetennisapi.com'
+llmsUrl: 'https://livetennisapi.com/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-21'
+---
+
+# Live Tennis API
+
+Live Tennis API is a read-only HTTP API for professional tennis data. It covers live and upcoming matches, point-by-point scores, players and rankings, and a forward fixture schedule across ATP, WTA, Challenger and ITF — singles and doubles — plus a model-driven win-probability for tracked matches.
+
+## Key Focus Areas
+
+- Real-time match scores and state
+- Players, rankings and cached season statistics
+- Forward fixture schedule
+- Model win-probability
+
+## About llms.txt Implementation
+
+The llms.txt enumerates every endpoint with its minimum plan, the base URL, the authentication scheme, and the response envelope, so an agent can construct a valid call without fetching the full reference. A complete OpenAPI 3.1 specification and a server-rendered HTML reference are published at docs.livetennisapi.com, and official MIT-licensed clients exist for JavaScript and Python alongside an MCP server.


### PR DESCRIPTION
Adds **Live Tennis API** to the directory.

A read-only HTTP API for professional tennis — live and upcoming matches, point-by-point scores, players and rankings, and a forward fixture schedule across ATP, WTA, Challenger and ITF, plus a model-driven win-probability for tracked matches.

- **Site:** <https://livetennisapi.com>
- **llms.txt:** <https://livetennisapi.com/llms.txt> (HTTP 200)
- **Category:** `developer-tools`
- **Docs:** <https://docs.livetennisapi.com> — OpenAPI 3.1 + a server-rendered HTML reference

A single new `.mdx` under `packages/content/data/websites/`. I did **not** touch `data/websites.json`, per the note in CONTRIBUTING.md that it is auto-generated.

`llmsFullUrl` is omitted deliberately — we don't publish a genuine `llms-full.txt` (the path only redirects), and ~750 existing entries omit it, so I'd rather leave it out than point at something that doesn't resolve.

**Disclosure:** I maintain this API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Live Tennis API documentation page.
  * Included key API details, including available endpoints, plan requirements, base URL, authentication, response format, and links to related resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->