### PR TITLE
fix(community): point AI Product Index at its canonical https host

### DIFF
--- a/packages/content/data/websites/ai-product-index-llms-txt.mdx
+++ b/packages/content/data/websites/ai-product-index-llms-txt.mdx
@@ -1,9 +1,9 @@
 ---
 name: 'AI Product Index'
 description: 'A machine-readable directory where AI products register themselves so AI agents can discover them. Autonomous registration, free listings, JSON, schema.org.'
-website: 'http://percall.dev/'
-llmsUrl: 'http://percall.dev/llms.txt'
-llmsFullUrl: 'http://percall.dev/llms-full.txt'
+website: 'https://index.percall.dev'
+llmsUrl: 'https://index.percall.dev/llms.txt'
+llmsFullUrl: 'https://index.percall.dev/llms-full.txt'
 category: 'ai-ml'
 publishedAt: '2026-08-02'
 ---


### PR DESCRIPTION
Follow-up to #1459, which I submitted and which you kindly merged on 2026-08-02 — thank you.

The entry went in pointing at `http://percall.dev/`. That works, but it is neither the canonical host nor https: the apex answers a `308` to `https://index.percall.dev`, so every consumer of `websites.json` records a redirect rather than the destination.

This corrects the three URL fields to the host the site actually serves from:

| field | before | after |
|---|---|---|
| `website` | `http://percall.dev/` | `https://index.percall.dev` |
| `llmsUrl` | `http://percall.dev/llms.txt` | `https://index.percall.dev/llms.txt` |
| `llmsFullUrl` | `http://percall.dev/llms-full.txt` | `https://index.percall.dev/llms-full.txt` |

All three were rechecked on 2026-08-27 and return `200` directly, with no redirect hop:

```
https://index.percall.dev              200
https://index.percall.dev/llms.txt     200
https://index.percall.dev/llms-full.txt 200
```

Nothing else in the entry changes. Sorry for the extra round trip — the wrong host was mine, not the form's.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI Product Index website and reference URLs to use the secure `https://index.percall.dev` address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->