### PR TITLE
feat(community): add Daniel Yoon to llms.txt hub

### DIFF
--- a/packages/content/data/websites/daniel-yoon-llms-txt.mdx
+++ b/packages/content/data/websites/daniel-yoon-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Daniel Yoon'
+description: 'Real Estate Agent Daniel Yoon of Greater Richmond VA. ABR & SRS designated agent helping buyers and sellers across Greater Richmond. Bilingual in Korean.'
+website: 'HTTPS://www.danielyoonrealty.com'
+llmsUrl: 'https://www.danielyoonrealty.com/llms.txt'
+llmsFullUrl: 'https://www.danielyoonrealty.com/llms-full.txt'
+category: 'agency-services'
+publishedAt: '2026-07-21'
+---
+
+# Daniel Yoon
+
+Real Estate Agent Daniel Yoon of Greater Richmond VA. ABR & SRS designated agent helping buyers and sellers across Greater Richmond. Bilingual in Korean.


### PR DESCRIPTION
This PR adds Daniel Yoon to the llms.txt hub.

**Website:** HTTPS://www.danielyoonrealty.com
**llms.txt:** https://www.danielyoonrealty.com/llms.txt
**llms-full.txt:** https://www.danielyoonrealty.com/llms-full.txt  
**Category:** agency-services

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added a new website profile page for Daniel Yoon.
  * Included website and LLMS endpoint metadata, content categorization, publication date, and a descriptive overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->