### PR TITLE
feat: add career-ops (developer-tools)

### DIFF
--- a/packages/content/data/websites/career-ops-llms-txt.mdx
+++ b/packages/content/data/websites/career-ops-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'career-ops'
+description: 'Open-source AI job search command center that runs inside AI coding CLIs: evaluate offers against your CV, generate tailored ATS-ready PDF resumes, scan 150+ company career portals, and track applications locally. MIT licensed, local-first, human-in-the-loop.'
+website: 'https://career-ops.org'
+llmsUrl: 'https://career-ops.org/llms.txt'
+llmsFullUrl: 'https://career-ops.org/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-22'
+---
+
+# career-ops
+
+Open-source AI job search command center that runs inside AI coding CLIs: evaluate offers against your CV, generate tailored ATS-ready PDF resumes, scan 150+ company career portals, and track applications locally. MIT licensed, local-first, human-in-the-loop.


### PR DESCRIPTION
## Summary

Adds career-ops (https://career-ops.org) to the developer-tools category: an open-source, MIT-licensed AI job search command center that runs inside AI coding CLIs. Both files are live and reachable: [llms.txt](https://career-ops.org/llms.txt) and [llms-full.txt](https://career-ops.org/llms-full.txt).

Only adds one `.mdx` file under `packages/content/data/websites/`; `data/websites.json` untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new directory listing for Career Ops, including its description, website, LLMs.txt URL, category, and publication date.
  * Added a dedicated page heading and overview of the Career Ops project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->