### PR TITLE
Add LLM Latency Tracker

### DIFF
--- a/packages/content/data/websites/llm-latency-tracker-llms-txt.mdx
+++ b/packages/content/data/websites/llm-latency-tracker-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'LLM Latency Tracker'
+description: 'Independent, provider-neutral latency & uptime for ~45 AI inference APIs, measured from 4 regions. Free, open data (CC-BY-4.0) with a JSON API and an MCP server.'
+website: 'https://llmlatency.dev'
+llmsUrl: 'https://llmlatency.dev/llms.txt'
+llmsFullUrl: 'https://llmlatency.dev/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-23'
+---
+
+# LLM Latency Tracker
+
+Independent, provider-neutral latency and uptime for ~45 AI inference APIs, measured (not scraped) from four regions. Free, open data (CC-BY-4.0) with a JSON API and an MCP server.


### PR DESCRIPTION
Adds **LLM Latency Tracker** (https://llmlatency.dev) to the llms.txt directory.

It publishes `llms.txt` and `llms-full.txt`, plus an independent, provider-neutral dataset of latency & uptime for ~45 AI inference APIs measured from 4 regions (free, CC-BY-4.0), a JSON API, and an MCP server.

- llms.txt: https://llmlatency.dev/llms.txt
- llms-full.txt: https://llmlatency.dev/llms-full.txt

New file: `packages/content/data/websites/llm-latency-tracker-llms-txt.mdx` · category `developer-tools`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new “LLM Latency Tracker” resource page with its description, website links, category, and publication details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->