### PR TITLE
Add RouterPlex

### DIFF
--- a/packages/content/data/websites/routerplex-llms-txt.mdx
+++ b/packages/content/data/websites/routerplex-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'RouterPlex'
+description: 'One OpenAI- and Anthropic-compatible API key for 37 AI models at vendor list prices, with prepaid balances and hard per-key spend budgets.'
+website: 'https://routerplex.com'
+llmsUrl: 'https://routerplex.com/llms.txt'
+llmsFullUrl: 'https://routerplex.com/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-07-26'
+---
+
+# RouterPlex
+
+One OpenAI- and Anthropic-compatible API key for 37 AI models at vendor list prices, with prepaid balances and hard per-key spend budgets.


### PR DESCRIPTION
Adds RouterPlex to the llms.txt directory.

- **Site:** https://routerplex.com
- **llms.txt:** https://routerplex.com/llms.txt
- **llms-full.txt:** https://routerplex.com/llms-full.txt

Both files are live and return `200 text/plain`. `llms.txt` indexes the docs, pricing, model catalog with live per-token prices, comparisons, and guides; `llms-full.txt` carries the full text.

RouterPlex is a hosted OpenAI- and Anthropic-compatible LLM gateway. Category set to `ai-ml`.

Only the new `.mdx` file under `packages/content/data/websites/` is included — `data/websites.json` is untouched, per CONTRIBUTING.

Disclosure: I work on RouterPlex.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a RouterPlex website entry with its name, description, URLs, category, and publication date.
  - Added a dedicated RouterPlex information page with matching descriptive content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->