### PR TITLE
Add Thisispaper

### DIFF
--- a/packages/content/data/websites/thisispaper-llms-txt.mdx
+++ b/packages/content/data/websites/thisispaper-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Thisispaper'
+description: 'Independent architecture and design publication. 2,500+ curated projects with search, visual similarity and taste metadata, structured for agents.'
+website: 'https://www.thisispaper.com'
+llmsUrl: 'https://www.thisispaper.com/llms.txt'
+category: 'content-media'
+publishedAt: '2026-07-22'
+---
+
+# Thisispaper
+
+Thisispaper is an independent architecture, design, photography and art publication. Every project in the archive was selected by human editors since 2011. The archive of 2,500+ curated projects is available to agents through a public API and an MCP server: ranked search, visual similarity, and full project metadata with material, light, mood and composition tags.
+
+## Key Focus Areas
+
+- Curated architecture, design, photography and art projects
+- Visual similarity search (precomputed SigLIP neighbours)
+- Taste metadata: material, light, mood and composition tags
+- MCP server at https://www.thisispaper.com/intelligence/api/mcp
+- Free API tier, 200 calls/month, no signup to try
+
+## About llms.txt Implementation
+
+The root llms.txt describes the publication and its sections. A second llms.txt at /intelligence/llms.txt documents the Intelligence API surface for agents: REST endpoints, the MCP server, authentication, and the free tier. Full API docs live at https://www.thisispaper.com/intelligence/api-docs


### PR DESCRIPTION
Adds Thisispaper, an independent architecture and design publication (est. 2011).

- Website: https://www.thisispaper.com
- llms.txt: https://www.thisispaper.com/llms.txt (root, canonical) and https://www.thisispaper.com/intelligence/llms.txt (Intelligence API surface)
- Category: content-media
- 2,500+ human-curated projects, available to agents via a public API and MCP server (free tier, docs at https://www.thisispaper.com/intelligence/api-docs)

Entry added as packages/content/data/websites/thisispaper-llms-txt.mdx per CONTRIBUTING (did not touch the auto-generated data/websites.json).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry documenting the Thisispaper publication and its available AI resources.
  * Included details about the publication’s sections, Intelligence API, REST endpoints, MCP server, authentication, free tier, and API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->