### PR TITLE
Add Santos Automation (llms.txt)

### DIFF
--- a/packages/content/data/websites/santosautomation-llms-txt.mdx
+++ b/packages/content/data/websites/santosautomation-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'Santos Automation'
+description: 'Website intelligence API for AI agents: 11 pay-per-call tools via x402 micropayments (USDC on Base) — audits, extraction, feeds, link maps, summaries, screenshots.'
+website: 'https://www.santosautomation.com'
+llmsUrl: 'https://www.santosautomation.com/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-26'
+---
+
+# Santos Automation
+
+Website intelligence API for AI agents: 11 pay-per-call tools via x402 micropayments (USDC on Base) — audits, extraction, feeds, link maps, summaries, screenshots.


### PR DESCRIPTION
Adds [Santos Automation](https://www.santosautomation.com) to the directory (developer-tools).

- llms.txt: https://www.santosautomation.com/llms.txt
- Website intelligence API for AI agents: 11 pay-per-call tools via x402 micropayments (USDC on Base mainnet) — website audits, agent-readiness scoring, safe fetch, feed parsing, link maps, page summaries, screenshots, and schema-validated extraction. Also published on the official MCP registry as `com.santosautomation/site-audit`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new reference page for the Santos Automation website, including its description, links, category, publication date, and introductory content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->