### PR TITLE
Add MilitaryCalc, GovCalcs, VisaGPS, Cities.gg

### DIFF
--- a/packages/content/data/websites/cities-gg-llms-txt.mdx
+++ b/packages/content/data/websites/cities-gg-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'Cities.gg'
+description: 'Walking routes between named landmarks in 450+ cities worldwide - distance, time, turn-by-turn pedestrian directions, and street video.'
+website: 'https://cities.gg'
+llmsUrl: 'https://cities.gg/llms.txt'
+category: 'other'
+publishedAt: '2026-08-01'
+---
+
+# Cities.gg
+
+Walking routes between named landmarks in 450+ cities worldwide - distance, time, turn-by-turn pedestrian directions, and street video.

--- a/packages/content/data/websites/govcalcs-llms-txt.mdx
+++ b/packages/content/data/websites/govcalcs-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'GovCalcs'
+description: 'Free, no-signup calculators for US government money rules - IRS, SSA, DOL, and Treasury figures for the 2026 tax year.'
+website: 'https://govcalcs.com'
+llmsUrl: 'https://govcalcs.com/llms.txt'
+category: 'finance-fintech'
+publishedAt: '2026-08-01'
+---
+
+# GovCalcs
+
+Free, no-signup calculators for US government money rules - IRS, SSA, DOL, and Treasury figures for the 2026 tax year.

--- a/packages/content/data/websites/militarycalc-llms-txt.mdx
+++ b/packages/content/data/websites/militarycalc-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'MilitaryCalc'
+description: 'Free, no-signup calculators for U.S. military money: BAH housing allowance, pay, and benefits, sourced from DoD DTMO.'
+website: 'https://militarycalc.com'
+llmsUrl: 'https://militarycalc.com/llms.txt'
+category: 'finance-fintech'
+publishedAt: '2026-08-01'
+---
+
+# MilitaryCalc
+
+Free, no-signup calculators for U.S. military money: BAH housing allowance, pay, and benefits, sourced from DoD DTMO.

--- a/packages/content/data/websites/visagps-llms-txt.mdx
+++ b/packages/content/data/websites/visagps-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'VisaGPS'
+description: 'Free, no-signup tools to track the U.S. immigration journey, built on State Department Visa Bulletin and USCIS data.'
+website: 'https://visagps.com'
+llmsUrl: 'https://visagps.com/llms.txt'
+category: 'other'
+publishedAt: '2026-08-01'
+---
+
+# VisaGPS
+
+Free, no-signup tools to track the U.S. immigration journey, built on State Department Visa Bulletin and USCIS data.


### PR DESCRIPTION
Four free, no-signup public-data tools, each with a live `/llms.txt`:

- **MilitaryCalc** (finance-fintech) - US military pay & BAH calculators, DoD DTMO data
- **GovCalcs** (finance-fintech) - US government money-rule calculators (IRS/SSA/DOL/Treasury)
- **VisaGPS** (other) - US immigration trackers on State Dept + USCIS data
- **Cities.gg** (other) - walking routes between landmarks in 450+ cities

All have /llms.txt live. Happy to split into separate PRs if you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added directory entries for Cities.gg, GovCalcs, MilitaryCalc, and VisaGPS.
  * Included website metadata, categories, publication dates, links, and descriptions.
  * Added information about walking routes, government money-rule calculators, military finance tools, and immigration tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->