### PR TITLE
feat(community): add five scholarly agent-infrastructure properties

### DIFF
--- a/packages/content/data/websites/afmr-llms-txt.mdx
+++ b/packages/content/data/websites/afmr-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'AFMR'
+description: 'The Agent Failure Mode Registry: a governed vocabulary authority for naming and scoping agent failure modes.'
+website: 'https://afmr.ai'
+llmsUrl: 'https://afmr.ai/llms.txt'
+llmsFullUrl: 'https://afmr.ai/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-08-04'
+---
+
+# AFMR
+
+The Agent Failure Mode Registry: a governed vocabulary authority for naming and scoping agent failure modes.

--- a/packages/content/data/websites/agentic-substrate-llms-txt.mdx
+++ b/packages/content/data/websites/agentic-substrate-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'Agentic Substrate'
+description: 'A pre-launch venue producing performance and expertise-tag reputation for autonomous agents.'
+website: 'https://agenticsubstrate.org'
+llmsUrl: 'https://agenticsubstrate.org/llms.txt'
+category: 'ai-ml'
+publishedAt: '2026-08-04'
+---
+
+# Agentic Substrate
+
+A pre-launch venue producing performance and expertise-tag reputation for autonomous agents.

--- a/packages/content/data/websites/open-standing-llms-txt.mdx
+++ b/packages/content/data/websites/open-standing-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'Open Standing'
+description: 'A live write venue for autonomous agents, with two-round validation pools and a hash-chained public ledger.'
+website: 'https://openstanding.org'
+llmsUrl: 'https://openstanding.org/llms.txt'
+category: 'ai-ml'
+publishedAt: '2026-08-04'
+---
+
+# Open Standing
+
+A live write venue for autonomous agents, with two-round validation pools and a hash-chained public ledger.

--- a/packages/content/data/websites/trustcarry-llms-txt.mdx
+++ b/packages/content/data/websites/trustcarry-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'TrustCarry'
+description: 'A carry profile separating continuity, competence, trust, and authority into four sequential fail-closed gates.'
+website: 'https://trustcarry.org'
+llmsUrl: 'https://trustcarry.org/llms.txt'
+llmsFullUrl: 'https://trustcarry.org/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-08-04'
+---
+
+# TrustCarry
+
+A carry profile separating continuity, competence, trust, and authority into four sequential fail-closed gates.

--- a/packages/content/data/websites/wulf-kaal-corpus-llms-txt.mdx
+++ b/packages/content/data/websites/wulf-kaal-corpus-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'Wulf Kaal Corpus'
+description: 'A scholarly corpus with an atomic claim layer, each claim bound to its source by content hash.'
+website: 'https://wulfkaal.github.io'
+llmsUrl: 'https://wulfkaal.github.io/llms.txt'
+category: 'other'
+publishedAt: '2026-08-04'
+---
+
+# Wulf Kaal Corpus
+
+A scholarly corpus with an atomic claim layer, each claim bound to its source by content hash.


### PR DESCRIPTION
Adds five llms.txt entries for scholarly agent infrastructure: Open Standing, AFMR, TrustCarry, Agentic Substrate, and the Wulf Kaal Corpus. All five serve a live llms.txt. Only MDX entries under packages/content/data/websites/ are touched; websites.json is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added directory entries for five AI/ML websites: AFMR, Agentic Substrate, Open Standing, TrustCarry, and Wulf Kaal Corpus.
  * Each entry includes a description, category, publication details, and links to the website and LLM resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->