### PR TITLE
fix: align llms.txt Generator listing with live Actor

### DIFF
--- a/packages/content/data/websites/ai-rag-llms-txt-monitor-llms-txt.mdx
+++ b/packages/content/data/websites/ai-rag-llms-txt-monitor-llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
-name: 'AI/RAG llms.txt Monitor'
-description: 'Pay-per-result Apify Actor that generates review-ready llms.txt files, site manifests, and page-change reports across repeat runs.'
+name: 'llms.txt Generator on Apify'
+description: 'Pay-per-result Apify Actor that crawls public same-domain pages and generates review-ready llms.txt, optional llms-full.txt, and an exportable per-page dataset.'
 website: 'https://cekuu35.github.io/llms-txt-generator/'
 llmsUrl: 'https://cekuu35.github.io/llms.txt'
 llmsFullUrl: ''
@@ -8,18 +8,18 @@ category: 'developer-tools'
 publishedAt: '2026-07-25'
 ---
 
-# AI/RAG llms.txt Monitor
+# llms.txt Generator on Apify
 
-A public landing page for a bounded, pay-per-result Apify Actor that generates review-ready `llms.txt` and optional `llms-full.txt` files from public pages. It also produces a per-page inventory, normalized metadata, SHA-256 content fingerprints, and a comparable change report for later successful runs.
+A public landing page for a pay-per-result Apify Actor that crawls public same-domain pages and generates review-ready `llms.txt` and optional `llms-full.txt` files. Each processed page is also written to an exportable dataset with its URL, title, description, and content size.
 
 ## Key Focus Areas
 
+- Bounded same-domain crawling through the `maxPages` input
 - Reviewable `llms.txt` and optional `llms-full.txt` outputs
-- Public-page inventory with normalized URLs and metadata
-- Hashed manifests for repeatable comparisons
-- Added, changed, unchanged, and possible-removal reporting
-- Bounded crawl inputs and human review before publication
+- Per-page dataset exportable as JSON or CSV
+- Batch and API use through Apify
+- Human review before publishing generated files
 
 ## About llms.txt Implementation
 
-The root `llms.txt` describes the current public product and developer surfaces. The Actor checks public pages only, can respect `robots.txt`, and does not bypass authentication. `llms.txt` is an emerging optional convention; neither the landing page nor the Actor guarantees rankings, AI citations, traffic, conversions, or revenue.
+The root `llms.txt` describes the current public product and developer surfaces. The Actor processes public pages and does not bypass authentication. `llms.txt` is an emerging optional convention; neither the landing page nor the Actor guarantees rankings, AI citations, traffic, conversions, or revenue.

--- a/packages/content/data/websites/ai-rag-llms-txt-monitor-llms-txt.mdx
+++ b/packages/content/data/websites/ai-rag-llms-txt-monitor-llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
-name: 'AI/RAG Readiness & llms.txt Change Monitor'
-description: 'Public landing page for a pay-per-result Apify Actor that generates review-ready llms.txt and llms-full.txt files, creates hashed site manifests, and reports page changes across repeat runs.'
+name: 'AI/RAG llms.txt Monitor'
+description: 'Pay-per-result Apify Actor that generates review-ready llms.txt files, site manifests, and page-change reports across repeat runs.'
 website: 'https://cekuu35.github.io/llms-txt-generator/'
 llmsUrl: 'https://cekuu35.github.io/llms.txt'
 llmsFullUrl: ''
@@ -8,9 +8,9 @@ category: 'developer-tools'
 publishedAt: '2026-07-25'
 ---
 
-# AI/RAG Readiness & llms.txt Change Monitor
+# AI/RAG llms.txt Monitor
 
-A public landing page for a bounded, pay-per-result Apify Actor that generates review-ready `llms.txt` and optional `llms-full.txt` files from public site pages. It also produces a per-page inventory, normalized metadata, SHA-256 content fingerprints, and a comparable change report for later successful runs.
+A public landing page for a bounded, pay-per-result Apify Actor that generates review-ready `llms.txt` and optional `llms-full.txt` files from public pages. It also produces a per-page inventory, normalized metadata, SHA-256 content fingerprints, and a comparable change report for later successful runs.
 
 ## Key Focus Areas
 

--- a/packages/content/data/websites/ai-rag-readiness-llms-txt-change-monitor.mdx
+++ b/packages/content/data/websites/ai-rag-readiness-llms-txt-change-monitor.mdx
@@ -1,0 +1,25 @@
+---
+name: 'AI/RAG Readiness & llms.txt Change Monitor'
+description: 'Public landing page for a pay-per-result Apify Actor that generates review-ready llms.txt and llms-full.txt files, creates hashed site manifests, and reports page changes across repeat runs.'
+website: 'https://cekuu35.github.io/llms-txt-generator/'
+llmsUrl: 'https://cekuu35.github.io/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-07-25'
+---
+
+# AI/RAG Readiness & llms.txt Change Monitor
+
+A public landing page for a bounded, pay-per-result Apify Actor that generates review-ready `llms.txt` and optional `llms-full.txt` files from public site pages. It also produces a per-page inventory, normalized metadata, SHA-256 content fingerprints, and a comparable change report for later successful runs.
+
+## Key Focus Areas
+
+- Reviewable `llms.txt` and optional `llms-full.txt` outputs
+- Public-page inventory with normalized URLs and metadata
+- Hashed manifests for repeatable comparisons
+- Added, changed, unchanged, and possible-removal reporting
+- Bounded crawl inputs and human review before publication
+
+## About llms.txt Implementation
+
+The root `llms.txt` describes the current public product and developer surfaces. The Actor checks public pages only, can respect `robots.txt`, and does not bypass authentication. `llms.txt` is an emerging optional convention; neither the landing page nor the Actor guarantees rankings, AI citations, traffic, conversions, or revenue.


### PR DESCRIPTION
## What changed

- Renames the entry to match the live Apify Actor.
- Removes unsupported claims about manifests, SHA-256 fingerprints, and repeat-run change reports.
- Describes only the currently verified outputs: `llms.txt`, optional `llms-full.txt`, and the exportable per-page dataset.

## Verification

- Live Actor: https://apify.com/nacred_corner/llms-txt-generator
- Current public pricing: from $5 / 1,000 results
- Landing page: https://cekuu35.github.io/llms-txt-generator/

No ranking, citation, traffic, conversion, or revenue outcome is claimed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a landing page for the llms.txt Generator on Apify.
  * Describes same-domain website crawling, generation of `llms.txt` and optional `llms-full.txt` files, and per-page dataset exports.
  * Includes guidance on llms.txt conventions, ranking, citations, and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->