### PR TITLE
Add iSimplifyMe (isimplifyme.com)

### DIFF
--- a/packages/content/data/websites/isimplifyme-llms-txt.mdx
+++ b/packages/content/data/websites/isimplifyme-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'iSimplifyMe'
+description: 'AI orchestration infrastructure and answer-engine optimization for regulated and mid-market enterprises — production AI on AWS Bedrock, publisher of The AEO Standard.'
+website: 'https://isimplifyme.com'
+llmsUrl: 'https://isimplifyme.com/llms.txt'
+category: 'ai-ml'
+priority: 'medium'
+publishedAt: '2026-07-25'
+---
+
+# iSimplifyMe
+
+iSimplifyMe builds AI orchestration infrastructure for regulated and mid-market enterprises — production AI systems on AWS Bedrock — and publishes The AEO Standard, a versioned 100-point Answer Engine Optimization rubric, alongside open engineering whitepapers and labs dossiers.
+
+## Key Focus Areas
+
+- AI Infrastructure & Orchestration (AWS Bedrock)
+- Answer Engine Optimization — The AEO Standard
+- Engineering whitepapers and labs dossiers
+
+## About llms.txt Implementation
+
+iSimplifyMe provides an `llms.txt` file with an AI-readable index of its services, whitepapers, labs dossiers, and blog content.


### PR DESCRIPTION
Adds iSimplifyMe via the manual-PR flow (Option 3): one new MDX entry in `packages/content/data/websites`, category `ai-ml`. The llms.txt is live at https://isimplifyme.com/llms.txt (HTTP 200; no llms-full.txt, so none is claimed).

Disclosure: I'm affiliated with iSimplifyMe — self-submission per the contribution options. Happy to adjust category or wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new website entry for iSimplifyMe.
  * Included its description, URL, category, priority, publication date, and llms.txt information.
  * Added an overview of iSimplifyMe’s key focus areas and implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->