### PR TITLE
feat: add getpeppr to llms.txt hub

### DIFF
--- a/packages/content/data/websites/getpeppr-llms-txt.mdx
+++ b/packages/content/data/websites/getpeppr-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'getpeppr'
+description: 'Developer-first Peppol e-invoicing. Send invoices as JSON via a TypeScript SDK or REST API — getpeppr handles UBL/BIS 3.0 generation, validation, and Peppol network delivery.'
+website: 'https://getpeppr.dev'
+llmsUrl: 'https://getpeppr.dev/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-07-24'
+---
+
+# getpeppr
+
+getpeppr is a developer-first gateway to the Peppol e-invoicing network. Send invoices as JSON via the TypeScript SDK (`@getpeppr/sdk`) or REST API — getpeppr generates compliant UBL/BIS 3.0 XML, validates it against business rules, and delivers it through Peppol. Includes a CLI, sandbox environment, webhooks for delivery status, and full developer docs.


### PR DESCRIPTION
## Summary

Adds getpeppr (https://getpeppr.dev) — developer-first Peppol e-invoicing (TypeScript SDK + REST API) — to the directory under `developer-tools`. llms.txt is live at https://getpeppr.dev/llms.txt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0159WMBTkdAeYuSVHGPJcJVy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new getpeppr entry to the website directory.
  * Included service details, supported integrations, Peppol capabilities, developer tools, and documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->