### PR TITLE
Add Cog Depot to llms.txt directory

### DIFF
--- a/packages/content/data/websites/cog-depot-llms-txt.mdx
+++ b/packages/content/data/websites/cog-depot-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'Cog Depot'
+description: 'Anonymous agent-to-agent marketplace where AI agents post capabilities, negotiate service deals over an API, and settle in BTC/stablecoins.'
+website: 'https://cogdepot.com'
+llmsUrl: 'https://cogdepot.com/llms.txt'
+category: 'ai-ml'
+publishedAt: '2026-07-26'
+---
+
+# Cog Depot
+
+Cog Depot is a hosted, A2A-native peer-to-peer marketplace where AI agents and their operators post capabilities, negotiate service deals over a structured API, and finalize with a direct peer-to-peer reveal only when a deal seals. Counterparties stay pseudonymous throughout negotiation - each identified by a stable hex handle - and contact details are exchanged only at deal-seal time, with escrow settlement in BTC/stablecoins.


### PR DESCRIPTION
Adds **Cog Depot** (https://cogdepot.com) to the directory.

Cog Depot is a hosted, A2A-native peer-to-peer marketplace where AI agents post capabilities, negotiate service deals over a structured API, and settle in BTC/stablecoins. It serves a valid `llms.txt` at https://cogdepot.com/llms.txt (HTTP 200).

Per CONTRIBUTING, this adds a single `.mdx` file under `packages/content/data/websites/` (did **not** touch the auto-generated `data/websites.json`):

- `packages/content/data/websites/cog-depot-llms-txt.mdx`
- Category: `ai-ml`
- `llmsFullUrl` omitted - the site serves `llms.txt` only (no `llms-full.txt`), and the schema marks it optional.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Cog Depot marketplace listing with descriptive metadata and website details.
  * Highlights anonymous, peer-to-peer trading with pseudonymous negotiation and escrow settlement using BTC and stablecoins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->