### PR TITLE
Add AI Visibility Check to llms.txt hub

### DIFF
--- a/packages/content/data/websites/ai-visibility-check-llms-txt.mdx
+++ b/packages/content/data/websites/ai-visibility-check-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'AI Visibility Check'
+description: 'Free, no-signup browser tool that checks whether GPTBot, ClaudeBot, PerplexityBot and other AI crawlers can actually read a site — llms.txt, robots.txt AI-crawler policy, structured data, and no-JS legibility, scored out of 100.'
+website: 'https://alexander-k-eliot.github.io/ai-visibility-check-free/'
+llmsUrl: 'https://alexander-k-eliot.github.io/ai-visibility-check-free/llms.txt'
+category: 'ai-ml'
+publishedAt: '2026-07-25'
+---
+
+# AI Visibility Check
+
+A free, browser-based audit that runs nine machine-readability checks against any public homepage: llms.txt presence, robots.txt AI-crawler policy (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, and others by name), schema.org structured data, XML sitemap, no-JS legibility, and more. No signup, nothing stored, runs entirely client-side.
+
+## Key Focus Areas
+
+- llms.txt and llms-full.txt presence checks
+- robots.txt AI-crawler policy, checked per named bot
+- schema.org structured data detection
+- No-JS legibility (can an agent read the page without executing scripts)
+- A free generator that produces real llms.txt, agents.md, JSON-LD, and a robots.txt patch from a site's actual content
+
+## About llms.txt Implementation
+
+The tool's own site publishes a real llms.txt at the URL above, indexing its free checker, generator, and a set of published AI-visibility benchmarks across multiple industries (SaaS, dental, financial services, and more), each run with the same real, server-side audit engine.


### PR DESCRIPTION
Free, no-signup browser tool that checks whether GPTBot, ClaudeBot, PerplexityBot and other AI crawlers can read a site (llms.txt, robots.txt AI-crawler policy, structured data, no-JS legibility), scored out of 100. Real, working llms.txt at the linked URL.

Adds the AI Visibility Check tool as a real, working llms.txt implementation.
> **Note:** `data/websites.json` is auto-generated. Do not edit it -- PRs that modify it will be blocked. Only add or edit `.mdx` files under `packages/content/data/websites/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a website entry for AI Visibility Check.
  * Included details about its AI visibility checks, including `llms.txt`, bot access policies, structured data, and no-JavaScript readability.
  * Added metadata and a link to the tool’s published `llms.txt` file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->