### PR TITLE
feat(community): add London Builders | LMDEC LTD to llms.txt hub

### DIFF
--- a/packages/content/data/websites/london-builders-lmdec-ltd-llms-txt.mdx
+++ b/packages/content/data/websites/london-builders-lmdec-ltd-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'London Builders | LMDEC LTD'
+description: 'South London builders family-run LMDEC LTD since 2014. Kitchen renovations, bathrooms, extensions across Wandsworth, Richmond, Chelsea & Croydon Free quote 48h.'
+website: 'https://lmdec.co.uk/'
+llmsUrl: 'https://lmdec.co.uk/llms.txt'
+llmsFullUrl: 'https://lmdec.co.uk/llms-full.txt'
+category: 'other'
+publishedAt: '2026-07-28'
+---
+
+# London Builders | LMDEC LTD
+
+South London builders family-run LMDEC LTD since 2014. Kitchen renovations, bathrooms, extensions across Wandsworth, Richmond, Chelsea & Croydon Free quote 48h.


### PR DESCRIPTION
This PR adds London Builders | LMDEC LTD to the llms.txt hub.

**Website:** https://lmdec.co.uk/
**llms.txt:** https://lmdec.co.uk/llms.txt
**llms-full.txt:** https://lmdec.co.uk/llms-full.txt  
**Category:** other

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added a new page for London Builders | LMDEC LTD.
  * Includes business details, website links, category information, publication date, and descriptive content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->