### PR TITLE
Add Travvy llms.txt listing

### DIFF
--- a/packages/content/data/websites/travvy-llms-txt.mdx
+++ b/packages/content/data/websites/travvy-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'Travvy'
+description: 'AI travel app for planning trips and creating self-guided city tours with routes, audio guides, local tips, offline access, and on-trip changes.'
+website: 'https://gettravvy.com/es/'
+llmsUrl: 'https://gettravvy.com/llms.txt'
+category: 'international'
+publishedAt: '2026-07-23'
+---
+
+# Travvy
+
+Travvy helps travelers plan trips and create self-guided city tours with personalized routes, audio guides, local tips, offline access, and flexible on-trip changes. The Spanish-language product entry is available at https://gettravvy.com/es/, with iOS and Android download links on the site.


### PR DESCRIPTION
## Summary

- Adds Travvy as an international AI travel app with a public llms.txt endpoint.
- Points the website field to Travvy's Spanish-language product entry for travelers in Spain.

## Validation

- Confirmed https://gettravvy.com/llms.txt returns HTTP 200 with current product and localized-page links.
- Previewed the MDX frontmatter and kept the change to one new file under packages/content/data/websites/.

## Disclosure

I am Travvy's founder-operator and am submitting the product I operate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Spanish-language Travvy product page.
  * Highlights trip planning, self-guided city tours, audio guides, local recommendations, offline access, and itinerary updates during travel.
  * Includes product details, category information, publication date, website link, and mobile download links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->