### PR TITLE
feat(community): add helpers4 to llms.txt hub

### DIFF
--- a/packages/content/data/websites/helpers4-llms-txt.mdx
+++ b/packages/content/data/websites/helpers4-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'helpers4'
+description: 'Open-source dev tooling: tree-shakable TypeScript utilities, DevContainer Features, and reusable GitHub Actions. Zero dependencies, LGPL-3.0.'
+website: 'https://helpers4.dev'
+llmsUrl: 'https://helpers4.dev/llms.txt'
+llmsFullUrl: 'ttps://helpers4.dev/typescript/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-21'
+---
+
+# helpers4
+
+Open-source dev tooling: tree-shakable TypeScript utilities, DevContainer Features, and reusable GitHub Actions. Zero dependencies, LGPL-3.0.


### PR DESCRIPTION
This PR adds helpers4 to the llms.txt hub.

**Website:** https://helpers4.dev
**llms.txt:** https://helpers4.dev/llms.txt
**llms-full.txt:** ttps://helpers4.dev/typescript/llms-full.txt  
**Category:** developer-tools

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new helpers4 website entry with descriptive metadata and links.
  * Added a dedicated helpers4 page featuring its name and tagline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->