### PR TITLE
Add Ansvar Systems website

### DIFF
--- a/packages/content/data/websites/ansvar-systems-llms-txt.mdx
+++ b/packages/content/data/websites/ansvar-systems-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'Ansvar Systems'
+description: 'Cited legal answers for AI agents: an MCP gateway serving European and US laws, regulations, and standards with paragraph-level citations.'
+website: 'https://ansvar.eu'
+llmsUrl: 'https://ansvar.eu/llms.txt'
+category: 'security-identity'
+publishedAt: '2026-07-23'
+---
+
+# Ansvar Systems
+
+Ansvar Systems operates gateway.ansvar.eu, an MCP gateway that connects AI agents (Claude, Copilot, ChatGPT) to European and US laws, regulations, and standards — 46 live jurisdictions with paragraph-level citations to the official publisher. Built-in compliance workflows cover threat modeling, DPIA, and NIS2/DORA/CRA gap analysis.
+
+## Key Focus Areas
+
+- Legal and regulatory search over MCP (OAuth 2.1) with citations to official publishers
+- EU regulations (GDPR, NIS2, DORA, CRA, AI Act) plus national law across 46 jurisdictions
+- Compliance workflows: threat modeling, DPIA, gap analysis with audit-ready output
+- Accuracy over availability: unavailable sources return errors, never uncited answers
+
+## About llms.txt Implementation
+
+The llms.txt at ansvar.eu documents the product surface, documentation, coverage pages per jurisdiction, and connection instructions, so AI assistants can accurately answer questions about the gateway and route users to the right docs.


### PR DESCRIPTION
Adds ansvar.eu (Ansvar Systems — MCP gateway for cited legal/regulatory data, category security-identity).

- llms.txt live at https://ansvar.eu/llms.txt (200, plain text, follows the spec)
- Entry follows the schema rules (name ≤30 chars, description 50–160 chars ending with a period)
- No llms-full.txt (field omitted)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a content page for Ansvar Systems.
  * Documented its MCP gateway, legal and regulatory resources, paragraph-level citations, key focus areas, and `llms.txt` documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->