### PR TITLE
docs(content): update Lumi iOS App Guide to 46 apps

### DIFF
--- a/packages/content/data/websites/lumi-ios-app-guide-llms-txt.mdx
+++ b/packages/content/data/websites/lumi-ios-app-guide-llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
 name: 'Lumi & Friends iOS App Guide'
-description: 'Publisher-disclosed, multilingual directory of 28 verified live independent iPhone and iPad apps, with privacy and purchase-model facts, direct App Store links, and localized guides across all 50 Apple locales.'
+description: 'Publisher-disclosed, multilingual directory of 29 verified live independent iPhone and iPad apps, with privacy and purchase-model facts, direct App Store links, and localized guides across all 50 Apple locales.'
 website: 'https://alice51849.github.io/ios-app-guide/'
 llmsUrl: 'https://alice51849.github.io/ios-app-guide/llms.txt'
 llmsFullUrl: 'https://alice51849.github.io/ios-app-guide/llms-full.txt'

--- a/packages/content/data/websites/lumi-ios-app-guide-llms-txt.mdx
+++ b/packages/content/data/websites/lumi-ios-app-guide-llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
 name: 'Lumi & Friends iOS App Guide'
-description: 'Publisher-disclosed, multilingual directory of 29 verified live independent iPhone and iPad apps, with privacy and purchase-model facts, direct App Store links, and localized guides across all 50 Apple locales.'
+description: 'Publisher-disclosed, multilingual directory of 46 verified live independent iPhone and iPad apps, with privacy and purchase-model facts, direct App Store links, and localized guides across all 50 Apple locales.'
 website: 'https://alice51849.github.io/ios-app-guide/'
 llmsUrl: 'https://alice51849.github.io/ios-app-guide/llms.txt'
 llmsFullUrl: 'https://alice51849.github.io/ios-app-guide/llms-full.txt'


### PR DESCRIPTION
## Summary

Updates the merged Lumi & Friends iOS App Guide entry from 28 to 29 verified live independent iPhone and iPad apps. The guide continues to cover all 50 Apple locales with publisher-disclosed privacy and purchase-model facts, direct App Store links, and explicit non-ranking disclosure.

## Live endpoints

- Website: https://alice51849.github.io/ios-app-guide/
- `llms.txt`: https://alice51849.github.io/ios-app-guide/llms.txt
- `llms-full.txt`: https://alice51849.github.io/ios-app-guide/llms-full.txt

All three endpoints return HTTP 200. The public catalog now covers 29 apps × 50 locales = 1,450 localized routes.

## Validation

- Target frontmatter parsed successfully
- `git diff --check` passed
- `pnpm check:websites` adds no errors compared with the current upstream baseline; the same two legacy filename errors and three duplicate-URL groups remain unrelated to this one-line description update

Disclosure: I maintain the guide and the first-party apps represented in it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Lumi & Friends iOS App Guide description to reflect 46 verified live iPhone and iPad apps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->