### PR TITLE
feat: add Pipe2.ai

### DIFF
--- a/packages/content/data/websites/pipe2-ai-llms-txt.mdx
+++ b/packages/content/data/websites/pipe2-ai-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Pipe2.ai'
+description: 'One-click AI pipelines for video, image, audio, and text — runnable from the web, a CLI, SDKs, or an MCP server.'
+website: 'https://pipe2.ai'
+llmsUrl: 'https://pipe2.ai/llms.txt'
+llmsFullUrl: 'https://pipe2.ai/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-07-31'
+---
+
+# Pipe2.ai
+
+One-click AI pipelines for video, image, audio, and text — runnable from the web, a CLI, SDKs, or an MCP server.


### PR DESCRIPTION
## Summary

Adds Pipe2.ai to the hub. Pipe2.ai runs one-click AI pipelines for video, image, audio and text, and publishes both `llms.txt` and `llms-full.txt`.

- `llms.txt`: https://pipe2.ai/llms.txt
- `llms-full.txt`: https://pipe2.ai/llms-full.txt

Single new file: `packages/content/data/websites/pipe2-ai-llms-txt.mdx`. `data/websites.json` is untouched.

Frontmatter checked against `scripts/check-frontmatter.ts` and `scripts/validate-websites.ts` — required fields present, filename matches `-llms-txt.mdx`, URL patterns match, and `category: 'ai-ml'` is in the allowed set.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Pipe2.ai to the website directory with its metadata, links, publication date, category, title, and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->