### PR TITLE
feat(community): add Get Storefront Token to llms.txt hub

### DIFF
--- a/packages/content/data/websites/get-storefront-token-llms-txt.mdx
+++ b/packages/content/data/websites/get-storefront-token-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Get Storefront Token'
+description: 'Get a permanent Shopify Storefront API token on real merchant stores.'
+website: 'https://github.com/devnazir/get-storefront-token/tree/main'
+llmsUrl: 'https://github.com/devnazir/get-storefront-token/tree/main/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-07-28'
+---
+
+# Get Storefront Token
+
+Get a permanent Shopify Storefront API token on real merchant stores.


### PR DESCRIPTION
This PR adds Get Storefront Token to the llms.txt hub.

**Website:** https://github.com/devnazir/get-storefront-token/tree/main
**llms.txt:** https://github.com/devnazir/get-storefront-token/tree/main/llms.txt

**Category:** developer-tools

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new guide explaining how to obtain a permanent Shopify Storefront API token.
  * Included page metadata, description, category, and related links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->