### PR TITLE
feat(community): add CueFrame to llms.txt hub

### DIFF
--- a/packages/content/data/websites/cueframe-llms-txt.mdx
+++ b/packages/content/data/websites/cueframe-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'CueFrame'
+description: 'The video editing API. Your agent or code writes the edit — clips, captions, brand — and CueFrame renders the finished video, the same way every time.'
+website: 'https://cueframe.ai'
+llmsUrl: 'https://cueframe.ai/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-07-31'
+---
+
+# CueFrame
+
+The video editing API. Your agent or code writes the edit — clips, captions, brand — and CueFrame renders the finished video, the same way every time.


### PR DESCRIPTION
This PR adds CueFrame to the llms.txt hub.

**Website:** https://cueframe.ai
**llms.txt:** https://cueframe.ai/llms.txt
**Category:** developer-tools

CueFrame is a video editing API — your agent or code writes the edit (clips, captions, brand) and CueFrame renders the finished video deterministically.

Adds a single `.mdx` entry under `packages/content/data/websites/` per CONTRIBUTING; `data/websites.json` is left untouched since it is generated. No `llmsFullTxtUrl` is declared because we do not publish an `llms-full.txt` yet — I'd rather omit the field than point it at a 404. All 23 links in our `llms.txt` were verified 200 before submitting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CueFrame to the website directory with its description, links, category, publication date, and introductory content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->