### PR TITLE
Add DinnerElite

### DIFF
--- a/packages/content/data/websites/dinnerelite-llms-txt.mdx
+++ b/packages/content/data/websites/dinnerelite-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'DinnerElite'
+description: 'Reservation alerts for NYC hardest-to-book restaurants. Watches Resy and OpenTable around the clock and emails you the second a matching table opens.'
+website: 'https://dinnerelite.com/'
+llmsUrl: 'https://dinnerelite.com/llms.txt'
+category: 'other'
+publishedAt: '2026-07-31'
+---
+
+# DinnerElite
+
+Reservation alerts for NYC hardest-to-book restaurants. Watches Resy and OpenTable around the clock and emails you the second a matching table opens.


### PR DESCRIPTION
Adds DinnerElite to the websites list.

DinnerElite watches Resy and OpenTable for NYC's hardest-to-book restaurants and emails you when a matching table opens. It serves llms.txt at https://dinnerelite.com/llms.txt.

- name: DinnerElite
- website: https://dinnerelite.com/
- llmsUrl: https://dinnerelite.com/llms.txt
- category: other

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added DinnerElite to the website directory, including its category, publication details, URLs, and description.
  * Highlighted DinnerElite’s NYC restaurant reservation alert service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->