### PR TITLE
feat(community): add Glenlist to llms.txt hub

### DIFF
--- a/packages/content/data/websites/glenlist-llms-txt.mdx
+++ b/packages/content/data/websites/glenlist-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Glenlist'
+description: 'Rent houses, real estate, apartments, buy and sell vehicles, job postings, services.'
+website: 'https://glenlist.com'
+llmsUrl: 'https://glenlist.com/llms.txt'
+llmsFullUrl: 'https://glenlist.com/llms-full.txt'
+category: 'business-operations'
+publishedAt: '2026-07-29'
+---
+
+# Glenlist
+
+Rent houses, real estate, apartments, buy and sell vehicles, job postings, services.


### PR DESCRIPTION
This PR adds Glenlist to the llms.txt hub.

**Website:** https://glenlist.com
**llms.txt:** https://glenlist.com/llms.txt
**llms-full.txt:** https://glenlist.com/llms-full.txt  
**Category:** business-operations

---
This PR was created via admin token for a user without GitHub repository access.

Please review and merge if appropriate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Glenlist website entry with descriptive metadata and links to its `llms.txt` and `llms-full.txt` resources.
  * Included the Glenlist description in the site’s content directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->