### PR TITLE
Add Rizzshots to the llms.txt hub

### DIFF
--- a/packages/content/data/websites/rizzshots-llms-txt.mdx
+++ b/packages/content/data/websites/rizzshots-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Rizzshots'
+description: 'AI dating-profile photo generator for men. Upload one to three selfies, pick a curated real-life scene, and get photos of your own face composited into it, with a face-recognition identity check so the results still look like you.'
+website: 'https://rizzshots.com'
+llmsUrl: 'https://rizzshots.com/llms.txt'
+category: 'content-media'
+publishedAt: '2026-07-29'
+priority: 'medium'
+---
+
+# Rizzshots
+
+Rizzshots is an AI dating-photo generator for men on Tinder, Hinge and Bumble. Upload one to three selfies, choose a curated real-life scene, and it composites your own face into that scene using Gemini 3 Pro Image, with a face-recognition identity check so the results keep your actual features and build instead of turning you into a generic model. Every result is editable in the browser, it is free to try, and there are no subscriptions.
+
+## Key Focus Areas
+
+- AI Dating Profile Photos
+- Face-Consistent Image Generation
+- In-Browser Photo Editing
+- Privacy-First Selfie Handling
+
+## About llms.txt Implementation
+
+Rizzshots' llms.txt summarizes the product and links to its core pages and dating-photo guides, so language models can accurately describe what the tool does and who it is for.


### PR DESCRIPTION
Adds an entry for **Rizzshots** (https://rizzshots.com), an AI dating-profile photo generator for men.

- `llmsUrl`: https://rizzshots.com/llms.txt (verified returns 200)
- Category: content-media
- New file: packages/content/data/websites/rizzshots-llms-txt.mdx following the existing entry format (frontmatter + Key Focus Areas + About llms.txt Implementation). websites.json left untouched (auto-generated).

Thanks for maintaining the hub!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `llms.txt` content entry for Rizzshots.
  * Included product details, website metadata, key focus areas, and links to relevant dating-photo guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->