### PR TITLE
Add Aura UI

### DIFF
--- a/packages/content/data/websites/aura-ui-llms-txt.mdx
+++ b/packages/content/data/websites/aura-ui-llms-txt.mdx
@@ -1,0 +1,15 @@
+---
+name: 'Aura UI'
+description: 'Blade component library for Laravel, Livewire and Tailwind CSS 4, with machine-readable component documentation.'
+website: 'https://aura-ui.com'
+llmsUrl: 'https://aura-ui.com/llms.txt'
+llmsFullUrl: 'https://aura-ui.com/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-03'
+---
+
+# Aura UI
+
+Blade component library for Laravel, Livewire and Tailwind CSS 4, with 64 of its 89 components under the MIT licence.
+
+Every documentation page is also served as raw Markdown by appending `.md` to its URL. Alongside `llms.txt` there is a machine-readable component registry at `/r/registry.json` and a public MCP server at `/mcp/aura`, so an assistant can list the components, read a component's real Blade tag and props, and produce the exact install command instead of guessing the API.


### PR DESCRIPTION
## Summary

Describe the change in one or two sentences.

Hosted MCP server for the Aura UI Blade component library (Laravel + Livewire + Tailwind CSS 4). Lets an assistant list and search 89 components, read a component's real Blade tag, props and docs, and get the exact `php artisan aura:add` command to install it — so it stops inventing component APIs. Remote server, no install: `https://aura-ui.com/mcp/aura`

> **Note:** `data/websites.json` is auto-generated. Do not edit it -- PRs that modify it will be blocked. Only add or edit `.mdx` files under `packages/content/data/websites/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Aura UI documentation metadata, including licensing, publication date, component coverage, Markdown access, registry, and MCP server links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->