### PR TITLE
Add Hadrian to llms.txt directory

### DIFF
--- a/packages/content/data/websites/hadrian-marketing-llms-txt.mdx
+++ b/packages/content/data/websites/hadrian-marketing-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Hadrian'
+description: 'Hadrian is an AI marketing operating system for marketing teams of 2-15 people, with 12 brand-aware AI agents across content, paid, SEO, PR, lifecycle, and creative in one unified inbox.'
+website: 'https://hadrian.marketing'
+llmsUrl: 'https://hadrian.marketing/llms.txt'
+llmsFullUrl: ''
+category: 'marketing-sales'
+publishedAt: '2026-07-29'
+---
+
+# Hadrian
+
+Hadrian is an AI marketing operating system for marketing teams of 2-15 people, with 12 brand-aware AI agents across content, paid, SEO, PR, lifecycle, and creative in one unified inbox. Multi-brand workspace from day one, with 24 integrations including HubSpot, Klaviyo, Shopify, Meta, and GA4.


### PR DESCRIPTION
Adds Hadrian (https://hadrian.marketing), an AI marketing operating system, following the existing website entry template. Live llms.txt: https://hadrian.marketing/llms.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new directory listing for the Hadrian website, including descriptive metadata, relevant links, category, publication date, and a product overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->