### PR TITLE
feat(community): declare llmsFullUrl for CueFrame

### DIFF
--- a/packages/content/data/websites/cueframe-llms-txt.mdx
+++ b/packages/content/data/websites/cueframe-llms-txt.mdx
@@ -3,6 +3,7 @@ name: 'CueFrame'
 description: 'The video editing API. Your agent or code writes the edit — clips, captions, brand — and CueFrame renders the finished video, the same way every time.'
 website: 'https://cueframe.ai'
 llmsUrl: 'https://cueframe.ai/llms.txt'
+llmsFullUrl: 'https://cueframe.ai/llms-full.txt'
 category: 'developer-tools'
 publishedAt: '2026-07-31'
 ---


### PR DESCRIPTION
Follow-up to #1444.

That PR deliberately omitted `llmsFullUrl` because we did not publish an `llms-full.txt` — I'd rather leave the field out than point it at a 404. We have since published one, so this declares it.

**llms-full.txt:** https://cueframe.ai/llms-full.txt (200, ~143 KB — the full text of all 14 guides inlined)

Both files are now generated from the site's own content source rather than hand-maintained, so they cannot drift from the published guides. Verified live before opening this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a link to CueFrame’s complete LLMs text endpoint in its website metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->