### PR TITLE
feat: add Noden

### DIFF
--- a/packages/content/data/websites/noden-llms-txt.mdx
+++ b/packages/content/data/websites/noden-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'Noden'
+description: 'Native macOS client for SSH, SFTP and RDP - a terminal, a dual-pane file manager and a Windows remote desktop in one window'
+website: 'https://noden.useroamteknoloji.com'
+llmsUrl: 'https://noden.useroamteknoloji.com/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-04'
+---
+
+# Noden
+
+Noden is a native macOS (SwiftUI) client that combines SSH, SFTP and RDP in a single window. Sessions can be tiled in a grid, so a Windows desktop can sit next to Linux shells and a file manager.
+
+## Key Focus Areas
+
+- Multi-session SSH terminal with saved connections, SSH tunnels, broadcast input and Touch ID lock
+- Dual-pane SFTP file manager with drag and drop from Finder and remote editing in your own editor
+- Windows RDP built on FreeRDP and rendered with Metal, with clipboard and file copy both ways and RD Gateway support
+- Optional AI command assistant (bring your own API key or use the built-in one)
+
+## About llms.txt Implementation
+
+The llms.txt file provides a structured, factual overview of Noden: features, pricing (free for up to 5 connections, Pro $10/year), system requirements (macOS 13+, Apple Silicon and Intel) and comparison pages. Machine-readable pricing is also available at /pricing.md.


### PR DESCRIPTION
## Summary

Adds Noden, a native macOS client for SSH, SFTP and RDP, to the websites directory (category: developer-tools).

- Website: https://noden.useroamteknoloji.com
- - llms.txt: https://noden.useroamteknoloji.com/llms.txt
Only adds a single .mdx file under packages/content/data/websites/ per the contribution guidelines. Disclosure: I'm the developer of Noden. (Tried the web submit flow first, but it currently returns "Verification unavailable".)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a metadata and overview page for Noden.
  * Documented its macOS SSH, SFTP, and RDP capabilities, AI assistant, pricing, system requirements, and machine-readable pricing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->