### PR TITLE
feat(content): add Lumi & Friends iOS App Guide

### DIFF
--- a/packages/content/data/websites/lumi-ios-app-guide-llms-txt.mdx
+++ b/packages/content/data/websites/lumi-ios-app-guide-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Lumi & Friends iOS App Guide'
+description: 'Publisher-disclosed, multilingual directory of 28 verified live independent iPhone and iPad apps, with privacy and purchase-model facts, direct App Store links, and localized guides across all 50 Apple locales.'
+website: 'https://alice51849.github.io/ios-app-guide/'
+llmsUrl: 'https://alice51849.github.io/ios-app-guide/llms.txt'
+llmsFullUrl: 'https://alice51849.github.io/ios-app-guide/llms-full.txt'
+category: 'personal'
+publishedAt: '2026-07-21'
+---
+
+# Lumi & Friends iOS App Guide
+
+Lumi & Friends is a publisher-disclosed directory of verified live independent iOS apps. It provides localized guides, privacy and purchase-model facts stated per app, and direct App Store links without presenting the publisher catalog as an independent ranking.


### PR DESCRIPTION
## Summary

Adds the publisher-disclosed Lumi & Friends iOS App Guide to the `personal` directory.

The guide covers 28 verified live independent iPhone and iPad apps across all 50 Apple locales. Its AI-readable indexes state privacy and purchase-model facts per app, link directly to each live App Store listing, and explicitly avoid presenting first-party catalog evidence as an independent ranking.

## Live endpoints

- Website: https://alice51849.github.io/ios-app-guide/
- `llms.txt`: https://alice51849.github.io/ios-app-guide/llms.txt
- `llms-full.txt`: https://alice51849.github.io/ios-app-guide/llms-full.txt

All three endpoints return HTTP 200. App availability is refreshed against Apple's public lookup service, and unavailable apps are omitted from the generated indexes.

## Validation

- `pnpm check:frontmatter lumi-ios-app-guide-llms-txt.mdx` passed
- `git diff --check` passed
- `pnpm check:websites` adds no errors compared with the current upstream baseline; the same two legacy filename errors and three duplicate-URL groups are present before and after this one-entry change
- Repository, open issues, pull requests, and generated data checked for an existing Lumi or `ios-app-guide` entry

Disclosure: I maintain the guide and the first-party apps represented in it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a directory page for verified independent iOS apps.
  * Includes localized guides, app details, and direct App Store links.
  * Added metadata and links to the directory’s standard and full content formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->