### PR TITLE
feat(community): add Semaf Electronics to llms.txt hub

### DIFF
--- a/packages/content/data/websites/semaf-electronics-llms-txt.mdx
+++ b/packages/content/data/websites/semaf-electronics-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Semaf Electronics'
+description: 'Official Raspberry Pi Reseller & electronics shop in Vienna. Provides full LLM & MCP agent interfaces for automated product discovery and catalog access.'
+website: 'https://electronics.semaf.at'
+llmsUrl: 'https://electronics.semaf.at/llms.txt'
+llmsFullUrl: 'https://electronics.semaf.at/llms-full.txt'
+category: 'ecommerce-retail'
+publishedAt: '2026-07-28'
+---
+
+# Semaf Electronics
+
+Official Raspberry Pi Reseller & electronics shop in Vienna. Provides full LLM & MCP agent interfaces for automated product discovery and catalog access.


### PR DESCRIPTION
This PR adds Semaf Electronics to the llms.txt hub.

**Website:** https://electronics.semaf.at
**llms.txt:** https://electronics.semaf.at/llms.txt
**llms-full.txt:** https://electronics.semaf.at/llms-full.txt  
**Category:** ecommerce-retail

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Semaf Electronics website entry with descriptive metadata and links to its LLM resources.
  * Included human-readable content describing the website and its available resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->