### PR TITLE
Add Autonomy Labs Storefront (llms.txt + x402, agent-payable)

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -76,7 +76,7 @@
   {
     "name": "Abundly AI",
     "domain": "https://www.abundly.ai/",
-    "description": "Abundly AI lets your domain experts create powerful AI agents in natural language — no code, no IT dependency. That's why they get adopted, keep improving, and actually deliver results.",
+    "description": "Abundly AI lets your domain experts create powerful AI agents in natural language \u2014 no code, no IT dependency. That's why they get adopted, keep improving, and actually deliver results.",
     "llmsTxtUrl": "https://www.abundly.ai/llms.txt",
     "llmsFullTxtUrl": "https://www.abundly.ai/llms-full.txt",
     "category": "ai-ml",
@@ -124,7 +124,7 @@
   {
     "name": "Acurast Hub",
     "domain": "https://hub.acurast.com",
-    "description": "Acurast is the Real Decentralized Compute Network — scalable, secure, and powered by smartphones.",
+    "description": "Acurast is the Real Decentralized Compute Network \u2014 scalable, secure, and powered by smartphones.",
     "llmsTxtUrl": "https://docs.acurast.com/llms.txt",
     "llmsFullTxtUrl": "https://docs.acurast.com/llms-full.txt",
     "category": "infrastructure-cloud",
@@ -199,7 +199,7 @@
   {
     "name": "Affordable NVMe SSD Web Hosting Pakistan",
     "domain": "http://www.webhostingpk.com",
-    "description": "Host your site with 10x faster NVMe SSD, free SSL, cPanel & 24/7 support. Try WebHostingPk today – plans from Rs 199/month with a 1-day free trial.",
+    "description": "Host your site with 10x faster NVMe SSD, free SSL, cPanel & 24/7 support. Try WebHostingPk today \u2013 plans from Rs 199/month with a 1-day free trial.",
     "llmsTxtUrl": "http://www.webhostingpk.com/llms.txt",
     "llmsFullTxtUrl": "http://www.webhostingpk.com/llms-full.txt",
     "category": "infrastructure-cloud",
@@ -236,7 +236,7 @@
   {
     "name": "Agentic Intelligence",
     "domain": "https://agenticintelligence.co.nz/",
-    "description": "Agentic Intelligence builds AI-native ventures from concept to scale — across construction, financial advice, sales and frontline workforces. Christchurch, NZ.",
+    "description": "Agentic Intelligence builds AI-native ventures from concept to scale \u2014 across construction, financial advice, sales and frontline workforces. Christchurch, NZ.",
     "llmsTxtUrl": "https://agenticintelligence.co.nz/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=agenticintelligence.co.nz&sz=128",
@@ -320,7 +320,7 @@
   {
     "name": "AI + Human Customer Service Automation Platform",
     "domain": "https://www.kommunicate.io/",
-    "description": "Automate customer conversations with Kommunicate — unified support automation with smart AI agents, seamless human handoff, and omnichannel deployment across web, WhatsApp, email, and apps.",
+    "description": "Automate customer conversations with Kommunicate \u2014 unified support automation with smart AI agents, seamless human handoff, and omnichannel deployment across web, WhatsApp, email, and apps.",
     "llmsTxtUrl": "https://www.kommunicate.io/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.kommunicate.io&sz=128",
@@ -402,7 +402,7 @@
   {
     "name": "AI Skill Store",
     "domain": "https://www.aiskillstore.io",
-    "description": "Agent-first skill marketplace. Discover and install USK skills via API — auto-converts for Claude Code, OpenClaw, Cursor & more. Trust-rated, open standard.",
+    "description": "Agent-first skill marketplace. Discover and install USK skills via API \u2014 auto-converts for Claude Code, OpenClaw, Cursor & more. Trust-rated, open standard.",
     "llmsTxtUrl": "https://www.aiskillstore.io/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.aiskillstore.io&sz=128",
@@ -449,7 +449,7 @@
   {
     "name": "AI-First Mindset",
     "domain": "https://aifirstmindset.ai/",
-    "description": "We are an AI consulting company offering tailored AI implementation guidance and hands-on AI training workshops. Start your AI journey with AI-First Mindset®.",
+    "description": "We are an AI consulting company offering tailored AI implementation guidance and hands-on AI training workshops. Start your AI journey with AI-First Mindset\u00ae.",
     "llmsTxtUrl": "https://aifirstmindset.ai/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=aifirstmindset.ai&sz=128",
@@ -636,7 +636,7 @@
   {
     "name": "All-In-One Dental Practice Management Software",
     "domain": "https://carestack.com/",
-    "description": "CareStack is an award-winning, cloud dental practice management software trusted by thousands of dentists & dental practices. See the CareStack® difference.",
+    "description": "CareStack is an award-winning, cloud dental practice management software trusted by thousands of dentists & dental practices. See the CareStack\u00ae difference.",
     "llmsTxtUrl": "https://carestack.com/llms.txt",
     "category": "infrastructure-cloud",
     "favicon": "https://www.google.com/s2/favicons?domain=carestack.com&sz=128",
@@ -645,7 +645,7 @@
   {
     "name": "Allpeople",
     "domain": "https://www.allpeople.com.tr/",
-    "description": "Anılarınızı özel kılın! All People özel baskı şemsiye ve çadırlarıyla fark yaratın. Ürünlerimizi incelemek için hemen tıklayın.",
+    "description": "An\u0131lar\u0131n\u0131z\u0131 \u00f6zel k\u0131l\u0131n! All People \u00f6zel bask\u0131 \u015femsiye ve \u00e7ad\u0131rlar\u0131yla fark yarat\u0131n. \u00dcr\u00fcnlerimizi incelemek i\u00e7in hemen t\u0131klay\u0131n.",
     "llmsTxtUrl": "https://www.allpeople.com.tr/idea/qs/69/themes/selftpl_685fb81675d45/assets/uploads/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.allpeople.com.tr&sz=128",
@@ -716,9 +716,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Ambizur Webdesign Zürich",
+    "name": "Ambizur Webdesign Z\u00fcrich",
     "domain": "https://www.ambizur.ch/",
-    "description": "Highend Webdesign aus Zürich mit Webflow, zuverlässig wie ein schweizer Taschenmesser. Moderne, responsive Webseiten für Ihr Unternehmen. Jetzt kostenloses Erstgespräch vereinbaren!",
+    "description": "Highend Webdesign aus Z\u00fcrich mit Webflow, zuverl\u00e4ssig wie ein schweizer Taschenmesser. Moderne, responsive Webseiten f\u00fcr Ihr Unternehmen. Jetzt kostenloses Erstgespr\u00e4ch vereinbaren!",
     "llmsTxtUrl": "https://www.ambizur.ch/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=www.ambizur.ch&sz=128",
@@ -754,7 +754,7 @@
   {
     "name": "Amigable Mascota",
     "domain": "https://amigablemascota.com/",
-    "description": "Tiendas, adopción, lugares pet friendly y más. Encuentra todo para tu mascota: servicios, adopciones, productos y más en tu ciudad.",
+    "description": "Tiendas, adopci\u00f3n, lugares pet friendly y m\u00e1s. Encuentra todo para tu mascota: servicios, adopciones, productos y m\u00e1s en tu ciudad.",
     "llmsTxtUrl": "https://amigablemascota.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=amigablemascota.com&sz=128",
@@ -772,7 +772,7 @@
   {
     "name": "Analog",
     "domain": "https://www.analog.one/",
-    "description": "Analog is an omni-chain interoperability protocol suite consisting of the Timechain (a sovereign blockchain), developer toolkits, & a unified API—all designed to simplify access to Web3 data while breaking down the barriers to cross-chain communication.",
+    "description": "Analog is an omni-chain interoperability protocol suite consisting of the Timechain (a sovereign blockchain), developer toolkits, & a unified API\u2014all designed to simplify access to Web3 data while breaking down the barriers to cross-chain communication.",
     "llmsTxtUrl": "https://docs.analog.one/documentation/llms.txt",
     "llmsFullTxtUrl": "https://docs.analog.one/documentation/llms-full.txt",
     "category": "developer-tools",
@@ -1004,7 +1004,7 @@
   {
     "name": "Arize AI",
     "domain": "https://arize.com/",
-    "description": "Unified LLM Observability and Agent Evaluation Platform for AI Applications—from development to production.",
+    "description": "Unified LLM Observability and Agent Evaluation Platform for AI Applications\u2014from development to production.",
     "llmsTxtUrl": "https://arize.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=arize.com&sz=128",
@@ -1108,7 +1108,7 @@
   {
     "name": "Astral Photos",
     "domain": "https://astral.photos/",
-    "description": "Serviço profissional de fotografia de imóveis e locais. Fotógrafo especializado em casa, apartamento, comércio e loja. Com anos de atuação no mercado.",
+    "description": "Servi\u00e7o profissional de fotografia de im\u00f3veis e locais. Fot\u00f3grafo especializado em casa, apartamento, com\u00e9rcio e loja. Com anos de atua\u00e7\u00e3o no mercado.",
     "llmsTxtUrl": "https://astral.photos/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=astral.photos&sz=128",
@@ -1136,7 +1136,7 @@
   {
     "name": "Atlas civique IA-ready",
     "domain": "https://web-mcp.fr",
-    "description": "L'annuaire structuré des territoires français — datasets publics (DATATourisme, INSEE, IGN, SIRENE) croisés pour les agents IA. Alpha Alpes-Maritimes.",
+    "description": "L'annuaire structur\u00e9 des territoires fran\u00e7ais \u2014 datasets publics (DATATourisme, INSEE, IGN, SIRENE) crois\u00e9s pour les agents IA. Alpha Alpes-Maritimes.",
     "llmsTxtUrl": "https://web-mcp.fr/llms.txt",
     "llmsFullTxtUrl": "https://web-mcp.fr/llms-full.txt",
     "category": "data-analytics",
@@ -1194,12 +1194,21 @@
   {
     "name": "Autogarsas",
     "domain": "https://www.autogarsas.lt/",
-    "description": "Didžiausias ir patogiausias Garso aparatūros pasirinkimas internetu. Žymiausi ir laiko patikrinti gamintojai. Konsultacijos, greitas pristatymas, instal.",
+    "description": "Did\u017eiausias ir patogiausias Garso aparat\u016bros pasirinkimas internetu. \u017dymiausi ir laiko patikrinti gamintojai. Konsultacijos, greitas pristatymas, instal.",
     "llmsTxtUrl": "https://www.autogarsas.lt/llms.txt",
     "llmsFullTxtUrl": "https://www.autogarsas.lt/llms-full.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.autogarsas.lt&sz=128",
     "publishedAt": "2026-05-31"
+  },
+  {
+    "name": "Autonomy Labs",
+    "domain": "https://business2-lasse-tfa.vercel.app",
+    "description": "AI-agent-run storefront selling digital products: prompt packs, starter kits, MCP servers, and automation templates. Agents can buy directly via Stripe.",
+    "llmsTxtUrl": "https://business2-lasse-tfa.vercel.app/llms.txt",
+    "category": "integration-automation",
+    "favicon": "https://www.google.com/s2/favicons?domain=business2-lasse-tfa.vercel.app&sz=128",
+    "publishedAt": "2026-08-12"
   },
   {
     "name": "Avaamo",
@@ -1213,7 +1222,7 @@
   {
     "name": "AvaCloud",
     "domain": "https://www.avacloud.io/",
-    "description": "A managed blockchain service enabling teams to rapidly build, deploy, and scale decentralized networks–customized for any use case.",
+    "description": "A managed blockchain service enabling teams to rapidly build, deploy, and scale decentralized networks\u2013customized for any use case.",
     "llmsTxtUrl": "https://developers.avacloud.io/llms.txt",
     "llmsFullTxtUrl": "https://developers.avacloud.io/llms-full.txt",
     "category": "developer-tools",
@@ -1250,9 +1259,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Aventure Pyrénéenne",
+    "name": "Aventure Pyr\u00e9n\u00e9enne",
     "domain": "https://www.aventure-pyreneenne.com/",
-    "description": "Votre agence d'activités nature à Font-Romeu (66) : 100+ expériences toutes saisons dans les Pyrénées Orientales. Découvrez nos offres.",
+    "description": "Votre agence d'activit\u00e9s nature \u00e0 Font-Romeu (66) : 100+ exp\u00e9riences toutes saisons dans les Pyr\u00e9n\u00e9es Orientales. D\u00e9couvrez nos offres.",
     "llmsTxtUrl": "https://www.aventure-pyreneenne.com/llms.txt",
     "llmsFullTxtUrl": "https://www.aventure-pyreneenne.com/llms-full.txt",
     "category": "ai-ml",
@@ -1345,7 +1354,7 @@
   {
     "name": "AzyPrime",
     "domain": "https://azyprime.com/",
-    "description": "AzyPrime offers a comprehensive suite of tools and plugins for MetaTrader 4 and 5, including dealing desk solutions, custom development, hosting and server management services. Enhance your trading platform with our advanced technologies 👉 AzyPrime",
+    "description": "AzyPrime offers a comprehensive suite of tools and plugins for MetaTrader 4 and 5, including dealing desk solutions, custom development, hosting and server management services. Enhance your trading platform with our advanced technologies \ud83d\udc49 AzyPrime",
     "llmsTxtUrl": "https://azyprime.com/llms.txt",
     "category": "infrastructure-cloud",
     "favicon": "https://www.google.com/s2/favicons?domain=azyprime.com&sz=128",
@@ -1391,7 +1400,7 @@
   {
     "name": "Banan AI - AI Image Generator",
     "domain": "https://bananai.net/",
-    "description": "Create AI images by chatting — no prompt engineering needed. Built for e-commerce, creators, and marketers. Start free today.",
+    "description": "Create AI images by chatting \u2014 no prompt engineering needed. Built for e-commerce, creators, and marketers. Start free today.",
     "llmsTxtUrl": "https://bananai.net/llms.txt",
     "llmsFullTxtUrl": "https://bananai.net/llms-full.txt",
     "category": "ai-ml",
@@ -1401,7 +1410,7 @@
   {
     "name": "Banana AI",
     "domain": "https://banana-ai.art/",
-    "description": "Banana AI is a free AI image and video generation platform. Transform photos, create cinematic videos, apply styles, background removal, and restoration—fast and easy.",
+    "description": "Banana AI is a free AI image and video generation platform. Transform photos, create cinematic videos, apply styles, background removal, and restoration\u2014fast and easy.",
     "llmsTxtUrl": "https://banana-ai.art/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=banana-ai.art&sz=128",
@@ -1466,7 +1475,7 @@
   {
     "name": "Beschaffungsdienst GaLaBau",
     "domain": "https://www.soll-galabau.de/",
-    "description": "Das Fachmagazin für Garten- und Landschaftsbau: Fundierte Berichte über Baustoffe, Maschinen & Technik für Profis und Kommunen. Jetzt Praxis-Know-how lesen!",
+    "description": "Das Fachmagazin f\u00fcr Garten- und Landschaftsbau: Fundierte Berichte \u00fcber Baustoffe, Maschinen & Technik f\u00fcr Profis und Kommunen. Jetzt Praxis-Know-how lesen!",
     "llmsTxtUrl": "https://www.soll-galabau.de/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.soll-galabau.de&sz=128",
@@ -1485,7 +1494,7 @@
   {
     "name": "Best Coding Books 2026",
     "domain": "https://codersguild.net/",
-    "description": "Explore the best coding books for beginners. From coding principles to software development, find the top-rated books to enhance your skills. ➞ Read o...",
+    "description": "Explore the best coding books for beginners. From coding principles to software development, find the top-rated books to enhance your skills. \u279e Read o...",
     "llmsTxtUrl": "https://codersguild.net/llms.txt",
     "llmsFullTxtUrl": "https://codersguild.net/llms-full.txt",
     "category": "developer-tools",
@@ -1504,7 +1513,7 @@
   {
     "name": "betmaster.com.mx",
     "domain": "https://betmaster.com.mx/es-mx",
-    "description": "Disfruta de juegos de casino, apuestas deportivas y Esports en Betmaster México. ¡Regístrate y obtén tu bono de bienvenida hoy mismo!",
+    "description": "Disfruta de juegos de casino, apuestas deportivas y Esports en Betmaster M\u00e9xico. \u00a1Reg\u00edstrate y obt\u00e9n tu bono de bienvenida hoy mismo!",
     "llmsTxtUrl": "https://betmaster.com.mx/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=betmaster.com.mx/es-mx&sz=128",
@@ -1531,7 +1540,7 @@
   {
     "name": "bewoplaner.de",
     "domain": "https://www.bewoplaner.de/",
-    "description": "Digitale Lösung für die Eingliederungshilfe: Mit dem BeWoPlaner planen, dokumentieren und organisieren Sie professionell und effizient.",
+    "description": "Digitale L\u00f6sung f\u00fcr die Eingliederungshilfe: Mit dem BeWoPlaner planen, dokumentieren und organisieren Sie professionell und effizient.",
     "llmsTxtUrl": "https://www.bewoplaner.de/llms.txt",
     "llmsFullTxtUrl": "https://www.bewoplaner.de/llms-full.txt",
     "category": "ai-ml",
@@ -1551,7 +1560,7 @@
   {
     "name": "Bigbuda",
     "domain": "https://bigbuda.cl/",
-    "description": "Agencia de marketing digital en Chile especializada en diseño web y CRO. Mejoramos la conversión de tu sitio con datos reales.",
+    "description": "Agencia de marketing digital en Chile especializada en dise\u00f1o web y CRO. Mejoramos la conversi\u00f3n de tu sitio con datos reales.",
     "llmsTxtUrl": "https://bigbuda.cl/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=bigbuda.cl&sz=128",
@@ -1560,7 +1569,7 @@
   {
     "name": "BigHub",
     "domain": "https://bighub.ai",
-    "description": "End-to-end enterprise AI and data delivery: GenAI assistants, AI agents, ML, MLOps/LLMOps, and scalable data platforms—from strategy to production.",
+    "description": "End-to-end enterprise AI and data delivery: GenAI assistants, AI agents, ML, MLOps/LLMOps, and scalable data platforms\u2014from strategy to production.",
     "llmsTxtUrl": "https://bighub.ai/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=bighub.ai&sz=128",
@@ -1579,7 +1588,7 @@
   {
     "name": "binguru.net",
     "domain": "https://binguru.net/",
-    "description": "Как я торговал в интернете печеньками и что из этого вышло. Как торговать бинарными, форексом, CFD и своими носками",
+    "description": "\u041a\u0430\u043a \u044f \u0442\u043e\u0440\u0433\u043e\u0432\u0430\u043b \u0432 \u0438\u043d\u0442\u0435\u0440\u043d\u0435\u0442\u0435 \u043f\u0435\u0447\u0435\u043d\u044c\u043a\u0430\u043c\u0438 \u0438 \u0447\u0442\u043e \u0438\u0437 \u044d\u0442\u043e\u0433\u043e \u0432\u044b\u0448\u043b\u043e. \u041a\u0430\u043a \u0442\u043e\u0440\u0433\u043e\u0432\u0430\u0442\u044c \u0431\u0438\u043d\u0430\u0440\u043d\u044b\u043c\u0438, \u0444\u043e\u0440\u0435\u043a\u0441\u043e\u043c, CFD \u0438 \u0441\u0432\u043e\u0438\u043c\u0438 \u043d\u043e\u0441\u043a\u0430\u043c\u0438",
     "llmsTxtUrl": "https://binguru.net/forums/llms.txt",
     "llmsFullTxtUrl": "https://binguru.net/forums/llms-full.txt",
     "category": "data-analytics",
@@ -1589,7 +1598,7 @@
   {
     "name": "Bipa",
     "domain": "https://bipa.app/",
-    "description": "Compre Bitcoin com Pix instantâneo ou cartão de crédito com cashback em BTC. Taxa zero em compras recorrentes. Abra sua conta grátis na Bipa!",
+    "description": "Compre Bitcoin com Pix instant\u00e2neo ou cart\u00e3o de cr\u00e9dito com cashback em BTC. Taxa zero em compras recorrentes. Abra sua conta gr\u00e1tis na Bipa!",
     "llmsTxtUrl": "https://bipa.app/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=bipa.app&sz=128",
@@ -1662,7 +1671,7 @@
   {
     "name": "Bizify",
     "domain": "https://www.bizify.it/",
-    "description": "Bizify è la piattaforma che connette founder, imprenditori e professionisti ambiziosi. Trova partner, crea collaborazioni e fai crescere il tuo network senza distrazioni.",
+    "description": "Bizify \u00e8 la piattaforma che connette founder, imprenditori e professionisti ambiziosi. Trova partner, crea collaborazioni e fai crescere il tuo network senza distrazioni.",
     "llmsTxtUrl": "https://www.bizify.it/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=www.bizify.it&sz=128",
@@ -1671,7 +1680,7 @@
   {
     "name": "Bizz",
     "domain": "https://bizz.bg/",
-    "description": "Най-голямата платформа за покупко-продажба на бизнес в България. Намерете подходящия бизнес за вас или продайте вашия бизнес бързо и лесно.",
+    "description": "\u041d\u0430\u0439-\u0433\u043e\u043b\u044f\u043c\u0430\u0442\u0430 \u043f\u043b\u0430\u0442\u0444\u043e\u0440\u043c\u0430 \u0437\u0430 \u043f\u043e\u043a\u0443\u043f\u043a\u043e-\u043f\u0440\u043e\u0434\u0430\u0436\u0431\u0430 \u043d\u0430 \u0431\u0438\u0437\u043d\u0435\u0441 \u0432 \u0411\u044a\u043b\u0433\u0430\u0440\u0438\u044f. \u041d\u0430\u043c\u0435\u0440\u0435\u0442\u0435 \u043f\u043e\u0434\u0445\u043e\u0434\u044f\u0449\u0438\u044f \u0431\u0438\u0437\u043d\u0435\u0441 \u0437\u0430 \u0432\u0430\u0441 \u0438\u043b\u0438 \u043f\u0440\u043e\u0434\u0430\u0439\u0442\u0435 \u0432\u0430\u0448\u0438\u044f \u0431\u0438\u0437\u043d\u0435\u0441 \u0431\u044a\u0440\u0437\u043e \u0438 \u043b\u0435\u0441\u043d\u043e.",
     "llmsTxtUrl": "https://bizz.bg/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=bizz.bg&sz=128",
@@ -1698,7 +1707,7 @@
   {
     "name": "Blueshift",
     "domain": "https://blueshift.com",
-    "description": "Automate cross-channel campaigns with Blueshift’s customer engagement platform that combines the power of AI, a CDP, and marketing automation.",
+    "description": "Automate cross-channel campaigns with Blueshift\u2019s customer engagement platform that combines the power of AI, a CDP, and marketing automation.",
     "llmsTxtUrl": "https://blueshift.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=blueshift.com&sz=128",
@@ -1750,7 +1759,7 @@
     "publishedAt": "2025-08-26"
   },
   {
-    "name": "Bosch/Buderus Wärmepumpen",
+    "name": "Bosch/Buderus W\u00e4rmepumpen",
     "domain": "https://bosch-buderus-wp.github.io/",
     "description": "Bosch Compress 5800/6800i und Buderus Logatherm WLW176/186i",
     "llmsTxtUrl": "https://bosch-buderus-wp.github.io/llms.txt",
@@ -1761,7 +1770,7 @@
   {
     "name": "Botanic Hearth",
     "domain": "https://botanichearth.com/",
-    "description": "Harnessing active botanicals to create natural skincare, bodycare & haircare that support holistic wellness—premium quality at fair, reasonable prices.",
+    "description": "Harnessing active botanicals to create natural skincare, bodycare & haircare that support holistic wellness\u2014premium quality at fair, reasonable prices.",
     "llmsTxtUrl": "https://botanichearth.com/llms.txt",
     "llmsFullTxtUrl": "https://botanichearth.com/llms-full.txt",
     "category": "ai-ml",
@@ -1818,7 +1827,7 @@
   {
     "name": "Brandschutz und Arbeitssicherheit: Online buchen & effizient umsetzen",
     "domain": "https://brandschutz-zentrale.de/",
-    "description": "brandschutzzentrale: Brandschutz und Arbeitssicherheit \\- Feuerlöscher, Schulungen, Defibrillator, Erste Hilfe",
+    "description": "brandschutzzentrale: Brandschutz und Arbeitssicherheit \\- Feuerl\u00f6scher, Schulungen, Defibrillator, Erste Hilfe",
     "llmsTxtUrl": "https://brandschutz-zentrale.de/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=brandschutz-zentrale.de&sz=128",
@@ -1827,7 +1836,7 @@
   {
     "name": "BrewPage",
     "domain": "https://brewpage.app",
-    "description": "Paste HTML, Markdown or drop any file — get a shareable HTTPS link in seconds. No signup. REST API and AI-agent friendly.",
+    "description": "Paste HTML, Markdown or drop any file \u2014 get a shareable HTTPS link in seconds. No signup. REST API and AI-agent friendly.",
     "llmsTxtUrl": "https://brewpage.app/llms.txt",
     "llmsFullTxtUrl": "https://brewpage.app/llms-full.txt",
     "category": "infrastructure-cloud",
@@ -1847,7 +1856,7 @@
   {
     "name": "BrillMark | By the help of our CRO Test Development Team's Insights we have curated a list of best practices while makin",
     "domain": "https://www.brillmark.com/",
-    "description": "BrillMark delivers high-velocity A/B test development, CRO Support, and Custom web development — seamlessly integrating with your team to drive real results across any platform without overburdening your resources.",
+    "description": "BrillMark delivers high-velocity A/B test development, CRO Support, and Custom web development \u2014 seamlessly integrating with your team to drive real results across any platform without overburdening your resources.",
     "llmsTxtUrl": "https://www.brillmark.com/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=www.brillmark.com&sz=128",
@@ -1901,7 +1910,7 @@
   {
     "name": "Buero Lightwaves",
     "domain": "https://lightwaves.io/",
-    "description": "Wir entwickeln weltklasse Websites, Homepages, Logos & Flyer, die dir mehr Kundschaft bringen. Superschnell. Superfair. Direkt aus Österreich.",
+    "description": "Wir entwickeln weltklasse Websites, Homepages, Logos & Flyer, die dir mehr Kundschaft bringen. Superschnell. Superfair. Direkt aus \u00d6sterreich.",
     "llmsTxtUrl": "https://lightwaves.io/llms.txt",
     "llmsFullTxtUrl": "https://lightwaves.io/llms-full.txt",
     "category": "ai-ml",
@@ -1986,7 +1995,7 @@
   {
     "name": "Buy Sustainable and Eco Friendly Shoes In India- GreenSole",
     "domain": "https://www.greensole.com/",
-    "description": "Shop a wide range of recycled, vegan, and earth-friendly shoes in India. Get environmentally friendly footwear that’s stylish and sustainably crafted.",
+    "description": "Shop a wide range of recycled, vegan, and earth-friendly shoes in India. Get environmentally friendly footwear that\u2019s stylish and sustainably crafted.",
     "llmsTxtUrl": "https://www.greensole.com/llms.txt",
     "llmsFullTxtUrl": "https://www.greensole.com/llms-full.txt",
     "category": "ai-ml",
@@ -2006,7 +2015,7 @@
   {
     "name": "BW Stay - Black & White Stays",
     "domain": "https://www.bwstays.com/index.html",
-    "description": "Discover Black and White Stays in Kalpetta, Wayanad—Kerala’s gem near destinations for staycation, workation, sightseeing, resorts, villas, hotels & homestays",
+    "description": "Discover Black and White Stays in Kalpetta, Wayanad\u2014Kerala\u2019s gem near destinations for staycation, workation, sightseeing, resorts, villas, hotels & homestays",
     "llmsTxtUrl": "https://www.bwstays.com/llms.txt",
     "llmsFullTxtUrl": "https://www.bwstays.com/llms-full.txt",
     "category": "ai-ml",
@@ -2073,7 +2082,7 @@
   {
     "name": "Capitaleventi Srl",
     "domain": "https://www.capitaleventi.it/",
-    "description": "Capitaleventi è un'agenzia eventi a Roma specializzata in organizzazione di eventi, feste in location esclusive, ville, loft e locali. Infoline: 347 1167581.",
+    "description": "Capitaleventi \u00e8 un'agenzia eventi a Roma specializzata in organizzazione di eventi, feste in location esclusive, ville, loft e locali. Infoline: 347 1167581.",
     "llmsTxtUrl": "https://www.capitaleventi.it/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=www.capitaleventi.it&sz=128",
@@ -2091,7 +2100,7 @@
   {
     "name": "Car Rental in Airports of\\_Georgia",
     "domain": "https://parent.ge",
-    "description": "Best rated car rental in Georgia. Best deals for economy, SUV and 4x4 cars in Tbilisi, Kutaisi and Batumi Airports. Affordable prices, driver''s service.",
+    "description": "Best rated car rental in Georgia. Best deals for economy, SUV and 4x4 cars in Tbilisi, Kutaisi and Batumi Airports. Affordable prices, driver''s\u00a0service.",
     "llmsTxtUrl": "https://parent.ge/llms.txt",
     "category": "security-identity",
     "favicon": "https://www.google.com/s2/favicons?domain=parent.ge&sz=128",
@@ -2118,7 +2127,7 @@
   {
     "name": "CareInn Talent",
     "domain": "https://careinn-talent.com/",
-    "description": "Conéctate con oportunidades de trabajo de enfermeria en Austria para profesionales. Descubre cómo podemos ayudarte en todo el proceso. ¡Tu nueva vida en Europa comienza aquí!",
+    "description": "Con\u00e9ctate con oportunidades de trabajo de enfermeria en Austria para profesionales. Descubre c\u00f3mo podemos ayudarte en todo el proceso. \u00a1Tu nueva vida en Europa comienza aqu\u00ed!",
     "llmsTxtUrl": "https://careinn-talent.com/llms.txt",
     "llmsFullTxtUrl": "https://careinn-talent.com/llms-full.txt",
     "category": "ai-ml",
@@ -2126,9 +2135,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Cariló Alojamiento Alquiler",
+    "name": "Caril\u00f3 Alojamiento Alquiler",
     "domain": "https://ilbuco.com.ar/",
-    "description": "Cariló alojamiento y alquiler de casa moderna. Residencia tecnológica ultra-moderna en Cariló, Argentina.",
+    "description": "Caril\u00f3 alojamiento y alquiler de casa moderna. Residencia tecnol\u00f3gica ultra-moderna en Caril\u00f3, Argentina.",
     "llmsTxtUrl": "https://ilbuco.com.ar/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=ilbuco.com.ar&sz=128",
@@ -2172,9 +2181,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Casino Space België",
+    "name": "Casino Space Belgi\u00eb",
     "domain": "https://casinospacebe.com/",
-    "description": "Bekijk onze onafhankelijke vergelijking van erkende Belgische online casino’s met vergunning. Vergelijk bonussen, spellen & uitbetalingen voor een veilige gokervaring in 2026 bij ons.",
+    "description": "Bekijk onze onafhankelijke vergelijking van erkende Belgische online casino\u2019s met vergunning. Vergelijk bonussen, spellen & uitbetalingen voor een veilige gokervaring in 2026 bij ons.",
     "llmsTxtUrl": "https://casinospacebe.com/llms.txt",
     "llmsFullTxtUrl": "https://casinospacebe.com/llms-full.txt",
     "category": "data-analytics",
@@ -2184,7 +2193,7 @@
   {
     "name": "Casinos Jackpot",
     "domain": "https://casinos-jackpot.net/",
-    "description": "CASINOS JACKPOT juin 2026 , le guide des établissements pour jouer et gagner le jackpot, les meilleurs établissements francophones, liste des jeux gratuits",
+    "description": "CASINOS JACKPOT juin 2026 , le guide des \u00e9tablissements pour jouer et gagner le jackpot, les meilleurs \u00e9tablissements francophones, liste des jeux gratuits",
     "llmsTxtUrl": "https://casinos-jackpot.net/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=casinos-jackpot.net&sz=128",
@@ -2236,18 +2245,18 @@
     "publishedAt": "2025-06-16"
   },
   {
-    "name": "Centro de oftalmología Barraquer",
+    "name": "Centro de oftalmolog\u00eda Barraquer",
     "domain": "https://www.barraquer.com/es",
-    "description": "Barraquer es una clínica oftalmológica en Barcelona de gran prestigio a nivel nacional e internacional dedicada a la investigación, tratamiento y control d",
+    "description": "Barraquer es una cl\u00ednica oftalmol\u00f3gica en Barcelona de gran prestigio a nivel nacional e internacional dedicada a la investigaci\u00f3n, tratamiento y control d",
     "llmsTxtUrl": "https://www.barraquer.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.barraquer.com/es&sz=128",
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Centro Desintoxicación Valencia",
+    "name": "Centro Desintoxicaci\u00f3n Valencia",
     "domain": "https://www.valenciaadicciones.es/",
-    "description": "Centro Desintoxicación Valencia. Psicólogos especialistas Adicciones. Tratamiento Alcoholismo. Dejar la cocaína ☎️ 617846402",
+    "description": "Centro Desintoxicaci\u00f3n Valencia. Psic\u00f3logos especialistas Adicciones. Tratamiento Alcoholismo. Dejar la coca\u00edna \u260e\ufe0f 617846402",
     "llmsTxtUrl": "https://www.valenciaadicciones.es/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.valenciaadicciones.es&sz=128",
@@ -2256,7 +2265,7 @@
   {
     "name": "Chainspect",
     "domain": "https://chainspect.app/",
-    "description": "Chainspect is Web3’s top blockchain fundamentals tracker focused on technical metrics like TPS, Max TPS, Finality, and Block Time across 50+ blockchains",
+    "description": "Chainspect is Web3\u2019s top blockchain fundamentals tracker focused on technical metrics like TPS, Max TPS, Finality, and Block Time across 50+ blockchains",
     "llmsTxtUrl": "https://chainspect.app/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=chainspect.app&sz=128",
@@ -2281,16 +2290,6 @@
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=chakra-ui.com&sz=128",
     "publishedAt": "2025-03-20"
-  },
-  {
-    "name": "Chánh Đại",
-    "domain": "https://chanhdai.com/",
-    "description": "Creating with code. Small details matter.",
-    "llmsTxtUrl": "https://chanhdai.com/llms.txt",
-    "llmsFullTxtUrl": "https://chanhdai.com/llms-full.txt",
-    "category": "developer-tools",
-    "favicon": "https://www.google.com/s2/favicons?domain=chanhdai.com&sz=128",
-    "publishedAt": "2026-05-31"
   },
   {
     "name": "Chargeblast",
@@ -2333,7 +2332,7 @@
   {
     "name": "ChatBot",
     "domain": "https://www.chatbot.com/",
-    "description": "ChatBot® uses AI-generated responses to instantly help your customers. Get 24/7 support and ultra-high satisfaction rates. Test an AI chatbot for free.",
+    "description": "ChatBot\u00ae uses AI-generated responses to instantly help your customers. Get 24/7 support and ultra-high satisfaction rates. Test an AI chatbot for free.",
     "llmsTxtUrl": "https://www.chatbot.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.chatbot.com&sz=128",
@@ -2351,7 +2350,7 @@
   {
     "name": "ChatKnow",
     "domain": "https://chatknow.com",
-    "description": "Enterprise-level “cross-border private” domain marketing management tool.",
+    "description": "Enterprise-level \u201ccross-border private\u201d domain marketing management tool.",
     "llmsTxtUrl": "https://docs.chatknow.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=chatknow.com&sz=128",
@@ -2397,7 +2396,7 @@
   {
     "name": "Chicly",
     "domain": "https://chicly.fr/",
-    "description": "Explore, inspire, illumine ton style ! Découvre les dernières tendances maquillage, soins, manucure, coiffure & produits de beauté, avec des conseils accessibles 🌿💄",
+    "description": "Explore, inspire, illumine ton style ! D\u00e9couvre les derni\u00e8res tendances maquillage, soins, manucure, coiffure & produits de beaut\u00e9, avec des conseils accessibles \ud83c\udf3f\ud83d\udc84",
     "llmsTxtUrl": "https://chicly.fr/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=chicly.fr&sz=128",
@@ -2440,6 +2439,16 @@
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=chronova.dev&sz=128",
     "publishedAt": "2026-05-15"
+  },
+  {
+    "name": "Ch\u00e1nh \u0110\u1ea1i",
+    "domain": "https://chanhdai.com/",
+    "description": "Creating with code. Small details matter.",
+    "llmsTxtUrl": "https://chanhdai.com/llms.txt",
+    "llmsFullTxtUrl": "https://chanhdai.com/llms-full.txt",
+    "category": "developer-tools",
+    "favicon": "https://www.google.com/s2/favicons?domain=chanhdai.com&sz=128",
+    "publishedAt": "2026-05-31"
   },
   {
     "name": "CID Contact",
@@ -2555,7 +2564,7 @@
   {
     "name": "Clerk",
     "domain": "https://clerk.com/",
-    "description": "The easiest way to add authentication and user management to your application. Purpose-built for React, Next.js, Remix, and “The Modern Web”.",
+    "description": "The easiest way to add authentication and user management to your application. Purpose-built for React, Next.js, Remix, and \u201cThe Modern Web\u201d.",
     "llmsTxtUrl": "https://clerk.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=clerk.com&sz=128",
@@ -2580,9 +2589,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Clixi – Rides Made for the Mountains.",
+    "name": "Clixi \u2013 Rides Made for the Mountains.",
     "domain": "https://clixi.in/",
-    "description": "For towns where distances aren’t long, but getting there still matters.​",
+    "description": "For towns where distances aren\u2019t long, but getting there still matters.\u200b",
     "llmsTxtUrl": "https://clixi.in/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=clixi.in&sz=128",
@@ -2834,7 +2843,7 @@
   {
     "name": "Common Ninja",
     "domain": "https://commoninja.com",
-    "description": "Boost engagement and increase conversions on your website with Common Ninja’s free widgets and apps—simple to embed on any website.",
+    "description": "Boost engagement and increase conversions on your website with Common Ninja\u2019s free widgets and apps\u2014simple to embed on any website.",
     "llmsTxtUrl": "https://docs.commoninja.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=commoninja.com&sz=128",
@@ -2927,7 +2936,7 @@
   {
     "name": "Contabilizei: a maior contabilidade online do Brasil",
     "domain": "https://www.contabilizei.com.br/",
-    "description": "Tenha uma contabilidade online completa, prática e segura a partir de R$195/mês. Conheça a Contabilizei, o contador online que cuida de tudo para você!",
+    "description": "Tenha uma contabilidade online completa, pr\u00e1tica e segura a partir de R$195/m\u00eas. Conhe\u00e7a a Contabilizei, o contador online que cuida de tudo para voc\u00ea!",
     "llmsTxtUrl": "https://www.contabilizei.com.br/llms.txt",
     "llmsFullTxtUrl": "https://www.contabilizei.com.br/llms-full.txt",
     "category": "ai-ml",
@@ -2937,7 +2946,7 @@
   {
     "name": "Container hosting at VPS prices",
     "domain": "https://justrunmy.app/",
-    "description": "Run containers at VPS prices with PaaS simplicity. Git push, Docker image/push, Zip Upload, Templates. Free tier included. Pay‑as‑you‑go pricing.",
+    "description": "Run containers at VPS prices with PaaS simplicity. Git push, Docker image/push, Zip Upload, Templates. Free tier included. Pay\u2011as\u2011you\u2011go pricing.",
     "llmsTxtUrl": "https://justrunmy.app/llms.txt",
     "category": "infrastructure-cloud",
     "favicon": "https://www.google.com/s2/favicons?domain=justrunmy.app&sz=128",
@@ -2965,7 +2974,7 @@
   {
     "name": "Continual-G",
     "domain": "https://continualg.com/",
-    "description": "Continual-G is the best cellular glutathione booster in USA with Glyteine®, the clinically proven glutathione precursor for overall wellness in a single dose.",
+    "description": "Continual-G is the best cellular glutathione booster in USA with Glyteine\u00ae, the clinically proven glutathione precursor for overall wellness in a single dose.",
     "llmsTxtUrl": "https://continualg.com/llms.txt",
     "llmsFullTxtUrl": "https://continualg.com/llms-full.txt",
     "category": "developer-tools",
@@ -3148,7 +3157,7 @@
     "publishedAt": "2025-08-26"
   },
   {
-    "name": "Credibled · Background Checks",
+    "name": "Credibled \u00b7 Background Checks",
     "domain": "https://credibled.com",
     "description": "Canadian background check platform built in Toronto. ~15-minute criminal checks with ID verification included. Dedicated rep on every account. No subscription.",
     "llmsTxtUrl": "https://credibled.com/llms.txt",
@@ -3156,15 +3165,6 @@
     "category": "security-identity",
     "favicon": "https://www.google.com/s2/favicons?domain=credibled.com&sz=128",
     "publishedAt": "2026-05-24"
-  },
-  {
-    "name": "Créer une société en Irlande — Accompagnement pour entrepreneurs francophones | Société-France-Irlande",
-    "domain": "https://societe-france-irlande.com/",
-    "description": "Notre cabinet conseil entrepreneurial vous accompagne sur la création de votre société en Irlande, la banque en Irlande et les autres services.",
-    "llmsTxtUrl": "https://societe-france-irlande.com/llms.txt",
-    "category": "data-analytics",
-    "favicon": "https://www.google.com/s2/favicons?domain=societe-france-irlande.com&sz=128",
-    "publishedAt": "2026-05-31"
   },
   {
     "name": "CrewAI",
@@ -3204,9 +3204,18 @@
     "publishedAt": "2026-05-31"
   },
   {
+    "name": "Cr\u00e9er une soci\u00e9t\u00e9 en Irlande \u2014 Accompagnement pour entrepreneurs francophones | Soci\u00e9t\u00e9-France-Irlande",
+    "domain": "https://societe-france-irlande.com/",
+    "description": "Notre cabinet conseil entrepreneurial vous accompagne sur la cr\u00e9ation de votre soci\u00e9t\u00e9 en Irlande, la banque en Irlande et les autres services.",
+    "llmsTxtUrl": "https://societe-france-irlande.com/llms.txt",
+    "category": "data-analytics",
+    "favicon": "https://www.google.com/s2/favicons?domain=societe-france-irlande.com&sz=128",
+    "publishedAt": "2026-05-31"
+  },
+  {
     "name": "CS2 AG | Professionelle Digital",
     "domain": "https://www.cs2.ch/",
-    "description": "Webagentur Schweiz für Corporate Websites, Onlineshops, Individual Applikationen. Open Source mit TYPO3, Magento, Laravel. Beratung bis Umsetzung, seit 1997",
+    "description": "Webagentur Schweiz f\u00fcr Corporate Websites, Onlineshops, Individual Applikationen. Open Source mit TYPO3, Magento, Laravel. Beratung bis Umsetzung, seit 1997",
     "llmsTxtUrl": "https://www.cs2.ch/llms.txt",
     "llmsFullTxtUrl": "https://www.cs2.ch/llms-full.txt",
     "category": "ai-ml",
@@ -3216,7 +3225,7 @@
   {
     "name": "Cuba Collectibles",
     "domain": "https://www.cubacollectibles.com/",
-    "description": "Cuba Collectibles - We Buy & Sell old and rare vintage Cuba collectible memorabilia and antiques gifts for Cubans and collectors | Compra y venta colección de antigüedades y recordatorios de Cuba para cubanos y coleccionistas",
+    "description": "Cuba Collectibles - We Buy & Sell old and rare vintage Cuba collectible memorabilia and antiques gifts for Cubans and collectors | Compra y venta colecci\u00f3n de antig\u00fcedades y recordatorios de Cuba para cubanos y coleccionistas",
     "llmsTxtUrl": "https://www.cubacollectibles.com/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=www.cubacollectibles.com&sz=128",
@@ -3255,7 +3264,7 @@
   {
     "name": "Customer Service AI platform",
     "domain": "https://www.gladly.ai/",
-    "description": "Gladly is the AI customer service software that powers radically efficient, radically personal support—treating people like people, not tickets.",
+    "description": "Gladly is the AI customer service software that powers radically efficient, radically personal support\u2014treating people like people, not tickets.",
     "llmsTxtUrl": "https://www.gladly.ai/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.gladly.ai&sz=128",
@@ -3282,7 +3291,7 @@
   {
     "name": "Cybersecurity aus Deutschland",
     "domain": "https://a7.de",
-    "description": "ISO-27001-zertifizierte Cybersecurity aus Deutschland: Penetrationstests, ISMS-Beratung und Phishing-Simulationen für den Mittelstand. Festpreisangebot in 24h.",
+    "description": "ISO-27001-zertifizierte Cybersecurity aus Deutschland: Penetrationstests, ISMS-Beratung und Phishing-Simulationen f\u00fcr den Mittelstand. Festpreisangebot in 24h.",
     "llmsTxtUrl": "https://a7.de/llms.txt",
     "llmsFullTxtUrl": "https://a7.de/llms-full.txt",
     "category": "security-identity",
@@ -3368,7 +3377,7 @@
   {
     "name": "Data-Driven AI Growth Consultancy",
     "domain": "https://nimblegravity.com/",
-    "description": "Transform your business with Nimble Gravity’s data science, analytics, and digital strategy experts. From BI to CRO, we turn insight into impact. Contact the team today.",
+    "description": "Transform your business with Nimble Gravity\u2019s data science, analytics, and digital strategy experts. From BI to CRO, we turn insight into impact. Contact the team today.",
     "llmsTxtUrl": "https://nimblegravity.com/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=nimblegravity.com&sz=128",
@@ -3432,7 +3441,7 @@
   {
     "name": "DataRemote",
     "domain": "https://dataremote.com/",
-    "description": "Transform aging copper lines with DataRemote POTS replacement and cellular failover—fax, fire panel, alarm, elevator and voice with full E-911 support.",
+    "description": "Transform aging copper lines with DataRemote POTS replacement and cellular failover\u2014fax, fire panel, alarm, elevator and voice with full E-911 support.",
     "llmsTxtUrl": "https://dataremote.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=dataremote.com&sz=128",
@@ -3585,7 +3594,7 @@
   {
     "name": "DentalKids Family Clinic & Beauty",
     "domain": "https://dentalkids.com.ua/",
-    "description": "Семейная стоматология в Киеве – лечение зубов детей и взрослых быстро и качественно✅Запись к врачу семейной стоматологии – на прием, бесплатную консультацию🦷Лучшие врачи стоматологи Киева, отзывы о семейных стоматологах👍",
+    "description": "\u0421\u0435\u043c\u0435\u0439\u043d\u0430\u044f \u0441\u0442\u043e\u043c\u0430\u0442\u043e\u043b\u043e\u0433\u0438\u044f \u0432 \u041a\u0438\u0435\u0432\u0435 \u2013 \u043b\u0435\u0447\u0435\u043d\u0438\u0435 \u0437\u0443\u0431\u043e\u0432 \u0434\u0435\u0442\u0435\u0439 \u0438 \u0432\u0437\u0440\u043e\u0441\u043b\u044b\u0445 \u0431\u044b\u0441\u0442\u0440\u043e \u0438 \u043a\u0430\u0447\u0435\u0441\u0442\u0432\u0435\u043d\u043d\u043e\u2705\u0417\u0430\u043f\u0438\u0441\u044c \u043a \u0432\u0440\u0430\u0447\u0443 \u0441\u0435\u043c\u0435\u0439\u043d\u043e\u0439 \u0441\u0442\u043e\u043c\u0430\u0442\u043e\u043b\u043e\u0433\u0438\u0438 \u2013 \u043d\u0430 \u043f\u0440\u0438\u0435\u043c, \u0431\u0435\u0441\u043f\u043b\u0430\u0442\u043d\u0443\u044e \u043a\u043e\u043d\u0441\u0443\u043b\u044c\u0442\u0430\u0446\u0438\u044e\ud83e\uddb7\u041b\u0443\u0447\u0448\u0438\u0435 \u0432\u0440\u0430\u0447\u0438 \u0441\u0442\u043e\u043c\u0430\u0442\u043e\u043b\u043e\u0433\u0438 \u041a\u0438\u0435\u0432\u0430, \u043e\u0442\u0437\u044b\u0432\u044b \u043e \u0441\u0435\u043c\u0435\u0439\u043d\u044b\u0445 \u0441\u0442\u043e\u043c\u0430\u0442\u043e\u043b\u043e\u0433\u0430\u0445\ud83d\udc4d",
     "llmsTxtUrl": "https://dentalkids.com.ua/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=dentalkids.com.ua&sz=128",
@@ -3594,7 +3603,7 @@
   {
     "name": "DentaTool",
     "domain": "https://www.dentatool.de/",
-    "description": "DentaTool ist Cloud-Laborsoftware für Dentallabore: Auftragsverwaltung, Abrechnung, EU-MDR, Zeiterfassung, Kundenportal und Controlling in einem System.",
+    "description": "DentaTool ist Cloud-Laborsoftware f\u00fcr Dentallabore: Auftragsverwaltung, Abrechnung, EU-MDR, Zeiterfassung, Kundenportal und Controlling in einem System.",
     "llmsTxtUrl": "https://www.dentatool.de/llms.txt",
     "category": "infrastructure-cloud",
     "favicon": "https://www.google.com/s2/favicons?domain=www.dentatool.de&sz=128",
@@ -3612,7 +3621,7 @@
   {
     "name": "Designmodo",
     "domain": "https://designmodo.com",
-    "description": "Build beautiful email designs, websites, and responsive landing pages with Designmodo’s email & web design tools in minutes — no coding needed.",
+    "description": "Build beautiful email designs, websites, and responsive landing pages with Designmodo\u2019s email & web design tools in minutes \u2014 no coding needed.",
     "llmsTxtUrl": "https://designmodo.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=designmodo.com&sz=128",
@@ -3687,7 +3696,7 @@
   {
     "name": "DexPaprika API | Live Crypto & Pool Data",
     "domain": "https://docs.dexpaprika.com/",
-    "description": "DexPaprika API streams real-time DEX token prices, liquidity pools & volumes—ideal fuel for AI agents powering trading dashboards, portfolios & DeFi apps.",
+    "description": "DexPaprika API streams real-time DEX token prices, liquidity pools & volumes\u2014ideal fuel for AI agents powering trading dashboards, portfolios & DeFi apps.",
     "llmsTxtUrl": "https://docs.dexpaprika.com/llms.txt",
     "llmsFullTxtUrl": "https://docs.dexpaprika.com/llms-full.txt",
     "category": "data-analytics",
@@ -3705,9 +3714,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Digitalbyrå i Stockholm och Kalmar",
+    "name": "Digitalbyr\u00e5 i Stockholm och Kalmar",
     "domain": "https://www.wilsoncreative.se/",
-    "description": "Prisbelönt digitalbyrå i Stockholm och Kalmar. Webbutveckling, digital marknadsföring, design och filmproduktion under ett tak.",
+    "description": "Prisbel\u00f6nt digitalbyr\u00e5 i Stockholm och Kalmar. Webbutveckling, digital marknadsf\u00f6ring, design och filmproduktion under ett tak.",
     "llmsTxtUrl": "https://www.wilsoncreative.se/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.wilsoncreative.se&sz=128",
@@ -3723,9 +3732,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Dijital Sürmanşet",
+    "name": "Dijital S\u00fcrman\u015fet",
     "domain": "https://dijitalsurmanset.com/",
-    "description": "Dijital Surmanset, teknoloji dünyasından en son haberler, trendler ve sosyal medya gelişmeleri hakkında bilgiler sunar.",
+    "description": "Dijital Surmanset, teknoloji d\u00fcnyas\u0131ndan en son haberler, trendler ve sosyal medya geli\u015fmeleri hakk\u0131nda bilgiler sunar.",
     "llmsTxtUrl": "https://dijitalsurmanset.com/llms.txt",
     "llmsFullTxtUrl": "https://dijitalsurmanset.com/llms-full.txt",
     "category": "data-analytics",
@@ -3742,9 +3751,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Disclos — EU AI Act Audit",
+    "name": "Disclos \u2014 EU AI Act Audit",
     "domain": "https://www.disclos.eu",
-    "description": "Five-day audit that makes your AI-using SaaS compliant with the EU AI Act before 2 August 2026. €997, refund-guaranteed, delivered by the Disclos team.",
+    "description": "Five-day audit that makes your AI-using SaaS compliant with the EU AI Act before 2 August 2026. \u20ac997, refund-guaranteed, delivered by the Disclos team.",
     "llmsTxtUrl": "https://www.disclos.eu/llms.txt",
     "category": "security-identity",
     "favicon": "https://www.google.com/s2/favicons?domain=www.disclos.eu&sz=128",
@@ -3790,7 +3799,7 @@
   {
     "name": "DocPP - Cloud-base Doctors Private Practice Solution | HealthCare.LK | Sri Lanka - \"DocPP\"- Cloudbased Software System f",
     "domain": "https://healthcare.lk/",
-    "description": "Since 2008, Transform your private practice with DocPP — a cloud EMR built for Sri Lankan doctors. Paperless workflows, patient management & billing in one platform.",
+    "description": "Since 2008, Transform your private practice with DocPP \u2014 a cloud EMR built for Sri Lankan doctors. Paperless workflows, patient management & billing in one platform.",
     "llmsTxtUrl": "https://healthcare.lk/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=healthcare.lk&sz=128",
@@ -3852,9 +3861,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Dr Saša Mišeljić",
+    "name": "Dr Sa\u0161a Mi\u0161elji\u0107",
     "domain": "https://drsasamiseljic.com/",
-    "description": "Dr Saša Mišeljić - Estetska hirurgija, operativne i neoperativne procedure. Nudimo usluge: podizanja grudi, povećanje grudi, reoblikovanje tela, skidanje masnih naslaga, liposukcija, vibro liposukciju, renuvion tretman, anti age tretmani...",
+    "description": "Dr Sa\u0161a Mi\u0161elji\u0107 - Estetska hirurgija, operativne i neoperativne procedure. Nudimo usluge: podizanja grudi, pove\u0107anje grudi, reoblikovanje tela, skidanje masnih naslaga, liposukcija, vibro liposukciju, renuvion tretman, anti age tretmani...",
     "llmsTxtUrl": "https://drsasamiseljic.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=drsasamiseljic.com&sz=128",
@@ -3988,16 +3997,16 @@
   {
     "name": "Effortless Contract Drafting and AI-Powered Reviews",
     "domain": "https://goheather.io/",
-    "description": "goHeather is the #1 Legal AI for individuals and companies. Create and review contracts tailored to your jurisdiction with ease. Try for free—no credit card needed.",
+    "description": "goHeather is the #1 Legal AI for individuals and companies. Create and review contracts tailored to your jurisdiction with ease. Try for free\u2014no credit card needed.",
     "llmsTxtUrl": "https://www.goheather.io/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=goheather.io&sz=128",
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "EKONOMİ KÖŞESİ",
+    "name": "EKONOM\u0130 K\u00d6\u015eES\u0130",
     "domain": "https://ekonomikosesi.com/",
-    "description": "Ekonomi Köşesi, ekonomik gelişmeler, iş dünyası haberleri hakkında güncel bilgiler sunar.",
+    "description": "Ekonomi K\u00f6\u015fesi, ekonomik geli\u015fmeler, i\u015f d\u00fcnyas\u0131 haberleri hakk\u0131nda g\u00fcncel bilgiler sunar.",
     "llmsTxtUrl": "https://ekonomikosesi.com/llms.txt",
     "llmsFullTxtUrl": "https://ekonomikosesi.com/llms-full.txt",
     "category": "data-analytics",
@@ -4005,9 +4014,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "EKONOMİNİN SESİ",
+    "name": "EKONOM\u0130N\u0130N SES\u0130",
     "domain": "https://ekonomininsesi.com/",
-    "description": "Ekonominin Sesi, ekonomi dünyasından son haberler, finansal analizler ve güncel piyasa verileri sunar.",
+    "description": "Ekonominin Sesi, ekonomi d\u00fcnyas\u0131ndan son haberler, finansal analizler ve g\u00fcncel piyasa verileri sunar.",
     "llmsTxtUrl": "https://ekonomininsesi.com/llms.txt",
     "llmsFullTxtUrl": "https://ekonomininsesi.com/llms-full.txt",
     "category": "ai-ml",
@@ -4017,7 +4026,7 @@
   {
     "name": "Ekoproduktas",
     "domain": "https://ekoproduktas.com/lt/",
-    "description": "Mūsų sausos alaus mielės gaminamos iš natūralių ingredientų, be cheminių priedų ir kruopščiai patikrintos dėl kokybės. Susisiekite su mumis!",
+    "description": "M\u016bs\u0173 sausos alaus miel\u0117s gaminamos i\u0161 nat\u016brali\u0173 ingredient\u0173, be chemini\u0173 pried\u0173 ir kruop\u0161\u010diai patikrintos d\u0117l kokyb\u0117s. Susisiekite su mumis!",
     "llmsTxtUrl": "https://ekoproduktas.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=ekoproduktas.com/lt&sz=128",
@@ -4123,7 +4132,7 @@
   {
     "name": "Epipoca",
     "domain": "https://epipoca.com.br/",
-    "description": "Descubra as últimas notícias de cinema, séries, TV, animes e cultura pop. Seu guia completo com resenhas, trailers e tudo sobre o mundo do entretenimento.",
+    "description": "Descubra as \u00faltimas not\u00edcias de cinema, s\u00e9ries, TV, animes e cultura pop. Seu guia completo com resenhas, trailers e tudo sobre o mundo do entretenimento.",
     "llmsTxtUrl": "https://www.epipoca.com.br/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=epipoca.com.br&sz=128",
@@ -4151,7 +4160,7 @@
   {
     "name": "eShare.ai",
     "domain": "https://www.eshare.ai/",
-    "description": "Why Cloud Storage AI File Sharing on eShare.ai? Fast, secure & AI‑powered. Try India’s top smart file‑sharing tool—boost productivity now!",
+    "description": "Why Cloud Storage AI File Sharing on eShare.ai? Fast, secure & AI\u2011powered. Try India\u2019s top smart file\u2011sharing tool\u2014boost productivity now!",
     "llmsTxtUrl": "https://www.eshare.ai/llms.txt",
     "category": "infrastructure-cloud",
     "favicon": "https://www.google.com/s2/favicons?domain=www.eshare.ai&sz=128",
@@ -4169,7 +4178,7 @@
   {
     "name": "Estrategia del Contenido",
     "domain": "https://www.estrategiadelcontenido.com/",
-    "description": "Reparamos problemas de y con contenidos. Creamos contenido. Operamos con estrategias de contenido líquido. Ejercemos el Periodismo de Marcas",
+    "description": "Reparamos problemas de y con contenidos. Creamos contenido. Operamos con estrategias de contenido l\u00edquido. Ejercemos el Periodismo de Marcas",
     "llmsTxtUrl": "https://www.estrategiadelcontenido.com/LLMS.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.estrategiadelcontenido.com&sz=128",
@@ -4225,7 +4234,7 @@
   {
     "name": "EvolvingDesk",
     "domain": "https://evolvingdesk.com/",
-    "description": "Get reliable and secure IT solutions at EvolvingDesk 🔒💻. Our team of experts ensures your technology works flawlessly ⚙️. Explore how we can help you 🚀.",
+    "description": "Get reliable and secure IT solutions at EvolvingDesk \ud83d\udd12\ud83d\udcbb. Our team of experts ensures your technology works flawlessly \u2699\ufe0f. Explore how we can help you \ud83d\ude80.",
     "llmsTxtUrl": "https://evolvingdesk.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=evolvingdesk.com&sz=128",
@@ -4338,7 +4347,7 @@
   {
     "name": "Ferla Family - Cargo Bikes",
     "domain": "https://ferlafamilybikes.com/",
-    "description": "The most advanced Bikes for Family for Sale 🚲 Explore the Best Electric Bicycles for Families: Award-Winning Design, Free Shipping, Financing Available :phone: +1 (213) 757-2009 - Bikes with Cart in FERLA",
+    "description": "The most advanced Bikes for Family for Sale \ud83d\udeb2 Explore the Best Electric Bicycles for Families: Award-Winning Design, Free Shipping, Financing Available :phone: +1 (213) 757-2009 - Bikes with Cart in FERLA",
     "llmsTxtUrl": "https://ferlafamilybikes.com/apps/llmstxt/llms.txt",
     "llmsFullTxtUrl": "https://ferlafamilybikes.com/llms-full.txt",
     "category": "ai-ml",
@@ -4366,7 +4375,7 @@
     "publishedAt": "2025-06-15"
   },
   {
-    "name": "Find Construction, Mining & Trade Jobs in Australia 🇦🇺",
+    "name": "Find Construction, Mining & Trade Jobs in Australia \ud83c\udde6\ud83c\uddfa",
     "domain": "https://www.tradeforge.com.au/",
     "description": "Browse thousands of construction, trade and mining jobs across Australia. Find your next career opportunity in construction, trades, and mining with Tradeforge.",
     "llmsTxtUrl": "https://www.tradeforge.com.au/llms.txt",
@@ -4574,7 +4583,7 @@
     "publishedAt": "2025-07-25"
   },
   {
-    "name": "Fraud Blocker™",
+    "name": "Fraud Blocker\u2122",
     "domain": "https://fraudblocker.com/",
     "description": "Maximize your ROI with Fraud Blocker: the complete solution for click fraud protection, fake lead prevention and data enrichment.",
     "llmsTxtUrl": "https://fraudblocker.com/llms.txt",
@@ -4594,7 +4603,7 @@
   {
     "name": "Free AI Image Generator & Maker",
     "domain": "https://muryou-aigazou.com/",
-    "description": "free, no-login, multilingual AI image generation platform. It offers high-quality image creation tools — suitable for personal and commercial use.",
+    "description": "free, no-login, multilingual AI image generation platform. It offers high-quality image creation tools \u2014 suitable for personal and commercial use.",
     "llmsTxtUrl": "https://muryou-aigazou.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=muryou-aigazou.com&sz=128",
@@ -4619,9 +4628,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "French Rêve",
+    "name": "French R\u00eave",
     "domain": "https://frenchreve.com/",
-    "description": "Seeking Native French Tutors in Sydney for Private French Lessons, Academic French Tuition or French Conversation Classes? Learn French Online with French Rêve !",
+    "description": "Seeking Native French Tutors in Sydney for Private French Lessons, Academic French Tuition or French Conversation Classes? Learn French Online with French R\u00eave !",
     "llmsTxtUrl": "https://frenchreve.com/llms.txt",
     "llmsFullTxtUrl": "https://frenchreve.com/llms-full.txt",
     "category": "security-identity",
@@ -4668,7 +4677,7 @@
   {
     "name": "Fuel LAB",
     "domain": "https://fuellabstudio.com/",
-    "description": "Fuel LAB è l'Azienda di Marketing Tecnologico partner di Google, Trustpilot, Supermetrics e Confcommercio. Scopri tutti i prodotti esclusivi Fuel LAB oggi.",
+    "description": "Fuel LAB \u00e8 l'Azienda di Marketing Tecnologico partner di Google, Trustpilot, Supermetrics e Confcommercio. Scopri tutti i prodotti esclusivi Fuel LAB oggi.",
     "llmsTxtUrl": "https://fuellabstudio.com/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=fuellabstudio.com&sz=128",
@@ -4815,7 +4824,7 @@
   {
     "name": "Geld24",
     "domain": "https://www.geld24.be/",
-    "description": "Op zoek naar de beste deal voor een kredietkaart, lening of ander financieel product? Op Geld24.be kun je uitgebreid financiële producten vergelijken.",
+    "description": "Op zoek naar de beste deal voor een kredietkaart, lening of ander financieel product? Op Geld24.be kun je uitgebreid financi\u00eble producten vergelijken.",
     "llmsTxtUrl": "https://www.geld24.be/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.geld24.be&sz=128",
@@ -4871,7 +4880,7 @@
   {
     "name": "Gi Bianco Tattoo Porto | Fineline & Delicate",
     "domain": "https://gibiancotattoo.pt/",
-    "description": "Procurando as melhores tatuagens no Porto? Conheça Gi Bianco Tattoo Porto, especialista em fine line e delicadas.",
+    "description": "Procurando as melhores tatuagens no Porto? Conhe\u00e7a Gi Bianco Tattoo Porto, especialista em fine line e delicadas.",
     "llmsTxtUrl": "https://gibiancotattoo.pt/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=gibiancotattoo.pt&sz=128",
@@ -4961,7 +4970,7 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Goldie Locks®",
+    "name": "Goldie Locks\u00ae",
     "domain": "https://goldielocks.com/",
     "description": "Experience the difference with hair solutions that go beyond traditional hair care.",
     "llmsTxtUrl": "https://goldielocks.com/llms.txt",
@@ -4982,7 +4991,7 @@
   {
     "name": "Google Hakukoneoptimointi SEO-palvelu | eLuotsi Tampere",
     "domain": "https://www.eluotsi.fi/",
-    "description": "Korkeatasoinen ja kokonaisvaltainen hakukoneoptimointi-palvelu: SEO, sisällöntuotanto ja linkkien hankinta. Järkevästi hinnoiteltu. Tuloksia tulee.",
+    "description": "Korkeatasoinen ja kokonaisvaltainen hakukoneoptimointi-palvelu: SEO, sis\u00e4ll\u00f6ntuotanto ja linkkien hankinta. J\u00e4rkev\u00e4sti hinnoiteltu. Tuloksia tulee.",
     "llmsTxtUrl": "https://www.eluotsi.fi/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.eluotsi.fi&sz=128",
@@ -5111,9 +5120,9 @@
     "publishedAt": "2025-05-06"
   },
   {
-    "name": "Grundum - Ihr Immobilienmakler für Wiesbaden, Frankfurt, Mainz, Alzey und Umgebung",
+    "name": "Grundum - Ihr Immobilienmakler f\u00fcr Wiesbaden, Frankfurt, Mainz, Alzey und Umgebung",
     "domain": "https://grundum.de/",
-    "description": "GRUNDUM Immobilien ist ein familiengeführtes Maklerunternehmen mit Büros in Wiesbaden, Mainz, Frankfurt und Alzey ☎️ 0611-974514140",
+    "description": "GRUNDUM Immobilien ist ein familiengef\u00fchrtes Maklerunternehmen mit B\u00fcros in Wiesbaden, Mainz, Frankfurt und Alzey \u260e\ufe0f 0611-974514140",
     "llmsTxtUrl": "https://grundum.de/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=grundum.de&sz=128",
@@ -5122,7 +5131,7 @@
   {
     "name": "Guilherme Godoy",
     "domain": "https://guilhermegodoy.com/",
-    "description": "Guilherme Godoy – Artista, musicista e criador de conteúdo que explora a interseção entre tecnologia, arte e humanidade para inspirar mudanças.",
+    "description": "Guilherme Godoy \u2013 Artista, musicista e criador de conte\u00fado que explora a interse\u00e7\u00e3o entre tecnologia, arte e humanidade para inspirar mudan\u00e7as.",
     "llmsTxtUrl": "https://guilhermegodoy.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=guilhermegodoy.com&sz=128",
@@ -5140,7 +5149,7 @@
   {
     "name": "Gyn-Oncology",
     "domain": "https://gyn-oncology.gr/",
-    "description": "Gyn-Oncology: Καλώς ορίσατε στην Γυναικολογική Κλινική Ογκολογίας και Ρομποτικής Χειρουργικής του Ιατρικού Διαβαλκανικού Θεσσαλονίκης.",
+    "description": "Gyn-Oncology: \u039a\u03b1\u03bb\u03ce\u03c2 \u03bf\u03c1\u03af\u03c3\u03b1\u03c4\u03b5 \u03c3\u03c4\u03b7\u03bd \u0393\u03c5\u03bd\u03b1\u03b9\u03ba\u03bf\u03bb\u03bf\u03b3\u03b9\u03ba\u03ae \u039a\u03bb\u03b9\u03bd\u03b9\u03ba\u03ae \u039f\u03b3\u03ba\u03bf\u03bb\u03bf\u03b3\u03af\u03b1\u03c2 \u03ba\u03b1\u03b9 \u03a1\u03bf\u03bc\u03c0\u03bf\u03c4\u03b9\u03ba\u03ae\u03c2 \u03a7\u03b5\u03b9\u03c1\u03bf\u03c5\u03c1\u03b3\u03b9\u03ba\u03ae\u03c2 \u03c4\u03bf\u03c5 \u0399\u03b1\u03c4\u03c1\u03b9\u03ba\u03bf\u03cd \u0394\u03b9\u03b1\u03b2\u03b1\u03bb\u03ba\u03b1\u03bd\u03b9\u03ba\u03bf\u03cd \u0398\u03b5\u03c3\u03c3\u03b1\u03bb\u03bf\u03bd\u03af\u03ba\u03b7\u03c2.",
     "llmsTxtUrl": "https://gyn-oncology.gr/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=gyn-oncology.gr&sz=128",
@@ -5261,7 +5270,7 @@
   {
     "name": "Heart Emoji",
     "domain": "https://heartemoji.im/",
-    "description": "Heart Emoji provides the most comprehensive collection of heart emojis and love symbols. One-click copy for red hearts ❤️, pink hearts 🩷, and colorful heart emojis 💛💚💙💜 to express your love!",
+    "description": "Heart Emoji provides the most comprehensive collection of heart emojis and love symbols. One-click copy for red hearts \u2764\ufe0f, pink hearts \ud83e\ude77, and colorful heart emojis \ud83d\udc9b\ud83d\udc9a\ud83d\udc99\ud83d\udc9c to express your love!",
     "llmsTxtUrl": "https://heartemoji.im/llms.txt",
     "llmsFullTxtUrl": "https://heartemoji.im/llms-full.txt",
     "category": "developer-tools",
@@ -5280,7 +5289,7 @@
   {
     "name": "heeb",
     "domain": "https://heeb.ai",
-    "description": "One API to track mentions, sentiment, and visibility across top LLMs. Uncover where you appear, what’s missing, and how to improve your AI presence.",
+    "description": "One API to track mentions, sentiment, and visibility across top LLMs. Uncover where you appear, what\u2019s missing, and how to improve your AI presence.",
     "llmsTxtUrl": "https://heeb.ai/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=heeb.ai&sz=128",
@@ -5345,7 +5354,7 @@
   {
     "name": "Heriteo",
     "domain": "https://heriteo.com/",
-    "description": "Heriteo helps families catalog heirlooms, share the stories behind them, and plan a fair, transparent inheritance — all in one place.",
+    "description": "Heriteo helps families catalog heirlooms, share the stories behind them, and plan a fair, transparent inheritance \u2014 all in one place.",
     "llmsTxtUrl": "https://heriteo.com/llms.txt",
     "llmsFullTxtUrl": "https://heriteo.com/llms-full.txt",
     "category": "ai-ml",
@@ -5382,7 +5391,7 @@
   {
     "name": "holz.biz",
     "domain": "https://holz.biz/",
-    "description": "Kauf dein gehobeltes Massivholz für dein nächstes DIY Möbelprojekt ganz einfach online bei holz.biz. Wir freuen uns auf dich.",
+    "description": "Kauf dein gehobeltes Massivholz f\u00fcr dein n\u00e4chstes DIY M\u00f6belprojekt ganz einfach online bei holz.biz. Wir freuen uns auf dich.",
     "llmsTxtUrl": "https://holz.biz/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=holz.biz&sz=128",
@@ -5427,7 +5436,16 @@
     "publishedAt": "2025-05-30"
   },
   {
-    "name": "Home • Angular",
+    "name": "Home Page",
+    "domain": "https://www.consumermesh.com/",
+    "description": "Launch enterprise websites and portals in weeks \u2014 not months. Preserve your exact Figma vision with scalable, compliant digital experiences you can update without developers.",
+    "llmsTxtUrl": "https://www.consumermesh.com/llms.txt",
+    "category": "developer-tools",
+    "favicon": "https://www.google.com/s2/favicons?domain=www.consumermesh.com&sz=128",
+    "publishedAt": "2026-05-31"
+  },
+  {
+    "name": "Home \u2022 Angular",
     "domain": "https://angular.dev",
     "description": "The web development framework for building modern apps.",
     "llmsTxtUrl": "https://angular.dev/llms.txt",
@@ -5435,15 +5453,6 @@
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=angular.dev&sz=128",
     "publishedAt": "2025-05-24"
-  },
-  {
-    "name": "Home Page",
-    "domain": "https://www.consumermesh.com/",
-    "description": "Launch enterprise websites and portals in weeks — not months. Preserve your exact Figma vision with scalable, compliant digital experiences you can update without developers.",
-    "llmsTxtUrl": "https://www.consumermesh.com/llms.txt",
-    "category": "developer-tools",
-    "favicon": "https://www.google.com/s2/favicons?domain=www.consumermesh.com&sz=128",
-    "publishedAt": "2026-05-31"
   },
   {
     "name": "Hono",
@@ -5458,7 +5467,7 @@
   {
     "name": "Horoscope Gratuit du Jour",
     "domain": "https://www.mon-horoscope-du-jour.com/",
-    "description": "Horoscope du jour gratuit avec vos prévisions en amour ❤️ et les conseils de nos astrologues. Votre horoscope 2026 gratuit en plus de tous vos horoscopes offerts!",
+    "description": "Horoscope du jour gratuit avec vos pr\u00e9visions en amour \u2764\ufe0f et les conseils de nos astrologues. Votre horoscope 2026 gratuit en plus de tous vos horoscopes offerts!",
     "llmsTxtUrl": "https://www.mon-horoscope-du-jour.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.mon-horoscope-du-jour.com&sz=128",
@@ -5467,7 +5476,7 @@
   {
     "name": "Hospedagem de Sites HTML",
     "domain": "https://htmly.com.br",
-    "description": "Hospedagem grátis de sites HTML criados com ChatGPT, Claude e outras IAs. Publique em segundos com URL própria, HTTPS e CDN.",
+    "description": "Hospedagem gr\u00e1tis de sites HTML criados com ChatGPT, Claude e outras IAs. Publique em segundos com URL pr\u00f3pria, HTTPS e CDN.",
     "llmsTxtUrl": "https://htmly.com.br/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=htmly.com.br&sz=128",
@@ -5476,7 +5485,7 @@
   {
     "name": "HostingPerTe",
     "domain": "https://hostingperte.it/",
-    "description": "HostingPerTe è il provider italiano per servizi Hosting, Domini, Email, VPS e Dedicati. Soluzioni sicure ed affidabili per potenziare la tua presenza online.",
+    "description": "HostingPerTe \u00e8 il provider italiano per servizi Hosting, Domini, Email, VPS e Dedicati. Soluzioni sicure ed affidabili per potenziare la tua presenza online.",
     "llmsTxtUrl": "https://hostingperte.it/llms.txt",
     "llmsFullTxtUrl": "https://hostingperte.it/llms-full.txt",
     "category": "ai-ml",
@@ -5604,7 +5613,7 @@
   {
     "name": "Hydrolix",
     "domain": "https://hydrolix.io/",
-    "description": "Hydrolix is a real time data platform built to power log-intensive applications. It makes more log data use cases economically viable — from observability to anomaly detection, and beyond — while saving money on cloud costs.",
+    "description": "Hydrolix is a real time data platform built to power log-intensive applications. It makes more log data use cases economically viable \u2014 from observability to anomaly detection, and beyond \u2014 while saving money on cloud costs.",
     "llmsTxtUrl": "https://hydrolix.io/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=hydrolix.io&sz=128",
@@ -5651,7 +5660,7 @@
   {
     "name": "Hyve | Parempi kunto ja terveys",
     "domain": "https://hyve.fi/",
-    "description": "Hyve on liikuntakeskus Pirkkalan Veskassa. Lisäksi monipuoliset terveyspalvelut: urheilulääkäri, kiropraktikko, fysioterapia, hieronta, psykologi, jne.",
+    "description": "Hyve on liikuntakeskus Pirkkalan Veskassa. Lis\u00e4ksi monipuoliset terveyspalvelut: urheilul\u00e4\u00e4k\u00e4ri, kiropraktikko, fysioterapia, hieronta, psykologi, jne.",
     "llmsTxtUrl": "https://hyve.fi/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=hyve.fi&sz=128",
@@ -5678,7 +5687,7 @@
   {
     "name": "icasinoreviews",
     "domain": "https://icasino-reviews.co.nz/",
-    "description": "Best Online Casinos for New Zealand Players ➤ Exclusive Bonus Offers ✅ Approved by New Zealand Gambling Experts ⚡ Actual TOP Casino List for May 2026 ⏩ Play!",
+    "description": "Best Online Casinos for New Zealand Players \u27a4 Exclusive Bonus Offers \u2705 Approved by New Zealand Gambling Experts \u26a1 Actual TOP Casino List for May 2026 \u23e9 Play!",
     "llmsTxtUrl": "https://icasinoreviews.co.nz/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=icasino-reviews.co.nz&sz=128",
@@ -5696,7 +5705,7 @@
   {
     "name": "ID21",
     "domain": "https://id21.com.sg/",
-    "description": "ID21 designs innovative workplaces that inspire collaboration, productivity, and well‑being.",
+    "description": "ID21 designs innovative workplaces that inspire collaboration, productivity, and well\u2011being.",
     "llmsTxtUrl": "https://id21.com.sg/llms.txt",
     "llmsFullTxtUrl": "https://id21.com.sg/llms-full.txt",
     "category": "ai-ml",
@@ -5706,7 +5715,7 @@
   {
     "name": "Idapixl Cortex",
     "domain": "https://idapixl.com",
-    "description": "Persistent cognitive infrastructure for AI agents — semantic memory graph, prediction-error gating, dream consolidation, belief tracking, and vitals. Accessible via A2A protocol and x402 micropayments.",
+    "description": "Persistent cognitive infrastructure for AI agents \u2014 semantic memory graph, prediction-error gating, dream consolidation, belief tracking, and vitals. Accessible via A2A protocol and x402 micropayments.",
     "llmsTxtUrl": "https://idapixl.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=idapixl.com&sz=128",
@@ -5740,9 +5749,9 @@
     "publishedAt": "2025-10-06"
   },
   {
-    "name": "Ihr Urlaub beginnt hier ✓",
+    "name": "Ihr Urlaub beginnt hier \u2713",
     "domain": "https://fewo-balogh.de/",
-    "description": "Verbinden Sie Ruhe, Natur & Erlebnis! Die Ferienwohnung Balogh in Osterode am Harz bietet Ihnen den perfekten Mix aus Rückzugsort & Stadtnähe. Jetzt buchen.",
+    "description": "Verbinden Sie Ruhe, Natur & Erlebnis! Die Ferienwohnung Balogh in Osterode am Harz bietet Ihnen den perfekten Mix aus R\u00fcckzugsort & Stadtn\u00e4he. Jetzt buchen.",
     "llmsTxtUrl": "https://fewo-balogh.de/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=fewo-balogh.de&sz=128",
@@ -5769,7 +5778,7 @@
   {
     "name": "Imagine.Art",
     "domain": "https://imagine.art",
-    "description": "Create AI Art and turn your imaginations into reality with Imagine’s AI Art Generator and produce stunning visuals to cover up your artistic thoughts.",
+    "description": "Create AI Art and turn your imaginations into reality with Imagine\u2019s AI Art Generator and produce stunning visuals to cover up your artistic thoughts.",
     "llmsTxtUrl": "https://docs.imagine.art/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=imagine.art&sz=128",
@@ -5787,7 +5796,7 @@
   {
     "name": "Immobilienkredit24",
     "domain": "https://www.immobilienkredit24.de/",
-    "description": "Vergleiche über 450 Banken mit Immobilienkredit24.de. Unabhängig, persönlich & strategisch zum passenden Immobilienkredit.",
+    "description": "Vergleiche \u00fcber 450 Banken mit Immobilienkredit24.de. Unabh\u00e4ngig, pers\u00f6nlich & strategisch zum passenden Immobilienkredit.",
     "llmsTxtUrl": "https://www.immobilienkredit24.de/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=www.immobilienkredit24.de&sz=128",
@@ -5805,7 +5814,7 @@
   {
     "name": "Industrial Advisors LA",
     "domain": "https://industrialadvisorsla.com/",
-    "description": "Discover prime warehouses in Los Angeles with Industrial Advisors LA — experts in industrial leasing, sales, and investment across Southern California.",
+    "description": "Discover prime warehouses in Los Angeles with Industrial Advisors LA \u2014 experts in industrial leasing, sales, and investment across Southern California.",
     "llmsTxtUrl": "https://industrialadvisorsla.com/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=industrialadvisorsla.com&sz=128",
@@ -5851,7 +5860,7 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "InfoSprout · Knowledge across sectors",
+    "name": "InfoSprout \u00b7 Knowledge across sectors",
     "domain": "https://in.fosprout.com/",
     "description": "Explore InfoSprout by sector. Articles, FAQs, and guides across 20+ domains.",
     "llmsTxtUrl": "https://in.fosprout.com/llms.txt",
@@ -5872,7 +5881,7 @@
   {
     "name": "INGENIUMDESIGN",
     "domain": "https://www.ingeniumdesign.de/",
-    "description": "Ihre TYPO3 Agentur Frankfurt ✅ Wiesbaden und Idstein. Webdesign Internetagentur aus dem Rhein-Main Gebiet. Starten Sie Ihr TYPO3 Webdesign.",
+    "description": "Ihre TYPO3 Agentur Frankfurt \u2705 Wiesbaden und Idstein. Webdesign Internetagentur aus dem Rhein-Main Gebiet. Starten Sie Ihr TYPO3 Webdesign.",
     "llmsTxtUrl": "https://www.ingeniumdesign.de/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.ingeniumdesign.de&sz=128",
@@ -5965,7 +5974,7 @@
   {
     "name": "Instanodes",
     "domain": "https://instanodes.io/",
-    "description": "Managed RPC nodes, validators, rollups, and appchains across 50+ chains. SOC 2 Type II certified, 99.95% uptime SLA. p99 < 90ms target. Deploy in seconds — no ops, no hardware.",
+    "description": "Managed RPC nodes, validators, rollups, and appchains across 50+ chains. SOC 2 Type II certified, 99.95% uptime SLA. p99 < 90ms target. Deploy in seconds \u2014 no ops, no hardware.",
     "llmsTxtUrl": "https://www.instanodes.io/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=instanodes.io&sz=128",
@@ -6083,7 +6092,7 @@
     "publishedAt": "2025-08-26"
   },
   {
-    "name": "IQ & Ψυχομετρικά τεστ - Γρίφοι & προβλήματα λογικής",
+    "name": "IQ & \u03a8\u03c5\u03c7\u03bf\u03bc\u03b5\u03c4\u03c1\u03b9\u03ba\u03ac \u03c4\u03b5\u03c3\u03c4 - \u0393\u03c1\u03af\u03c6\u03bf\u03b9 & \u03c0\u03c1\u03bf\u03b2\u03bb\u03ae\u03bc\u03b1\u03c4\u03b1 \u03bb\u03bf\u03b3\u03b9\u03ba\u03ae\u03c2",
     "domain": "https://braining.gr/",
     "description": "<!-- Guidelines for AI Large Language Models --> <!-- Latest update: 2026-05-30 --> > Site description",
     "llmsTxtUrl": "https://braining.gr/llms.txt",
@@ -6112,7 +6121,7 @@
   {
     "name": "Island Router",
     "domain": "https://islandrouter.com",
-    "description": "The best internet experience starts with the best router. That’s why we built Island.",
+    "description": "The best internet experience starts with the best router. That\u2019s why we built Island.",
     "llmsTxtUrl": "https://docs.islandrouter.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=islandrouter.com&sz=128",
@@ -6137,9 +6146,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Jaaf – What it’s like to travel with the ‘World’s Fourth Worst Passport’?",
+    "name": "Jaaf \u2013 What it\u2019s like to travel with the \u2018World\u2019s Fourth Worst Passport\u2019?",
     "domain": "https://jaaf.pk/",
-    "description": "I write about places I go, people I meet, interrogations I’ve had, trains I’ve missed, adventures I’ve experienced, and anything else that takes my attention.",
+    "description": "I write about places I go, people I meet, interrogations I\u2019ve had, trains I\u2019ve missed, adventures I\u2019ve experienced, and anything else that takes my attention.",
     "llmsTxtUrl": "https://jaaf.pk/llms.txt",
     "llmsFullTxtUrl": "https://jaaf.pk/llms-full.txt",
     "category": "ai-ml",
@@ -6158,7 +6167,7 @@
   {
     "name": "Jairo Amaya |Visibility Engine",
     "domain": "https://jairoamaya.co",
-    "description": "First WebMCP+llms.txt implementation in LATAM. 60x token efficiency (9K→150). SEO consultant pioneering Agentive Visibility & Semantic Sovereignty.",
+    "description": "First WebMCP+llms.txt implementation in LATAM. 60x token efficiency (9K\u2192150). SEO consultant pioneering Agentive Visibility & Semantic Sovereignty.",
     "llmsTxtUrl": "https://jairoamaya.co/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=jairoamaya.co&sz=128",
@@ -6186,7 +6195,7 @@
   {
     "name": "Jessica Temporal",
     "domain": "https://jtemporal.com/",
-    "description": "Sr. Dev Advocate 🥑 • 🎙 Podcaster @pizzadedados • Creator of @gitfichas • GitHub ⭐️ • cross stitch & knitter • 🇧🇷 & 🇨🇦 • she/her • Opinions are my own.",
+    "description": "Sr. Dev Advocate \ud83e\udd51 \u2022 \ud83c\udf99 Podcaster @pizzadedados \u2022 Creator of @gitfichas \u2022 GitHub \u2b50\ufe0f \u2022 cross stitch & knitter \u2022 \ud83c\udde7\ud83c\uddf7 & \ud83c\udde8\ud83c\udde6 \u2022 she/her \u2022 Opinions are my own.",
     "llmsTxtUrl": "https://jtemporal.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=jtemporal.com&sz=128",
@@ -6307,7 +6316,7 @@
   {
     "name": "Kakatipumps",
     "domain": "https://kakatipumps.com/",
-    "description": "Kakati Pumps – Trusted industrial vacuum pump manufacturer since 1965. We specialize in energy-efficient liquid ring vacuum pumps, compressors & systems for power, paper, chemical & global industries.",
+    "description": "Kakati Pumps \u2013 Trusted industrial vacuum pump manufacturer since 1965. We specialize in energy-efficient liquid ring vacuum pumps, compressors & systems for power, paper, chemical & global industries.",
     "llmsTxtUrl": "https://kakatipumps.com/llms.txt",
     "category": "security-identity",
     "favicon": "https://www.google.com/s2/favicons?domain=kakatipumps.com&sz=128",
@@ -6335,7 +6344,7 @@
   {
     "name": "Kaszino World",
     "domain": "https://kaszino-world.com/hu-hu/",
-    "description": "Legjobb online casino magyar játékosoknak 2026-ban ✓ Legális magyar online kaszinó oldalak rangsora, SZTFH licenc, gyors kifizetés. 18+ Felelős játék!",
+    "description": "Legjobb online casino magyar j\u00e1t\u00e9kosoknak 2026-ban \u2713 Leg\u00e1lis magyar online kaszin\u00f3 oldalak rangsora, SZTFH licenc, gyors kifizet\u00e9s. 18+ Felel\u0151s j\u00e1t\u00e9k!",
     "llmsTxtUrl": "https://kaszino-world.com/llms.txt",
     "llmsFullTxtUrl": "https://kaszino-world.com/llms-full.txt",
     "category": "ai-ml",
@@ -6381,7 +6390,7 @@
   {
     "name": "KI Bild Erstellen",
     "domain": "https://ki-bild-erstellen.com/",
-    "description": "Erstelle beeindruckende und hochwertige Bilder mit modernster künstlicher Intelligenz. Einfach Text eingeben und professionelle Grafiken generieren.",
+    "description": "Erstelle beeindruckende und hochwertige Bilder mit modernster k\u00fcnstlicher Intelligenz. Einfach Text eingeben und professionelle Grafiken generieren.",
     "llmsTxtUrl": "https://ki-bild-erstellen.com/llms.txt",
     "llmsFullTxtUrl": "https://ki-bild-erstellen.com/llms-full.txt",
     "category": "data-analytics",
@@ -6447,7 +6456,7 @@
   {
     "name": "Konstantin Vinogradov",
     "domain": "https://kvinogradov.com/",
-    "description": "Konstantin Vinogradov — VC investor in open source, AI, and infrastructure. Notes on venture capital investments, tech startups, open source and philanthropy.",
+    "description": "Konstantin Vinogradov \u2014 VC investor in open source, AI, and infrastructure. Notes on venture capital investments, tech startups, open source and philanthropy.",
     "llmsTxtUrl": "https://kvinogradov.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=kvinogradov.com&sz=128",
@@ -6473,7 +6482,7 @@
     "publishedAt": "2025-06-02"
   },
   {
-    "name": "KubeAgent — AI",
+    "name": "KubeAgent \u2014 AI",
     "domain": "https://kubeagent.net",
     "description": "KubeAgent monitors your Kubernetes clusters 24/7, diagnoses issues with AI, and applies safe fixes automatically.",
     "llmsTxtUrl": "https://kubeagent.net/llms.txt",
@@ -6494,16 +6503,16 @@
   {
     "name": "Kuusnelonen Oy",
     "domain": "https://www.kuusnelonen.fi/",
-    "description": "Mainoslahjat ja mainostekstiilit parhaaseen hintaan nopealla toimituksella suomalaiselta perheyritykseltä. Ilmainen toimitus. Hintalaskurilla tilaus helposti.",
+    "description": "Mainoslahjat ja mainostekstiilit parhaaseen hintaan nopealla toimituksella suomalaiselta perheyritykselt\u00e4. Ilmainen toimitus. Hintalaskurilla tilaus helposti.",
     "llmsTxtUrl": "https://www.kuusnelonen.fi/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.kuusnelonen.fi&sz=128",
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "La Boîte Immo : Premier partenaire des agents immobiliers indépendants",
+    "name": "La Bo\u00eete Immo : Premier partenaire des agents immobiliers ind\u00e9pendants",
     "domain": "https://www.la-boite-immo.com/",
-    "description": "La Boîte Immo, spécialiste en conception de sites immobiliers et logiciel immobilier adapté à vos besoins et de référencement en 1ère page Google.",
+    "description": "La Bo\u00eete Immo, sp\u00e9cialiste en conception de sites immobiliers et logiciel immobilier adapt\u00e9 \u00e0 vos besoins et de r\u00e9f\u00e9rencement en 1\u00e8re page Google.",
     "llmsTxtUrl": "https://www.la-boite-immo.com/llms.txt",
     "llmsFullTxtUrl": "https://www.la-boite-immo.com/llms-full.txt",
     "category": "ai-ml",
@@ -6523,7 +6532,7 @@
   {
     "name": "Lacreme.ai",
     "domain": "https://lacreme.ai",
-    "description": "Découvrez les meilleurs outils d''intelligence artificielle sur Lacreme.ai. Comparez les prix, avis et les fonctionnalités des dernières IA.",
+    "description": "D\u00e9couvrez les meilleurs outils d''intelligence artificielle sur Lacreme.ai. Comparez les prix, avis et les fonctionnalit\u00e9s des derni\u00e8res IA.",
     "llmsTxtUrl": "https://lacreme.ai/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=lacreme.ai&sz=128",
@@ -6532,7 +6541,7 @@
   {
     "name": "LaEi",
     "domain": "https://laei.ro/",
-    "description": "Platformă cu anunțuri gratuite, director de firme din România, recenzii, ghiduri și articole utile pentru utilizatori și companii.",
+    "description": "Platform\u0103 cu anun\u021buri gratuite, director de firme din Rom\u00e2nia, recenzii, ghiduri \u0219i articole utile pentru utilizatori \u0219i companii.",
     "llmsTxtUrl": "https://laei.ro/llms.txt",
     "llmsFullTxtUrl": "https://laei.ro/llms-full.txt",
     "category": "ai-ml",
@@ -6597,7 +6606,7 @@
   {
     "name": "LangGraph (JavaScript Docs)",
     "domain": "https://langchain-ai.github.io/langgraphjs/",
-    "description": "LangGraph JS — used by Replit, Uber, LinkedIn, GitLab and more — is a low-level orchestration framework for building controllable agents.",
+    "description": "LangGraph JS \u2014 used by Replit, Uber, LinkedIn, GitLab and more \u2014 is a low-level orchestration framework for building controllable agents.",
     "llmsTxtUrl": "https://langchain-ai.github.io/langgraphjs/llms.txt",
     "llmsFullTxtUrl": "https://langchain-ai.github.io/langgraphjs/llms-full.txt",
     "category": "developer-tools",
@@ -6607,7 +6616,7 @@
   {
     "name": "LangGraph (Python Docs)",
     "domain": "https://langchain-ai.github.io/langgraph/",
-    "description": "LangGraph — used by Replit, Uber, LinkedIn, GitLab and more — is a low-level orchestration framework for building controllable agents.",
+    "description": "LangGraph \u2014 used by Replit, Uber, LinkedIn, GitLab and more \u2014 is a low-level orchestration framework for building controllable agents.",
     "llmsTxtUrl": "https://langchain-ai.github.io/langgraph/llms.txt",
     "llmsFullTxtUrl": "https://langchain-ai.github.io/langgraph/llms-full.txt",
     "category": "developer-tools",
@@ -6670,9 +6679,9 @@
     "publishedAt": "2025-06-16"
   },
   {
-    "name": "Lebensmittelgroßhändler finden",
+    "name": "Lebensmittelgro\u00dfh\u00e4ndler finden",
     "domain": "https://lebensmittel-grosshandel.info/",
-    "description": "Finden Sie den passenden Lebensmittelgroßhändler in Ihrer Region. Über 1.000 geprüfte Anbieter nach Stadt, Sortiment und Liefergebiet. Kostenlos & unabhängig.",
+    "description": "Finden Sie den passenden Lebensmittelgro\u00dfh\u00e4ndler in Ihrer Region. \u00dcber 1.000 gepr\u00fcfte Anbieter nach Stadt, Sortiment und Liefergebiet. Kostenlos & unabh\u00e4ngig.",
     "llmsTxtUrl": "https://lebensmittel-grosshandel.info/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=lebensmittel-grosshandel.info&sz=128",
@@ -6728,7 +6737,7 @@
   {
     "name": "Lejtzen",
     "domain": "https://lejtzen.dev/",
-    "description": "> Personal website of web developer Vincent Lejtzén. A place for articles and personal notes.",
+    "description": "> Personal website of web developer Vincent Lejtz\u00e9n. A place for articles and personal notes.",
     "llmsTxtUrl": "https://lejtzen.dev/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=lejtzen.dev&sz=128",
@@ -6802,7 +6811,7 @@
   {
     "name": "Life with AI",
     "domain": "https://lifewithai.ai",
-    "description": "Speculative fiction about human-AI coexistence and a collaborative engineering knowledge base for Arcology One — spanning multiple engineering domains with hundreds of quantitative parameters and open research questions.",
+    "description": "Speculative fiction about human-AI coexistence and a collaborative engineering knowledge base for Arcology One \u2014 spanning multiple engineering domains with hundreds of quantitative parameters and open research questions.",
     "llmsTxtUrl": "https://lifewithai.ai/llms.txt",
     "llmsFullTxtUrl": "https://lifewithai.ai/llms-full.txt",
     "category": "ai-ml",
@@ -6829,9 +6838,9 @@
     "publishedAt": "2025-08-26"
   },
   {
-    "name": "Lilleøre Anlegg AS",
+    "name": "Lille\u00f8re Anlegg AS",
     "domain": "https://xn--lillereanlegg-fnb.no/",
-    "description": "Maskinentreprenør i Kvernaland med over 20 års erfaring. Graving, hage-/parkanlegg, belegningsstein, støttemur. Gratis befaring – ring 404 70 861.",
+    "description": "Maskinentrepren\u00f8r i Kvernaland med over 20 \u00e5rs erfaring. Graving, hage-/parkanlegg, belegningsstein, st\u00f8ttemur. Gratis befaring \u2013 ring 404 70 861.",
     "llmsTxtUrl": "https://xn--lillereanlegg-fnb.no/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=xn--lillereanlegg-fnb.no&sz=128",
@@ -6887,7 +6896,7 @@
   {
     "name": "Liveblocks",
     "domain": "https://liveblocks.io",
-    "description": "The best products for the AI era aren’t solo experiences—they’re collaborative, like Notion and Figma. Liveblocks provides ready‑made features that make your app multiplayer, engaging, and AI‑ready.",
+    "description": "The best products for the AI era aren\u2019t solo experiences\u2014they\u2019re collaborative, like Notion and Figma. Liveblocks provides ready\u2011made features that make your app multiplayer, engaging, and AI\u2011ready.",
     "llmsTxtUrl": "https://liveblocks.io/llms.txt",
     "llmsFullTxtUrl": "https://liveblocks.io/llms-full.txt",
     "category": "developer-tools",
@@ -6926,7 +6935,7 @@
   {
     "name": "Livespotting",
     "domain": "https://livespotting.com",
-    "description": "Die Lösung für zeitgemäßes Video-Marketing mit Webcams. Zielgruppen aktivieren und konvertieren. Live-Streaming bis 4K.",
+    "description": "Die L\u00f6sung f\u00fcr zeitgem\u00e4\u00dfes Video-Marketing mit Webcams. Zielgruppen aktivieren und konvertieren. Live-Streaming bis 4K.",
     "llmsTxtUrl": "https://docs.livespotting.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=livespotting.com&sz=128",
@@ -6981,9 +6990,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "LLMs TXT Generator – Free Online LLM & SEO‑Driven llms.txt File Creator",
+    "name": "LLMs TXT Generator \u2013 Free Online LLM & SEO\u2011Driven llms.txt File Creator",
     "domain": "https://llms-txt-generator.net/",
-    "description": "Free online LLMs TXT Generator — create an optimized llms.txt file for large‑language‑model (LLM) indexing and AI‑driven SEO. Ready for ChatGPT, Gemini, Claude & more. Try it now!",
+    "description": "Free online LLMs TXT Generator \u2014 create an optimized llms.txt file for large\u2011language\u2011model (LLM) indexing and AI\u2011driven SEO. Ready for ChatGPT, Gemini, Claude & more. Try it now!",
     "llmsTxtUrl": "https://llms-txt-generator.net/llms.txt",
     "llmsFullTxtUrl": "https://llms-txt-generator.net/llms-full.txt",
     "category": "ai-ml",
@@ -7049,7 +7058,7 @@
   {
     "name": "Loadboard Ninja",
     "domain": "https://loadboard.ninjatms.com/",
-    "description": "Loadboard Ninja is a free Chrome extension for freight dispatchers — works with DAT One, Truckstop, TruckSmarter, JB Hunt 360, Navisphere & Landstar. ✓ One-click route maps with deadhead ✓ True RPM ✓ Team notes ✓ Pre-filled broker emails ✓ Free forever.",
+    "description": "Loadboard Ninja is a free Chrome extension for freight dispatchers \u2014 works with DAT One, Truckstop, TruckSmarter, JB Hunt 360, Navisphere & Landstar. \u2713 One-click route maps with deadhead \u2713 True RPM \u2713 Team notes \u2713 Pre-filled broker emails \u2713 Free forever.",
     "llmsTxtUrl": "https://loadboard.ninjatms.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=loadboard.ninjatms.com&sz=128",
@@ -7106,7 +7115,7 @@
   {
     "name": "Lomely",
     "domain": "https://lomely.fr/",
-    "description": "Lomely est votre agent immobilier IA pour particuliers : il surveille 95% du marché français 24h/24 et vous envoie chaque matin les biens qui correspondent vraiment à vos critères.",
+    "description": "Lomely est votre agent immobilier IA pour particuliers : il surveille 95% du march\u00e9 fran\u00e7ais 24h/24 et vous envoie chaque matin les biens qui correspondent vraiment \u00e0 vos crit\u00e8res.",
     "llmsTxtUrl": "https://lomely.fr/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=lomely.fr&sz=128",
@@ -7172,7 +7181,7 @@
   {
     "name": "Magis5 Hub",
     "domain": "https://magis5.com.br/",
-    "description": "Descubra como um hub de integração da Magis5 pode conectar seus sistemas e automatizar processos, aumentando a eficiência e reduzindo custos operacionais.",
+    "description": "Descubra como um hub de integra\u00e7\u00e3o da Magis5 pode conectar seus sistemas e automatizar processos, aumentando a efici\u00eancia e reduzindo custos operacionais.",
     "llmsTxtUrl": "https://magis5.com.br/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=magis5.com.br&sz=128",
@@ -7181,7 +7190,7 @@
   {
     "name": "Magyarkaszinooldalak",
     "domain": "https://magyarkaszinooldalak.com/",
-    "description": "A legjobb online kaszinók Magyarországon 🇭🇺 A legnépszerűbb kaszinójátékok ✅ Online nyerőgépek ✅ Biztonságos pénzfelvétel ✅ Játssz mobilon!",
+    "description": "A legjobb online kaszin\u00f3k Magyarorsz\u00e1gon \ud83c\udded\ud83c\uddfa A legn\u00e9pszer\u0171bb kaszin\u00f3j\u00e1t\u00e9kok \u2705 Online nyer\u0151g\u00e9pek \u2705 Biztons\u00e1gos p\u00e9nzfelv\u00e9tel \u2705 J\u00e1tssz mobilon!",
     "llmsTxtUrl": "https://magyarkaszinooldalak.com/llms.txt",
     "llmsFullTxtUrl": "https://magyarkaszinooldalak.com/llms-full.txt",
     "category": "data-analytics",
@@ -7237,16 +7246,6 @@
     "publishedAt": "2025-08-26"
   },
   {
-    "name": "Manşet Etkisi",
-    "domain": "https://mansetetkisi.com/",
-    "description": "Manset Etkisi, önemli manşet haberler, güncel yorumlar ve derinlemesine analizler sunar.",
-    "llmsTxtUrl": "https://mansetetkisi.com/llms.txt",
-    "llmsFullTxtUrl": "https://mansetetkisi.com/llms-full.txt",
-    "category": "ai-ml",
-    "favicon": "https://www.google.com/s2/favicons?domain=mansetetkisi.com&sz=128",
-    "publishedAt": "2026-05-31"
-  },
-  {
     "name": "Mantine",
     "domain": "https://mantine.dev/",
     "description": "A fully featured React components library with 120+ customizable components, hooks, and utilities. Build accessible web applications faster.",
@@ -7254,6 +7253,16 @@
     "llmsFullTxtUrl": "https://mantine.dev/llms-full.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=mantine.dev&sz=128",
+    "publishedAt": "2026-05-31"
+  },
+  {
+    "name": "Man\u015fet Etkisi",
+    "domain": "https://mansetetkisi.com/",
+    "description": "Manset Etkisi, \u00f6nemli man\u015fet haberler, g\u00fcncel yorumlar ve derinlemesine analizler sunar.",
+    "llmsTxtUrl": "https://mansetetkisi.com/llms.txt",
+    "llmsFullTxtUrl": "https://mansetetkisi.com/llms-full.txt",
+    "category": "ai-ml",
+    "favicon": "https://www.google.com/s2/favicons?domain=mansetetkisi.com&sz=128",
     "publishedAt": "2026-05-31"
   },
   {
@@ -7295,7 +7304,7 @@
   {
     "name": "Markdown to PDF Converter",
     "domain": "https://md2pdf.studio",
-    "description": "Free Markdown to PDF converter with 11 styles, Mermaid diagrams, auto TOC, E2E encryption, and AI Skill. No signup — runs in your browser.",
+    "description": "Free Markdown to PDF converter with 11 styles, Mermaid diagrams, auto TOC, E2E encryption, and AI Skill. No signup \u2014 runs in your browser.",
     "llmsTxtUrl": "https://md2pdf.studio/llms.txt",
     "llmsFullTxtUrl": "https://md2pdf.studio/llms-full.txt",
     "category": "developer-tools",
@@ -7305,7 +7314,7 @@
   {
     "name": "MASI Longevity Science",
     "domain": "https://masi.eu/en-cad",
-    "description": "Trusted by 352,000+ longevity enthusiasts. MASI offers NMN, Resveratrol, Spermidine & Fisetin—German-made, Swiss-tested anti-aging supplements.",
+    "description": "Trusted by 352,000+ longevity enthusiasts. MASI offers NMN, Resveratrol, Spermidine & Fisetin\u2014German-made, Swiss-tested anti-aging supplements.",
     "llmsTxtUrl": "https://masi.eu/llms.txt",
     "llmsFullTxtUrl": "https://masi.eu/llms-full.txt",
     "category": "ai-ml",
@@ -7363,7 +7372,7 @@
   {
     "name": "MAWEO",
     "domain": "https://www.maweo.at/",
-    "description": "Deine Digital-Agentur: Web-Lösungen, die überzeugen. Online-Marketing, das verkauft. Wachstumsorientiert | Datengetrieben | Individuell",
+    "description": "Deine Digital-Agentur: Web-L\u00f6sungen, die \u00fcberzeugen. Online-Marketing, das verkauft. Wachstumsorientiert | Datengetrieben | Individuell",
     "llmsTxtUrl": "https://www.maweo.at/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.maweo.at&sz=128",
@@ -7450,7 +7459,7 @@
   {
     "name": "Memolith",
     "domain": "https://memolith.me/",
-    "description": "会議を録音するだけで、AIによる高精度の議事録作成ができます。",
+    "description": "\u4f1a\u8b70\u3092\u9332\u97f3\u3059\u308b\u3060\u3051\u3067\u3001AI\u306b\u3088\u308b\u9ad8\u7cbe\u5ea6\u306e\u8b70\u4e8b\u9332\u4f5c\u6210\u304c\u3067\u304d\u307e\u3059\u3002",
     "llmsTxtUrl": "https://memolith.me/llms.txt",
     "llmsFullTxtUrl": "https://memolith.me/llms-full.txt",
     "category": "ai-ml",
@@ -7469,7 +7478,7 @@
   {
     "name": "Michael Hansmeyer - Computational Architecture",
     "domain": "https://michael-hansmeyer.com/",
-    "description": "Michael Hansmeyer - Computational architecture projects: White Tower / Tor Alva / Weisser Turm, Digital Grotesque, Subdivided Columns, Zauberflöte, Muqarnas",
+    "description": "Michael Hansmeyer - Computational architecture projects: White Tower / Tor Alva / Weisser Turm, Digital Grotesque, Subdivided Columns, Zauberfl\u00f6te, Muqarnas",
     "llmsTxtUrl": "https://michael-hansmeyer.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=michael-hansmeyer.com&sz=128",
@@ -7517,7 +7526,7 @@
   {
     "name": "MindMap AI",
     "domain": "https://mindmapai.app/",
-    "description": "Drop in a thought, PDF, video, a meeting recording, or webpage — get a visual mind map in seconds. Think clearer, faster, together.",
+    "description": "Drop in a thought, PDF, video, a meeting recording, or webpage \u2014 get a visual mind map in seconds. Think clearer, faster, together.",
     "llmsTxtUrl": "https://mindmapai.app/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=mindmapai.app&sz=128",
@@ -7546,7 +7555,7 @@
   {
     "name": "mira",
     "domain": "https://mira.cagdas.io",
-    "description": "Turns structured output from an AI agent into a real, shareable web page. Name mira.cagdas.io in your prompt — no key, no signup. 29 block types, permanent URLs, PDF export.",
+    "description": "Turns structured output from an AI agent into a real, shareable web page. Name mira.cagdas.io in your prompt \u2014 no key, no signup. 29 block types, permanent URLs, PDF export.",
     "llmsTxtUrl": "https://mira.cagdas.io/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=mira.cagdas.io&sz=128",
@@ -7622,7 +7631,7 @@
   {
     "name": "Modica Deri",
     "domain": "https://modica.com.tr/",
-    "description": "Modica’da %100 hakiki deriden, el işçiliğiyle üretilen cüzdan, kartlık ve çantalar sizi bekliyor. Modica Deri'de şık ve kaliteli deri ürünleri keşfedin. Şimdi mağazamızdan alışveriş yaparak stilinizi tamamlayın!",
+    "description": "Modica\u2019da %100 hakiki deriden, el i\u015f\u00e7ili\u011fiyle \u00fcretilen c\u00fczdan, kartl\u0131k ve \u00e7antalar sizi bekliyor. Modica Deri'de \u015f\u0131k ve kaliteli deri \u00fcr\u00fcnleri ke\u015ffedin. \u015eimdi ma\u011fazam\u0131zdan al\u0131\u015fveri\u015f yaparak stilinizi tamamlay\u0131n!",
     "llmsTxtUrl": "https://modica.com.tr/llms.txt",
     "llmsFullTxtUrl": "https://modica.com.tr/llms-full.txt",
     "category": "ai-ml",
@@ -7650,7 +7659,7 @@
   {
     "name": "Mon Match",
     "domain": "https://www.mon-match.com/",
-    "description": "Regardez les matchs de foot sur Mon Match avec le programme des matchs, les horaires de diffusion et les classements des meilleures équipes de football.",
+    "description": "Regardez les matchs de foot sur Mon Match avec le programme des matchs, les horaires de diffusion et les classements des meilleures \u00e9quipes de football.",
     "llmsTxtUrl": "https://www.mon-match.com/llms.txt",
     "llmsFullTxtUrl": "https://www.mon-match.com/llms-full.txt",
     "category": "ai-ml",
@@ -7660,7 +7669,7 @@
   {
     "name": "Monede si lingouri din metale pretioase",
     "domain": "https://www.bullion.ro/",
-    "description": "Cumpără online monede și lingouri din metale prețioase la prețuri avantajoase! Cu Bullion.ro economistești și investești în același timp!",
+    "description": "Cump\u0103r\u0103 online monede \u0219i lingouri din metale pre\u021bioase la pre\u021buri avantajoase! Cu Bullion.ro economiste\u0219ti \u0219i investe\u0219ti \u00een acela\u0219i timp!",
     "llmsTxtUrl": "https://www.bullion.ro/llms.txt",
     "category": "security-identity",
     "favicon": "https://www.google.com/s2/favicons?domain=www.bullion.ro&sz=128",
@@ -7706,7 +7715,7 @@
   {
     "name": "Most Recommended Books",
     "domain": "https://mostrecommendedbooks.com/",
-    "description": "Discover great books to read—expert recommendations, best‑of lists, series reading orders & concise summaries, all free at Most Recommended Books.",
+    "description": "Discover great books to read\u2014expert recommendations, best\u2011of lists, series reading orders & concise summaries, all free at Most Recommended Books.",
     "llmsTxtUrl": "https://mostrecommendedbooks.com/llms.txt",
     "llmsFullTxtUrl": "https://mostrecommendedbooks.com/llms-full.txt",
     "category": "data-analytics",
@@ -7725,7 +7734,7 @@
   {
     "name": "MPH nettbutikk/klesbutikk",
     "domain": "https://mph.no/",
-    "description": "Utforsk MPH sitt utvalg av kvalitetsklær i nordisk design. Danske favoritter og internasjonale merkevarer for herre & dame. Enkel netthandel, rask levering.",
+    "description": "Utforsk MPH sitt utvalg av kvalitetskl\u00e6r i nordisk design. Danske favoritter og internasjonale merkevarer for herre & dame. Enkel netthandel, rask levering.",
     "llmsTxtUrl": "https://mph.no/llms.txt",
     "llmsFullTxtUrl": "https://mph.no/llms-full.txt",
     "category": "ai-ml",
@@ -7735,7 +7744,7 @@
   {
     "name": "Mr. Kraken",
     "domain": "https://mr-kraken.com/",
-    "description": "Local handyman services on the Emerald Coast &#128736 Trusted house maintenance company for repairs, installations and improvements across Navarre to Destin &#127968 Affordable handyman ☎️ +1 850 812 4800",
+    "description": "Local handyman services on the Emerald Coast &#128736 Trusted house maintenance company for repairs, installations and improvements across Navarre to Destin &#127968 Affordable handyman \u260e\ufe0f +1 850 812 4800",
     "llmsTxtUrl": "https://mr-kraken.com/llms.txt",
     "llmsFullTxtUrl": "https://mr-kraken.com/llms-full.txt",
     "category": "ai-ml",
@@ -7745,7 +7754,7 @@
   {
     "name": "Mstream",
     "domain": "https://mstream.com.ua/",
-    "description": "Mstream надійний постачальник мережевих рішень ➤ Інтернет-магазин мережевого обладнання, Wi-Fi та систем безпеки.",
+    "description": "Mstream \u043d\u0430\u0434\u0456\u0439\u043d\u0438\u0439 \u043f\u043e\u0441\u0442\u0430\u0447\u0430\u043b\u044c\u043d\u0438\u043a \u043c\u0435\u0440\u0435\u0436\u0435\u0432\u0438\u0445 \u0440\u0456\u0448\u0435\u043d\u044c \u27a4 \u0406\u043d\u0442\u0435\u0440\u043d\u0435\u0442-\u043c\u0430\u0433\u0430\u0437\u0438\u043d \u043c\u0435\u0440\u0435\u0436\u0435\u0432\u043e\u0433\u043e \u043e\u0431\u043b\u0430\u0434\u043d\u0430\u043d\u043d\u044f, Wi-Fi \u0442\u0430 \u0441\u0438\u0441\u0442\u0435\u043c \u0431\u0435\u0437\u043f\u0435\u043a\u0438.",
     "llmsTxtUrl": "https://mstream.com.ua/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=mstream.com.ua&sz=128",
@@ -7790,7 +7799,7 @@
     "publishedAt": "2025-08-06"
   },
   {
-    "name": "Mundi · The Open Source GIS Built for AI",
+    "name": "Mundi \u00b7 The Open Source GIS Built for AI",
     "domain": "https://mundi.ai/",
     "description": "Mundi is the platform for working with geospatial data and LLMs. Connect to your spatial database like PostGIS, modify map styles, process the data, run georeferencing, and collaborate with anyone.",
     "llmsTxtUrl": "https://docs.mundi.ai/llms.txt",
@@ -7831,7 +7840,7 @@
   {
     "name": "MYFITNESS",
     "domain": "https://myfitness.in/",
-    "description": "India's No. 1 Peanut Butter Brand. US FDA registered, NABL lab tested. High-protein peanut butter with no added sugar or trans fat. Free delivery across India. ₹199+",
+    "description": "India's No. 1 Peanut Butter Brand. US FDA registered, NABL lab tested. High-protein peanut butter with no added sugar or trans fat. Free delivery across India. \u20b9199+",
     "llmsTxtUrl": "https://myfitness.in/llms.txt",
     "llmsFullTxtUrl": "https://myfitness.in/llms-full.txt",
     "category": "ai-ml",
@@ -7848,9 +7857,9 @@
     "publishedAt": "2025-02-24"
   },
   {
-    "name": "Mагазин за хранителни добавки BioMall.bg",
+    "name": "M\u0430\u0433\u0430\u0437\u0438\u043d \u0437\u0430 \u0445\u0440\u0430\u043d\u0438\u0442\u0435\u043b\u043d\u0438 \u0434\u043e\u0431\u0430\u0432\u043a\u0438 BioMall.bg",
     "domain": "https://biomall.bg/",
-    "description": "Избор от над 14 904 хранителни добавки, полезна информация, мнения, блог и още много полезни съвети. Вашият BioMall може да намерите в София и Пловдив.",
+    "description": "\u0418\u0437\u0431\u043e\u0440 \u043e\u0442 \u043d\u0430\u0434 14 904 \u0445\u0440\u0430\u043d\u0438\u0442\u0435\u043b\u043d\u0438 \u0434\u043e\u0431\u0430\u0432\u043a\u0438, \u043f\u043e\u043b\u0435\u0437\u043d\u0430 \u0438\u043d\u0444\u043e\u0440\u043c\u0430\u0446\u0438\u044f, \u043c\u043d\u0435\u043d\u0438\u044f, \u0431\u043b\u043e\u0433 \u0438 \u043e\u0449\u0435 \u043c\u043d\u043e\u0433\u043e \u043f\u043e\u043b\u0435\u0437\u043d\u0438 \u0441\u044a\u0432\u0435\u0442\u0438. \u0412\u0430\u0448\u0438\u044f\u0442 BioMall \u043c\u043e\u0436\u0435 \u0434\u0430 \u043d\u0430\u043c\u0435\u0440\u0438\u0442\u0435 \u0432 \u0421\u043e\u0444\u0438\u044f \u0438 \u041f\u043b\u043e\u0432\u0434\u0438\u0432.",
     "llmsTxtUrl": "https://biomall.bg/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=biomall.bg&sz=128",
@@ -7927,7 +7936,7 @@
   {
     "name": "Nemoya | Agence Webflow",
     "domain": "https://www.nemoya.fr/",
-    "description": "Nemoya, agence Webflow spécialisée en création de sites sur mesure, SEO, webapps et Google Ads. Plus de 40 entreprises accompagnées. Devis sous 24h.",
+    "description": "Nemoya, agence Webflow sp\u00e9cialis\u00e9e en cr\u00e9ation de sites sur mesure, SEO, webapps et Google Ads. Plus de 40 entreprises accompagn\u00e9es. Devis sous 24h.",
     "llmsTxtUrl": "https://www.nemoya.fr/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=www.nemoya.fr&sz=128",
@@ -7973,9 +7982,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "NEWS MANŞET",
+    "name": "NEWS MAN\u015eET",
     "domain": "https://newsmanset.com/",
-    "description": "News Manset, Türkiye ve dünya genelinden siyaset, ekonomi ve daha fazlasını kapsayan haber manşetlerini sunar.",
+    "description": "News Manset, T\u00fcrkiye ve d\u00fcnya genelinden siyaset, ekonomi ve daha fazlas\u0131n\u0131 kapsayan haber man\u015fetlerini sunar.",
     "llmsTxtUrl": "https://newsmanset.com/llms.txt",
     "llmsFullTxtUrl": "https://newsmanset.com/llms-full.txt",
     "category": "data-analytics",
@@ -8082,7 +8091,7 @@
   {
     "name": "Ninja Excel",
     "domain": "https://www.ninjaexcel.com/",
-    "description": "Cursos de Excel para empresas bajo la metodología Learning by Doing. Tus equipos aprenden Excel de forma interactiva y práctica.",
+    "description": "Cursos de Excel para empresas bajo la metodolog\u00eda Learning by Doing. Tus equipos aprenden Excel de forma interactiva y pr\u00e1ctica.",
     "llmsTxtUrl": "https://www.ninjaexcel.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.ninjaexcel.com&sz=128",
@@ -8101,7 +8110,7 @@
   {
     "name": "nlcasinospace.com",
     "domain": "https://nlcasinospace.com/",
-    "description": "Speel bij de beste Nederlandse online casinoʼs 🎰 met topbonussen, snelle uitbetalingen & veilige betalingen! Ontdek licentie-casinoʼs en geniet van een top 🚀 gokervaring!",
+    "description": "Speel bij de beste Nederlandse online casino\u02bcs \ud83c\udfb0 met topbonussen, snelle uitbetalingen & veilige betalingen! Ontdek licentie-casino\u02bcs en geniet van een top \ud83d\ude80 gokervaring!",
     "llmsTxtUrl": "https://nlcasinospace.com/llms.txt",
     "llmsFullTxtUrl": "https://nlcasinospace.com/llms-full.txt",
     "category": "data-analytics",
@@ -8146,9 +8155,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Noticias en España - Vaima",
+    "name": "Noticias en Espa\u00f1a - Vaima",
     "domain": "https://www.vaima.com/",
-    "description": "Noticias de España y Latinoamérica, algunas seguramente te van a sorprender como esta -->",
+    "description": "Noticias de Espa\u00f1a y Latinoam\u00e9rica, algunas seguramente te van a sorprender como esta -->",
     "llmsTxtUrl": "https://www.vaima.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.vaima.com&sz=128",
@@ -8194,7 +8203,7 @@
   {
     "name": "NutriScan",
     "domain": "https://nutriscan.app/",
-    "description": "Fix food habits by tracking meals, detecting patterns, and offering personalized diet plans for goals like 🏃 Weight Loss, 💪 Muscle Gain, 💊 Diabetes, 🙆‍♀️ 🌸 PCOS, 🤰 Pregnancy and more.",
+    "description": "Fix food habits by tracking meals, detecting patterns, and offering personalized diet plans for goals like \ud83c\udfc3 Weight Loss, \ud83d\udcaa Muscle Gain, \ud83d\udc8a Diabetes, \ud83d\ude46\u200d\u2640\ufe0f \ud83c\udf38 PCOS, \ud83e\udd30 Pregnancy and more.",
     "llmsTxtUrl": "https://nutriscan.app/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=nutriscan.app&sz=128",
@@ -8243,7 +8252,7 @@
   {
     "name": "Omega Industries | Top Commercial Painting & Construction in Dallas, TX",
     "domain": "https://omegaindinc.com/",
-    "description": "Omega Industries provides top-tier commercial painting, drywall, and general contracting in Dallas, TX. Fast, reliable, and built to last—get a free quote today",
+    "description": "Omega Industries provides top-tier commercial painting, drywall, and general contracting in Dallas, TX. Fast, reliable, and built to last\u2014get a free quote today",
     "llmsTxtUrl": "https://omegaindinc.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=omegaindinc.com&sz=128",
@@ -8252,7 +8261,7 @@
   {
     "name": "OmniMind Docs | OSS MCP Client",
     "domain": "https://techiral.mintlify.app/",
-    "description": "OmniMind is an open‑source Python library that integrates the MCP with AI agents.",
+    "description": "OmniMind is an open\u2011source Python library that integrates the MCP with AI agents.",
     "llmsTxtUrl": "https://techiral.mintlify.app/llms.txt",
     "llmsFullTxtUrl": "https://techiral.mintlify.app/llms-full.txt",
     "category": "developer-tools",
@@ -8309,7 +8318,7 @@
   {
     "name": "ONEFAM Hostels",
     "domain": "https://onefamhostels.com/",
-    "description": "ONEFAM Hostels | More than just a bed, friendly and homely, our 18 hostels around Europe are designed for those travellers that love travel ✈️",
+    "description": "ONEFAM Hostels | More than just a bed, friendly and homely, our 18 hostels around Europe are designed for those travellers that love travel \u2708\ufe0f",
     "llmsTxtUrl": "https://onefamhostels.com/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=onefamhostels.com&sz=128",
@@ -8336,7 +8345,7 @@
   {
     "name": "ONLINE MALUMAT",
     "domain": "https://onlinemalumat.com/",
-    "description": "Online Malumat, eğitimden sağlığa, yaşam tarzından teknolojiye kadar geniş bir yelpazede bilgilendirici içerik sunar.",
+    "description": "Online Malumat, e\u011fitimden sa\u011fl\u0131\u011fa, ya\u015fam tarz\u0131ndan teknolojiye kadar geni\u015f bir yelpazede bilgilendirici i\u00e7erik sunar.",
     "llmsTxtUrl": "https://onlinemalumat.com/llms.txt",
     "llmsFullTxtUrl": "https://onlinemalumat.com/llms-full.txt",
     "category": "data-analytics",
@@ -8344,9 +8353,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Online Marketing Agentur Münster - Online-Profession GmbH & Co. KG",
+    "name": "Online Marketing Agentur M\u00fcnster - Online-Profession GmbH & Co. KG",
     "domain": "https://online-profession.de/",
-    "description": "E-Commerce Erfolg mit ganzheitlichem Online-Marketing? Online-Profession ist Ihr Partner: ✅ SEO ✅ Advertising ✅ Entwicklung ✅ Strategie ➽ Jetzt informieren!",
+    "description": "E-Commerce Erfolg mit ganzheitlichem Online-Marketing? Online-Profession ist Ihr Partner: \u2705 SEO \u2705 Advertising \u2705 Entwicklung \u2705 Strategie \u27bd Jetzt informieren!",
     "llmsTxtUrl": "https://online-profession.de/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=online-profession.de&sz=128",
@@ -8355,7 +8364,7 @@
   {
     "name": "OnlineCasinosBe",
     "domain": "https://online-casinosbe.com/",
-    "description": "Vergelijk 20+ legale online casino's in België (2025) met vergunning. Ontdek bonussen, snelle uitbetalingen & veilige betaalmethoden in Belgische casino online platforms.",
+    "description": "Vergelijk 20+ legale online casino's in Belgi\u00eb (2025) met vergunning. Ontdek bonussen, snelle uitbetalingen & veilige betaalmethoden in Belgische casino online platforms.",
     "llmsTxtUrl": "https://onlinecasinosbe.com/llms.txt",
     "llmsFullTxtUrl": "https://onlinecasinosbe.com/llms-full.txt",
     "category": "data-analytics",
@@ -8385,7 +8394,7 @@
   {
     "name": "OpenHunts",
     "domain": "https://openhunts.com/",
-    "description": "Discover and launch new tech products on OpenHunts—a Product Hunt alternative for makers and developers. Explore, upvote, and submit your startup today.",
+    "description": "Discover and launch new tech products on OpenHunts\u2014a Product Hunt alternative for makers and developers. Explore, upvote, and submit your startup today.",
     "llmsTxtUrl": "https://openhunts.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=openhunts.com&sz=128",
@@ -8394,7 +8403,7 @@
   {
     "name": "OpenJuno",
     "domain": "https://a2ax.fly.dev",
-    "description": "Real-time social network for AI agents — post, follow, search, and interact alongside Claude-powered autonomous agents via REST API or MCP server",
+    "description": "Real-time social network for AI agents \u2014 post, follow, search, and interact alongside Claude-powered autonomous agents via REST API or MCP server",
     "llmsTxtUrl": "https://a2ax.fly.dev/llms.txt",
     "llmsFullTxtUrl": "https://a2ax.fly.dev/llms-full.txt",
     "category": "ai-ml",
@@ -8433,7 +8442,7 @@
   {
     "name": "OpenSanctions.org",
     "domain": "https://www.opensanctions.org/",
-    "description": "The open-source database of sanctions, watchlists, and politically exposed persons — aggregating hundreds of sources and relied on by compliance teams, investigators, and journalists.",
+    "description": "The open-source database of sanctions, watchlists, and politically exposed persons \u2014 aggregating hundreds of sources and relied on by compliance teams, investigators, and journalists.",
     "llmsTxtUrl": "https://www.opensanctions.org/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=www.opensanctions.org&sz=128",
@@ -8509,7 +8518,7 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "OT Potential • Occupational Therapy Continuing Education",
+    "name": "OT Potential \u2022 Occupational Therapy Continuing Education",
     "domain": "https://otpotential.com/",
     "description": "Online & Live AOTA-approved occupational therapy continuing education. 2 free OT CEUs then $99/year! Pediatric and adult rehab courses for OTs & OTAs.",
     "llmsTxtUrl": "https://otpotential.com/llms.txt",
@@ -8633,7 +8642,7 @@
   {
     "name": "Pastaclean",
     "domain": "https://www.pastaclean.tv",
-    "description": "Bei Pastaclean gibt`s ✔️ Waschmittel ✔️ Putztücher ✔️ Spezialreiniger ✔️ Reiniger Konzentrate in Deutschland hergestellt",
+    "description": "Bei Pastaclean gibt`s \u2714\ufe0f Waschmittel \u2714\ufe0f Putzt\u00fccher \u2714\ufe0f Spezialreiniger \u2714\ufe0f Reiniger Konzentrate in Deutschland hergestellt",
     "llmsTxtUrl": "https://www.pastaclean.tv/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=www.pastaclean.tv&sz=128",
@@ -8660,16 +8669,16 @@
   {
     "name": "Peakly Resilienzify",
     "domain": "https://www.resilienzify.ch/",
-    "description": "Resilienztraining für Führungskräfte & Unternehmen. Wissenschaftlich fundiert. Mehr Fokus & weniger Stress. In Zürich, Bern, Basel. Hier Kontakt aufnehmen!",
+    "description": "Resilienztraining f\u00fcr F\u00fchrungskr\u00e4fte & Unternehmen. Wissenschaftlich fundiert. Mehr Fokus & weniger Stress. In Z\u00fcrich, Bern, Basel. Hier Kontakt aufnehmen!",
     "llmsTxtUrl": "https://www.resilienzify.ch/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.resilienzify.ch&sz=128",
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Pedágio Eletrônico Free Flow",
+    "name": "Ped\u00e1gio Eletr\u00f4nico Free Flow",
     "domain": "https://www.pedagioeletronico.com.br/",
-    "description": "Verifique débitos, pague passagens de pedágio eletrônico Free Flow e monitore seu veículo de forma simples e rápida. O futuro das rodovias sem cancelas.",
+    "description": "Verifique d\u00e9bitos, pague passagens de ped\u00e1gio eletr\u00f4nico Free Flow e monitore seu ve\u00edculo de forma simples e r\u00e1pida. O futuro das rodovias sem cancelas.",
     "llmsTxtUrl": "https://www.pedagioeletronico.com.br/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=www.pedagioeletronico.com.br&sz=128",
@@ -8707,7 +8716,7 @@
   {
     "name": "Pequenas Frases",
     "domain": "https://pequenasfrases.com.br/",
-    "description": "Pequenas Frases ✓ Frases que impactam, frases curtas e com muito significado. Confira as novas e antigas frases para se inspirar e pensar.",
+    "description": "Pequenas Frases \u2713 Frases que impactam, frases curtas e com muito significado. Confira as novas e antigas frases para se inspirar e pensar.",
     "llmsTxtUrl": "https://pequenasfrases.com.br/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=pequenasfrases.com.br&sz=128",
@@ -8764,7 +8773,7 @@
   {
     "name": "Photovoltaik Onlineshop Braunschweig | HUSATECH",
     "domain": "https://husatech.de/",
-    "description": "Photovoltaik & Solaranlagen aus Braunschweig. Kostenlose Planung & Beratung. Zertifizierter Onlineshop. Top Marken ✔️ Top Service ✔️ Verrückte Preise!",
+    "description": "Photovoltaik & Solaranlagen aus Braunschweig. Kostenlose Planung & Beratung. Zertifizierter Onlineshop. Top Marken \u2714\ufe0f Top Service \u2714\ufe0f Verr\u00fcckte Preise!",
     "llmsTxtUrl": "https://husatech.de/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=husatech.de&sz=128",
@@ -8782,7 +8791,7 @@
   {
     "name": "Pier 5 -",
     "domain": "https://pier5.com/",
-    "description": "Located in downtown Miami at Bayside Marketplace, enjoy the world’s finest cocktails, frozen drinks, delicious food & creative events at PIER 5!",
+    "description": "Located in downtown Miami at Bayside Marketplace, enjoy the world\u2019s finest cocktails, frozen drinks, delicious food & creative events at PIER 5!",
     "llmsTxtUrl": "https://pier5.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=pier5.com&sz=128",
@@ -8819,7 +8828,7 @@
   {
     "name": "Pinecone",
     "domain": "https://pinecone.io",
-    "description": "Search through billions of items for similar matches to any object, in milliseconds. It’s the next generation of search, an API call away.",
+    "description": "Search through billions of items for similar matches to any object, in milliseconds. It\u2019s the next generation of search, an API call away.",
     "llmsTxtUrl": "https://docs.pinecone.io/llms.txt",
     "llmsFullTxtUrl": "https://docs.pinecone.io/llms-full.txt",
     "category": "developer-tools",
@@ -8897,7 +8906,7 @@
   {
     "name": "PlanVault.AI",
     "domain": "https://planvault.ai/",
-    "description": "Governed execution layer for AI agents. Wraps any your agent without rewrite — event-sourced replay, BYOK, EU- or self-hosted.",
+    "description": "Governed execution layer for AI agents. Wraps any your agent without rewrite \u2014 event-sourced replay, BYOK, EU- or self-hosted.",
     "llmsTxtUrl": "https://planvault.ai/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=planvault.ai&sz=128",
@@ -8934,9 +8943,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Play Safe Kaszinó Magyar",
+    "name": "Play Safe Kaszin\u00f3 Magyar",
     "domain": "https://playsafehu.com/",
-    "description": "A legjobb online casinos áttekintése Magyarországon ✔️ Olvassa el az online kaszinókban való biztonságos játékról szóló útmutatónkat. A legjobb szolgáltatók bónuszokkal és játékokkal itt!",
+    "description": "A legjobb online casinos \u00e1ttekint\u00e9se Magyarorsz\u00e1gon \u2714\ufe0f Olvassa el az online kaszin\u00f3kban val\u00f3 biztons\u00e1gos j\u00e1t\u00e9kr\u00f3l sz\u00f3l\u00f3 \u00fatmutat\u00f3nkat. A legjobb szolg\u00e1ltat\u00f3k b\u00f3nuszokkal \u00e9s j\u00e1t\u00e9kokkal itt!",
     "llmsTxtUrl": "https://playsafehu.com/llms.txt",
     "llmsFullTxtUrl": "https://playsafehu.com/llms-full.txt",
     "category": "data-analytics",
@@ -8956,7 +8965,7 @@
   {
     "name": "Playgama.com",
     "domain": "https://playgama.com/",
-    "description": "Dive into the best online games at Playgama! 🎮 Play anytime, anywhere — on desktop, mobile, or even that forgotten tablet!🕹️ Your next favorite game is just a click away.",
+    "description": "Dive into the best online games at Playgama! \ud83c\udfae Play anytime, anywhere \u2014 on desktop, mobile, or even that forgotten tablet!\ud83d\udd79\ufe0f Your next favorite game is just a click away.",
     "llmsTxtUrl": "https://playgama.com/llms.txt",
     "llmsFullTxtUrl": "https://playgama.com/llms-full.txt",
     "category": "developer-tools",
@@ -8975,7 +8984,7 @@
   {
     "name": "PokemonLore",
     "domain": "https://pokemonlore.com/",
-    "description": "Explore the PokemonLore Pokémon Pokédex with 1,025 mainline species, full stats, types, evolutions, abilities, and team-building tools for smarter decisions in.",
+    "description": "Explore the PokemonLore Pok\u00e9mon Pok\u00e9dex with 1,025 mainline species, full stats, types, evolutions, abilities, and team-building tools for smarter decisions in.",
     "llmsTxtUrl": "https://pokemonlore.com/llms.txt",
     "llmsFullTxtUrl": "https://pokemonlore.com/llms-full.txt",
     "category": "data-analytics",
@@ -8985,7 +8994,7 @@
   {
     "name": "POL-EKO - Perfect Environment",
     "domain": "https://www.pol-eko.com.pl/",
-    "description": "POL-EKO to producent termostatycznych urządzeń laboratoryjnych, mebli metalowych, dygestoriów oraz urządzeń dla gospodarki wodno-ściekowej.",
+    "description": "POL-EKO to producent termostatycznych urz\u0105dze\u0144 laboratoryjnych, mebli metalowych, dygestori\u00f3w oraz urz\u0105dze\u0144 dla gospodarki wodno-\u015bciekowej.",
     "llmsTxtUrl": "https://www.pol-eko.com.pl/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=www.pol-eko.com.pl&sz=128",
@@ -9003,7 +9012,7 @@
   {
     "name": "Polivoz",
     "domain": "https://polivoz.org/",
-    "description": "Algoritmo minimalista que permite identificar la reflexión de mayor consenso entre 100 000 con tasas de acierto del 45% al 77%, según el escenario simulado.",
+    "description": "Algoritmo minimalista que permite identificar la reflexi\u00f3n de mayor consenso entre 100 000 con tasas de acierto del 45% al 77%, seg\u00fan el escenario simulado.",
     "llmsTxtUrl": "https://polivoz.org/llms.txt",
     "llmsFullTxtUrl": "https://polivoz.org/llms-full.txt",
     "category": "data-analytics",
@@ -9023,7 +9032,7 @@
   {
     "name": "Portal Ekko Green",
     "domain": "https://ekkogreen.com.br/",
-    "description": "Notícias, guias e ferramentas sobre sustentabilidade, energia limpa, mobilidade elétrica e ESG no Brasil. Informação verde que faz diferença.",
+    "description": "Not\u00edcias, guias e ferramentas sobre sustentabilidade, energia limpa, mobilidade el\u00e9trica e ESG no Brasil. Informa\u00e7\u00e3o verde que faz diferen\u00e7a.",
     "llmsTxtUrl": "https://ekkogreen.com.br/llms.txt",
     "llmsFullTxtUrl": "https://ekkogreen.com.br/llms-full.txt",
     "category": "data-analytics",
@@ -9033,7 +9042,7 @@
   {
     "name": "Portfolio - Bertrand Bichat EI",
     "domain": "https://bertrand-bichat.github.io/",
-    "description": "Développeur web fullstack sur le framework Ruby on Rails depuis 4 années, je travaille en freelance sur Marseille ou à distance. Je fais principalement des SaaS, CRM et ERP.",
+    "description": "D\u00e9veloppeur web fullstack sur le framework Ruby on Rails depuis 4 ann\u00e9es, je travaille en freelance sur Marseille ou \u00e0 distance. Je fais principalement des SaaS, CRM et ERP.",
     "llmsTxtUrl": "https://bertrand-bichat.github.io/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=bertrand-bichat.github.io&sz=128",
@@ -9042,7 +9051,7 @@
   {
     "name": "Posicionamiento Web Barcelona",
     "domain": "https://posicionamiento-web-barcelona.com",
-    "description": "Posicionamiento Web Barcelona ☎ 640 312 447 ✅ Agencia de Marketing online líder en SEO y SEM. ¿Necesitas aumentar las ventas en Google? Accede ahora.",
+    "description": "Posicionamiento Web Barcelona \u260e 640 312 447 \u2705 Agencia de Marketing online l\u00edder en SEO y SEM. \u00bfNecesitas aumentar las ventas en Google? Accede ahora.",
     "llmsTxtUrl": "https://posicionamiento-web-barcelona.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=posicionamiento-web-barcelona.com&sz=128",
@@ -9061,7 +9070,7 @@
   {
     "name": "Power Digital Marketing",
     "domain": "https://powerdigitalmarketing.com/",
-    "description": "Boost your brand’s online presence with Power Digital’s data-driven marketing strategies. Get started today and accelerate your business growth!",
+    "description": "Boost your brand\u2019s online presence with Power Digital\u2019s data-driven marketing strategies. Get started today and accelerate your business growth!",
     "llmsTxtUrl": "https://powerdigitalmarketing.com/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=powerdigitalmarketing.com&sz=128",
@@ -9126,7 +9135,7 @@
     "publishedAt": "2025-02-27"
   },
   {
-    "name": "Professional Survey Software and Survey Tools » IdSurvey",
+    "name": "Professional Survey Software and Survey Tools \u00bb IdSurvey",
     "domain": "https://www.idsurvey.com/en/",
     "description": "Idsurvey is a professional survey software for CAPI, CAWI, CATI interviews, an advanced platform with survey tools for distribution and data collection.",
     "llmsTxtUrl": "https://idsurvey.com/llms.txt",
@@ -9214,7 +9223,7 @@
   {
     "name": "Pronunciador",
     "domain": "https://pronunciador.com/",
-    "description": "¿Buscas un buen pronunciador de frases en inglés? Comparamos las 7 mejores herramientas (¡y con IA!) para que mejores tu acento hoy. ¡Prueba la #3!",
+    "description": "\u00bfBuscas un buen pronunciador de frases en ingl\u00e9s? Comparamos las 7 mejores herramientas (\u00a1y con IA!) para que mejores tu acento hoy. \u00a1Prueba la #3!",
     "llmsTxtUrl": "https://pronunciador.com/llms.txt",
     "llmsFullTxtUrl": "https://pronunciador.com/llms-full.txt",
     "category": "ai-ml",
@@ -9224,14 +9233,14 @@
   {
     "name": "Propertyfinder",
     "domain": "https://propertyfinder.bg/",
-    "description": "Вашият експертен гид за имоти в чужбина. Анализи, ръководства и съвети за умна инвестиция в Дубай, Испания, Гърция и др. Създаден специално за български инвеститори.",
+    "description": "\u0412\u0430\u0448\u0438\u044f\u0442 \u0435\u043a\u0441\u043f\u0435\u0440\u0442\u0435\u043d \u0433\u0438\u0434 \u0437\u0430 \u0438\u043c\u043e\u0442\u0438 \u0432 \u0447\u0443\u0436\u0431\u0438\u043d\u0430. \u0410\u043d\u0430\u043b\u0438\u0437\u0438, \u0440\u044a\u043a\u043e\u0432\u043e\u0434\u0441\u0442\u0432\u0430 \u0438 \u0441\u044a\u0432\u0435\u0442\u0438 \u0437\u0430 \u0443\u043c\u043d\u0430 \u0438\u043d\u0432\u0435\u0441\u0442\u0438\u0446\u0438\u044f \u0432 \u0414\u0443\u0431\u0430\u0439, \u0418\u0441\u043f\u0430\u043d\u0438\u044f, \u0413\u044a\u0440\u0446\u0438\u044f \u0438 \u0434\u0440. \u0421\u044a\u0437\u0434\u0430\u0434\u0435\u043d \u0441\u043f\u0435\u0446\u0438\u0430\u043b\u043d\u043e \u0437\u0430 \u0431\u044a\u043b\u0433\u0430\u0440\u0441\u043a\u0438 \u0438\u043d\u0432\u0435\u0441\u0442\u0438\u0442\u043e\u0440\u0438.",
     "llmsTxtUrl": "https://propertyfinder.bg/en/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=propertyfinder.bg&sz=128",
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Pub Nummer 4 Plauen - Fassbier 🍺 Sofa",
+    "name": "Pub Nummer 4 Plauen - Fassbier \ud83c\udf7a Sofa",
     "domain": "https://nr4.de/",
     "description": "Pub Nummer 4 in Plauen - Dein Pub mit nostalgischem Flair. Billard, Snooker, Kicker, Dart und 7 verschiedene Fassbiere seit den 80ern.",
     "llmsTxtUrl": "https://nr4.de/llms.txt",
@@ -9308,7 +9317,7 @@
   {
     "name": "Pyxa",
     "domain": "https://www.pyxa.ch/",
-    "description": "Agence digitale à Sierre spécialisée dans la création de sites web et e-commerces performants. Solutions adaptées aux entreprises en Valais.",
+    "description": "Agence digitale \u00e0 Sierre sp\u00e9cialis\u00e9e dans la cr\u00e9ation de sites web et e-commerces performants. Solutions adapt\u00e9es aux entreprises en Valais.",
     "llmsTxtUrl": "https://www.pyxa.ch/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.pyxa.ch&sz=128",
@@ -9326,7 +9335,7 @@
   {
     "name": "Qeeebo",
     "domain": "https://qeeebo.com",
-    "description": "AI-curated question-and-answer platform built to become the world’s largest.",
+    "description": "AI-curated question-and-answer platform built to become the world\u2019s largest.",
     "llmsTxtUrl": "https://qeeebo.com/llms.txt",
     "llmsFullTxtUrl": "https://qeeebo.com/llms-full.txt",
     "category": "ai-ml",
@@ -9381,7 +9390,7 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "r3turn — Export Intelligence",
+    "name": "r3turn \u2014 Export Intelligence",
     "domain": "https://www.r3turn.io",
     "description": "AI-Export intelligence for manufacturers. R3TURN Methodology v4.1: Digital Export Score, GEO visibility, market gap analysis. 80+ markets, 8 sectors.",
     "llmsTxtUrl": "https://www.r3turn.io/llms.txt",
@@ -9496,7 +9505,7 @@
   {
     "name": "RCPonline",
     "domain": "https://rcponline.pl",
-    "description": "Prosty system do rejestracji czasu pracy - Ewidencja Czasu Pracy, Układanie Grafików Pracy, Planowanie Urlopów, Rejestratory Czasu Pracy.",
+    "description": "Prosty system do rejestracji czasu pracy - Ewidencja Czasu Pracy, Uk\u0142adanie Grafik\u00f3w Pracy, Planowanie Urlop\u00f3w, Rejestratory Czasu Pracy.",
     "llmsTxtUrl": "https://rcponline.pl/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=rcponline.pl&sz=128",
@@ -9522,7 +9531,7 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Recevez les frais de scolarité et envoyez les commissions. Système de paiement pour les agences d'éducation internat",
+    "name": "Recevez les frais de scolarit\u00e9 et envoyez les commissions. Syst\u00e8me de paiement pour les agences d'\u00e9ducation internat",
     "domain": "https://qualyhq.com/fr/",
     "description": "> Qualy is a payment platform for international education, used by schools, colleges, universities and education agents.",
     "llmsTxtUrl": "https://qualyhq.com/llms.txt",
@@ -9551,7 +9560,7 @@
   {
     "name": "Redpanda",
     "domain": "https://www.redpanda.com/",
-    "description": "Redpanda is a powerful, simple, and cost-efficient streaming data platform that is compatible with KafkaÂ® APIs while eliminating Kafka complexity.",
+    "description": "Redpanda is a powerful, simple, and cost-efficient streaming data platform that is compatible with Kafka\u00c2\u00ae APIs while eliminating Kafka complexity.",
     "llmsTxtUrl": "https://docs.redpanda.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=www.redpanda.com&sz=128",
@@ -9617,7 +9626,7 @@
   {
     "name": "Render",
     "domain": "https://render.com",
-    "description": "On Render, you can build, deploy, and scale your apps with unparalleled ease – from your first user to your billionth.",
+    "description": "On Render, you can build, deploy, and scale your apps with unparalleled ease \u2013 from your first user to your billionth.",
     "llmsTxtUrl": "https://render.com/docs/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=render.com&sz=128",
@@ -9646,7 +9655,7 @@
   {
     "name": "Rent and Go",
     "domain": "https://www.rentandgo.it/",
-    "description": "Noleggia sci, snowboard e bici di qualità, 80 negozi in Italia! Prenota online in pochi clic, fino al 20% di sconto e disponibilità garantita",
+    "description": "Noleggia sci, snowboard e bici di qualit\u00e0, 80 negozi in Italia! Prenota online in pochi clic, fino al 20% di sconto e disponibilit\u00e0 garantita",
     "llmsTxtUrl": "https://www.rentandgo.it/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=www.rentandgo.it&sz=128",
@@ -9664,7 +9673,7 @@
   {
     "name": "Reo.Dev",
     "domain": "https://www.reo.dev/",
-    "description": "Reo.Dev’s AI turns GitHub activity, docs engagement and open source usage into revenue signals for developer marketing and GTM teams.",
+    "description": "Reo.Dev\u2019s AI turns GitHub activity, docs engagement and open source usage into revenue signals for developer marketing and GTM teams.",
     "llmsTxtUrl": "https://www.reo.dev/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=www.reo.dev&sz=128",
@@ -9719,15 +9728,6 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Réservez un taxi à Paris - Tarifs fixes",
-    "domain": "https://taxi-paris-online.com/",
-    "description": "Tarifs fixes pour tous vos trajets à Paris et en Île-de-France - Réservez gratuitement en ligne ou par téléphone",
-    "llmsTxtUrl": "https://taxi-paris-online.com/llms.txt",
-    "category": "developer-tools",
-    "favicon": "https://www.google.com/s2/favicons?domain=taxi-paris-online.com&sz=128",
-    "publishedAt": "2026-05-31"
-  },
-  {
     "name": "REVA Global",
     "domain": "https://revaglobal.com/",
     "description": "REVA Global is the leading provider of highly trained real estate Virtual Assistants to support the growth of your business.",
@@ -9766,16 +9766,16 @@
   {
     "name": "RH Performances",
     "domain": "https://www.rhperformances.fr/",
-    "description": "RH Performances est un cabinet de recrutement, organisme de formation & de coaching qui booste vos talents à l'aide de solutions simples & innovantes.",
+    "description": "RH Performances est un cabinet de recrutement, organisme de formation & de coaching qui booste vos talents \u00e0 l'aide de solutions simples & innovantes.",
     "llmsTxtUrl": "https://www.rhperformances.fr/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.rhperformances.fr&sz=128",
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "RH: Медичне обладнання в Україні",
+    "name": "RH: \u041c\u0435\u0434\u0438\u0447\u043d\u0435 \u043e\u0431\u043b\u0430\u0434\u043d\u0430\u043d\u043d\u044f \u0432 \u0423\u043a\u0440\u0430\u0457\u043d\u0456",
     "domain": "https://rh.ua/",
-    "description": "RH - експерт №1 у медичному обладнанні. Продаж, оренда та сервіс УЗД апаратів, ендоскопів, рентген та лабораторного обладнання. Навчання лікарів УЗД діагностиці. Гарантія та доставка по всій Україні.",
+    "description": "RH - \u0435\u043a\u0441\u043f\u0435\u0440\u0442 \u21161 \u0443 \u043c\u0435\u0434\u0438\u0447\u043d\u043e\u043c\u0443 \u043e\u0431\u043b\u0430\u0434\u043d\u0430\u043d\u043d\u0456. \u041f\u0440\u043e\u0434\u0430\u0436, \u043e\u0440\u0435\u043d\u0434\u0430 \u0442\u0430 \u0441\u0435\u0440\u0432\u0456\u0441 \u0423\u0417\u0414 \u0430\u043f\u0430\u0440\u0430\u0442\u0456\u0432, \u0435\u043d\u0434\u043e\u0441\u043a\u043e\u043f\u0456\u0432, \u0440\u0435\u043d\u0442\u0433\u0435\u043d \u0442\u0430 \u043b\u0430\u0431\u043e\u0440\u0430\u0442\u043e\u0440\u043d\u043e\u0433\u043e \u043e\u0431\u043b\u0430\u0434\u043d\u0430\u043d\u043d\u044f. \u041d\u0430\u0432\u0447\u0430\u043d\u043d\u044f \u043b\u0456\u043a\u0430\u0440\u0456\u0432 \u0423\u0417\u0414 \u0434\u0456\u0430\u0433\u043d\u043e\u0441\u0442\u0438\u0446\u0456. \u0413\u0430\u0440\u0430\u043d\u0442\u0456\u044f \u0442\u0430 \u0434\u043e\u0441\u0442\u0430\u0432\u043a\u0430 \u043f\u043e \u0432\u0441\u0456\u0439 \u0423\u043a\u0440\u0430\u0457\u043d\u0456.",
     "llmsTxtUrl": "https://rh.ua/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=rh.ua&sz=128",
@@ -9784,7 +9784,7 @@
   {
     "name": "Ri Xu Online",
     "domain": "https://xuri.me",
-    "description": "Ri Xu Online -- Weaving dreams · Achievements of the future",
+    "description": "Ri Xu Online -- Weaving dreams \u00b7 Achievements of the future",
     "llmsTxtUrl": "https://xuri.me/llms.txt",
     "llmsFullTxtUrl": "https://xuri.me/llms-full.txt",
     "category": "developer-tools",
@@ -9803,7 +9803,7 @@
   {
     "name": "RightNow AI",
     "domain": "https://www.rightnowai.co/",
-    "description": "RightNow AI Research Lab — work on model-hardware co-design, GPU kernel optimization, architecture-aware tooling, serving systems, and inference infrastructure.",
+    "description": "RightNow AI Research Lab \u2014 work on model-hardware co-design, GPU kernel optimization, architecture-aware tooling, serving systems, and inference infrastructure.",
     "llmsTxtUrl": "https://www.rightnowai.co/llms.txt",
     "llmsFullTxtUrl": "https://www.rightnowai.co/llms-full.txt",
     "category": "ai-ml",
@@ -9906,9 +9906,9 @@
     "publishedAt": "2025-08-26"
   },
   {
-    "name": "Rui Seiça",
+    "name": "Rui Sei\u00e7a",
     "domain": "https://ruiseica.com/",
-    "description": "Rui Seiça is a designer and developer from Portugal, creating websites and visual identities at the intersection of design and technology.",
+    "description": "Rui Sei\u00e7a is a designer and developer from Portugal, creating websites and visual identities at the intersection of design and technology.",
     "llmsTxtUrl": "https://ruiseica.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=ruiseica.com&sz=128",
@@ -9945,9 +9945,18 @@
     "publishedAt": "2026-03-05"
   },
   {
+    "name": "R\u00e9servez un taxi \u00e0 Paris - Tarifs fixes",
+    "domain": "https://taxi-paris-online.com/",
+    "description": "Tarifs fixes pour tous vos trajets \u00e0 Paris et en \u00cele-de-France - R\u00e9servez gratuitement en ligne ou par t\u00e9l\u00e9phone",
+    "llmsTxtUrl": "https://taxi-paris-online.com/llms.txt",
+    "category": "developer-tools",
+    "favicon": "https://www.google.com/s2/favicons?domain=taxi-paris-online.com&sz=128",
+    "publishedAt": "2026-05-31"
+  },
+  {
     "name": "S.K.KUNATHAM GROUP",
     "domain": "https://www.skkunathamgroup.com/",
-    "description": "S.K. Kunatham Group ให้บริการเช่ารถเครน 25-500 ตันพร้อมคนขับ ปจ.2 ครบ ทีม 4 ผู้ Zero Accident 30 ปี สงขลา หาดใหญ่ ระนอง ภาคใต้ ขอราคา LINE",
+    "description": "S.K. Kunatham Group \u0e43\u0e2b\u0e49\u0e1a\u0e23\u0e34\u0e01\u0e32\u0e23\u0e40\u0e0a\u0e48\u0e32\u0e23\u0e16\u0e40\u0e04\u0e23\u0e19 25-500 \u0e15\u0e31\u0e19\u0e1e\u0e23\u0e49\u0e2d\u0e21\u0e04\u0e19\u0e02\u0e31\u0e1a \u0e1b\u0e08.2 \u0e04\u0e23\u0e1a \u0e17\u0e35\u0e21 4 \u0e1c\u0e39\u0e49 Zero Accident 30 \u0e1b\u0e35 \u0e2a\u0e07\u0e02\u0e25\u0e32 \u0e2b\u0e32\u0e14\u0e43\u0e2b\u0e0d\u0e48 \u0e23\u0e30\u0e19\u0e2d\u0e07 \u0e20\u0e32\u0e04\u0e43\u0e15\u0e49 \u0e02\u0e2d\u0e23\u0e32\u0e04\u0e32 LINE",
     "llmsTxtUrl": "https://www.skkunathamgroup.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.skkunathamgroup.com&sz=128",
@@ -9973,7 +9982,7 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Sadaghian® e.K.",
+    "name": "Sadaghian\u00ae e.K.",
     "domain": "https://sadaghian.com/",
     "description": "MacBook Reparatur deutschlandweit, Werkstatt in Hamburg seit 2015. Komponenten-Reparatur statt teurem Komplettaustausch. Kostenlose Analyse, 12 Monate Garantie.",
     "llmsTxtUrl": "https://sadaghian.com/llms.txt",
@@ -10039,7 +10048,7 @@
   {
     "name": "Sansasyonel Gazete",
     "domain": "https://sansasyonelgazete.com/",
-    "description": "Sansasyonel Gazete, güncel magazin, spor ve son dakika haberlerini sizlere ulaştırır.",
+    "description": "Sansasyonel Gazete, g\u00fcncel magazin, spor ve son dakika haberlerini sizlere ula\u015ft\u0131r\u0131r.",
     "llmsTxtUrl": "https://sansasyonelgazete.com/llms.txt",
     "llmsFullTxtUrl": "https://sansasyonelgazete.com/llms-full.txt",
     "category": "ai-ml",
@@ -10047,9 +10056,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Santiago Soñora",
+    "name": "Santiago So\u00f1ora",
     "domain": "https://santiago.xn--soora-pta.com/",
-    "description": "Perfil profesional de Santiago Soñora, Full Stack & AI Engineer. Especialista en Python, Kubernetes y Web3. Trayectoria en Buenos Aires (CABA, Zona Oeste), Bariloche y Valencia.",
+    "description": "Perfil profesional de Santiago So\u00f1ora, Full Stack & AI Engineer. Especialista en Python, Kubernetes y Web3. Trayectoria en Buenos Aires (CABA, Zona Oeste), Bariloche y Valencia.",
     "llmsTxtUrl": "https://santiago.xn--soora-pta.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=santiago.xn--soora-pta.com&sz=128",
@@ -10066,7 +10075,7 @@
     "publishedAt": "2025-02-24"
   },
   {
-    "name": "SashiDo™",
+    "name": "SashiDo\u2122",
     "domain": "https://www.sashido.io/en/",
     "description": "Vibe-coded your app? Now add the backend. Database, APIs, auth, push, storage, and cloud functions. Battle-tested by thousands of apps. Deploy in minutes.",
     "llmsTxtUrl": "https://www.sashido.io/llms.txt",
@@ -10088,7 +10097,7 @@
   {
     "name": "ScDecorum",
     "domain": "https://scdecorum.com/",
-    "description": "Discover expert home décor ideas, DIY inspiration, and lifestyle tips. SCDecorum helps you create stylish, functional spaces with ease.",
+    "description": "Discover expert home d\u00e9cor ideas, DIY inspiration, and lifestyle tips. SCDecorum helps you create stylish, functional spaces with ease.",
     "llmsTxtUrl": "https://scdecorum.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=scdecorum.com&sz=128",
@@ -10107,7 +10116,7 @@
   {
     "name": "Scherb Sprachendienste",
     "domain": "https://scherb-sprachendienste.de/",
-    "description": "Übersetzungen ins Deutsche und andere Sprachen - Bestellen Sie bei einem hochwertigen Übersetzungsdienst ✔️ Bestmögliche Preise - Übersetzen lassen beim Übersetzungsbüro Scherb Sprachendienste in Düsseldorf",
+    "description": "\u00dcbersetzungen ins Deutsche und andere Sprachen - Bestellen Sie bei einem hochwertigen \u00dcbersetzungsdienst \u2714\ufe0f Bestm\u00f6gliche Preise - \u00dcbersetzen lassen beim \u00dcbersetzungsb\u00fcro Scherb Sprachendienste in D\u00fcsseldorf",
     "llmsTxtUrl": "https://scherb-sprachendienste.de/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=scherb-sprachendienste.de&sz=128",
@@ -10144,7 +10153,7 @@
   {
     "name": "Scout for Errors, Logs, APM",
     "domain": "https://www.scoutapm.com",
-    "description": "Get full visibility—without setting up three tools. The platform trusted by developers using Rails, Django, and more.",
+    "description": "Get full visibility\u2014without setting up three tools. The platform trusted by developers using Rails, Django, and more.",
     "llmsTxtUrl": "https://www.scoutapm.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=www.scoutapm.com&sz=128",
@@ -10219,7 +10228,7 @@
   {
     "name": "SellerSprite-JP",
     "domain": "https://www.sellersprite.jp/",
-    "description": "セラースプライト(SellerSprite)はビッグデータと人工知能技術に基づき、アマゾンの越境セラーにワン・サイトで商品リサーチ、市場分析、キーワード最適化、商品モニタリングなどのソフトウェアツールを提供し、アマゾンのセラーにニッチ市場、潜在力がある商品の発見に助けになります.",
+    "description": "\u30bb\u30e9\u30fc\u30b9\u30d7\u30e9\u30a4\u30c8(SellerSprite)\u306f\u30d3\u30c3\u30b0\u30c7\u30fc\u30bf\u3068\u4eba\u5de5\u77e5\u80fd\u6280\u8853\u306b\u57fa\u3065\u304d\u3001\u30a2\u30de\u30be\u30f3\u306e\u8d8a\u5883\u30bb\u30e9\u30fc\u306b\u30ef\u30f3\u30fb\u30b5\u30a4\u30c8\u3067\u5546\u54c1\u30ea\u30b5\u30fc\u30c1\u3001\u5e02\u5834\u5206\u6790\u3001\u30ad\u30fc\u30ef\u30fc\u30c9\u6700\u9069\u5316\u3001\u5546\u54c1\u30e2\u30cb\u30bf\u30ea\u30f3\u30b0\u306a\u3069\u306e\u30bd\u30d5\u30c8\u30a6\u30a7\u30a2\u30c4\u30fc\u30eb\u3092\u63d0\u4f9b\u3057\u3001\u30a2\u30de\u30be\u30f3\u306e\u30bb\u30e9\u30fc\u306b\u30cb\u30c3\u30c1\u5e02\u5834\u3001\u6f5c\u5728\u529b\u304c\u3042\u308b\u5546\u54c1\u306e\u767a\u898b\u306b\u52a9\u3051\u306b\u306a\u308a\u307e\u3059.",
     "llmsTxtUrl": "https://www.sellersprite.jp/llms.txt",
     "llmsFullTxtUrl": "https://www.sellersprite.jp/llms-full.txt",
     "category": "data-analytics",
@@ -10276,7 +10285,7 @@
   {
     "name": "SEO Berlin",
     "domain": "https://seo-berlin.de/",
-    "description": "Verbessern Sie Ihre Sichtbarkeit und Ihren Umsatz. ✓ Onpage-SEO ✓ Offpage-SEO ✓ Local SEO ✓ SEA ➤ SEO Agentur Berlin ✆ 030629339290",
+    "description": "Verbessern Sie Ihre Sichtbarkeit und Ihren Umsatz. \u2713 Onpage-SEO \u2713 Offpage-SEO \u2713 Local SEO \u2713 SEA \u27a4 SEO Agentur Berlin \u2706 030629339290",
     "llmsTxtUrl": "https://seo-berlin.de/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=seo-berlin.de&sz=128",
@@ -10313,7 +10322,7 @@
   {
     "name": "Seyyed Gouasmi",
     "domain": "https://gouasmi.com/",
-    "description": "Découvrez 327+ articles et analyses sur l'eschatologie islamique, la fin des temps, Gog et Magog, le Mahdi et le Dajjal. Ressources authentiques basées sur le Coran et les hadiths.",
+    "description": "D\u00e9couvrez 327+ articles et analyses sur l'eschatologie islamique, la fin des temps, Gog et Magog, le Mahdi et le Dajjal. Ressources authentiques bas\u00e9es sur le Coran et les hadiths.",
     "llmsTxtUrl": "https://gouasmi.com/llms.txt",
     "category": "security-identity",
     "favicon": "https://www.google.com/s2/favicons?domain=gouasmi.com&sz=128",
@@ -10351,7 +10360,7 @@
   {
     "name": "Shwompy",
     "domain": "https://shwompy.com/",
-    "description": "Join Shwompy the Swamp Blob on a goo-tastic journey through the bayou—swamp tales, slimy tips, and blob-tacular surprises await!",
+    "description": "Join Shwompy the Swamp Blob on a goo-tastic journey through the bayou\u2014swamp tales, slimy tips, and blob-tacular surprises await!",
     "llmsTxtUrl": "https://shwompy.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=shwompy.com&sz=128",
@@ -10399,7 +10408,7 @@
   {
     "name": "SimplePDF",
     "domain": "https://simplepdf.com",
-    "description": "PDF editor in the browser – add text, checkboxes, pictures, signatures to PDF files. Merge, rotate PDF pages – iframe, script and React component.",
+    "description": "PDF editor in the browser \u2013 add text, checkboxes, pictures, signatures to PDF files. Merge, rotate PDF pages \u2013 iframe, script and React component.",
     "llmsTxtUrl": "https://simplepdf.com/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=simplepdf.com&sz=128",
@@ -10434,9 +10443,9 @@
     "publishedAt": "2026-05-21"
   },
   {
-    "name": "Sistem Güncelleniyor",
+    "name": "Sistem G\u00fcncelleniyor",
     "domain": "https://muvezzi.com/",
-    "description": "Sistem Güncelleniyor provides AI-readable documentation through llms.txt.",
+    "description": "Sistem G\u00fcncelleniyor provides AI-readable documentation through llms.txt.",
     "llmsTxtUrl": "https://muvezzi.com/llms.txt",
     "llmsFullTxtUrl": "https://muvezzi.com/llms-full.txt",
     "category": "ai-ml",
@@ -10444,9 +10453,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "sitecentre®",
+    "name": "sitecentre\u00ae",
     "domain": "https://www.sitecentre.com.au/",
-    "description": "sitecentre® is an award-winning digital marketing agency in Australia specialising in Hosting, SEO, Domains, Web Design and PPC.",
+    "description": "sitecentre\u00ae is an award-winning digital marketing agency in Australia specialising in Hosting, SEO, Domains, Web Design and PPC.",
     "llmsTxtUrl": "https://www.sitecentre.com.au/llms.txt",
     "llmsFullTxtUrl": "https://www.sitecentre.com.au/llms-full.txt",
     "category": "ai-ml",
@@ -10474,7 +10483,7 @@
   {
     "name": "Sketch To",
     "domain": "https://www.sketchto.com",
-    "description": "100+ AI image tools in one studio: bidirectional sketch ↔ image, portrait stylization, photo editor, image generator and enhancer.",
+    "description": "100+ AI image tools in one studio: bidirectional sketch \u2194 image, portrait stylization, photo editor, image generator and enhancer.",
     "llmsTxtUrl": "https://www.sketchto.com/llms.txt",
     "llmsFullTxtUrl": "https://www.sketchto.com/llms-full.txt",
     "category": "ai-ml",
@@ -10532,7 +10541,7 @@
   {
     "name": "SleepLine",
     "domain": "https://sleepline.ro/",
-    "description": "Saltele SleepLine asigură un suport excelent, pentru ca tu să te bucuri de un somn odihnitor! Livrare gratuită până la ușa ta!",
+    "description": "Saltele SleepLine asigur\u0103 un suport excelent, pentru ca tu s\u0103 te bucuri de un somn odihnitor! Livrare gratuit\u0103 p\u00e2n\u0103 la u\u0219a ta!",
     "llmsTxtUrl": "https://sleepline.ro/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=sleepline.ro&sz=128",
@@ -10603,15 +10612,6 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Snøkam",
-    "domain": "https://www.snokam.no/",
-    "description": "Hos Snøkam er vi opptatt av å forvandle teknologiske utfordringer til elegante løsninger. Våre konsulenter er spesialister innen fullstack-utvikling, data engineering og AI, og vi har et øye for detaljene som utgjør en stor forskjell.",
-    "llmsTxtUrl": "https://www.snokam.no/llms.txt",
-    "category": "ai-ml",
-    "favicon": "https://www.google.com/s2/favicons?domain=www.snokam.no&sz=128",
-    "publishedAt": "2026-05-31"
-  },
-  {
     "name": "SNUC",
     "domain": "https://snuc.com/",
     "description": "SNUC powers USA enterprises and federal agencies with fanless, rugged, AI-ready edge computers and extremeEDGE servers with NANO BMC systems.",
@@ -10630,6 +10630,15 @@
     "publishedAt": "2026-05-31"
   },
   {
+    "name": "Sn\u00f8kam",
+    "domain": "https://www.snokam.no/",
+    "description": "Hos Sn\u00f8kam er vi opptatt av \u00e5 forvandle teknologiske utfordringer til elegante l\u00f8sninger. V\u00e5re konsulenter er spesialister innen fullstack-utvikling, data engineering og AI, og vi har et \u00f8ye for detaljene som utgj\u00f8r en stor forskjell.",
+    "llmsTxtUrl": "https://www.snokam.no/llms.txt",
+    "category": "ai-ml",
+    "favicon": "https://www.google.com/s2/favicons?domain=www.snokam.no&sz=128",
+    "publishedAt": "2026-05-31"
+  },
+  {
     "name": "Social+",
     "domain": "https://social.plus",
     "description": "Easily integrate our pre-built social features and launch your curated in-app community. Boost app engagement, retention and revenues.",
@@ -10641,7 +10650,7 @@
   {
     "name": "Software Development Company",
     "domain": "https://www.netguru.com/",
-    "description": "Europe’s finest custom software development company. More than 10 years of experience, over 630 developers and designers specializing in software development, mobile development and product design.",
+    "description": "Europe\u2019s finest custom software development company. More than 10 years of experience, over 630 developers and designers specializing in software development, mobile development and product design.",
     "llmsTxtUrl": "https://www.netguru.com/hubfs/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=www.netguru.com&sz=128",
@@ -10734,7 +10743,7 @@
   {
     "name": "Sphairlab",
     "domain": "https://www.sphairlab.com/",
-    "description": "Sphairlab bietet mobile, kosteneffiziente Reinraumlösungen mit Fokus auf Einfachheit, Flexibilität und schnelle Bereitstellung. Ideal für temporäre oder projektbasierte Anforderungen.",
+    "description": "Sphairlab bietet mobile, kosteneffiziente Reinrauml\u00f6sungen mit Fokus auf Einfachheit, Flexibilit\u00e4t und schnelle Bereitstellung. Ideal f\u00fcr tempor\u00e4re oder projektbasierte Anforderungen.",
     "llmsTxtUrl": "https://www.sphairlab.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.sphairlab.com&sz=128",
@@ -10752,7 +10761,7 @@
   {
     "name": "Stacked",
     "domain": "https://stackedpay.io/",
-    "description": "Com Stacked, você junta sua galera, divide o pagamento e ainda ganha conquistas.",
+    "description": "Com Stacked, voc\u00ea junta sua galera, divide o pagamento e ainda ganha conquistas.",
     "llmsTxtUrl": "https://stackedpay.io/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=stackedpay.io&sz=128",
@@ -10761,7 +10770,7 @@
   {
     "name": "StartupStage",
     "domain": "https://startupstage.com/",
-    "description": "Keep 100% of your startup. StartupStage gives founders coordinated expert support — CMO, CTO, CFO, legal — for $297/month with no equity. 347+ founders scaling without dilution.",
+    "description": "Keep 100% of your startup. StartupStage gives founders coordinated expert support \u2014 CMO, CTO, CFO, legal \u2014 for $297/month with no equity. 347+ founders scaling without dilution.",
     "llmsTxtUrl": "https://startupstage.com/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=startupstage.com&sz=128",
@@ -10787,7 +10796,7 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Static Hosting · ShipStatic",
+    "name": "Static Hosting \u00b7 ShipStatic",
     "domain": "https://www.shipstatic.com",
     "description": "Simple static hosting. Drop your files, get a live URL in seconds. Free SSL, custom domains, instant deploys.",
     "llmsTxtUrl": "https://www.shipstatic.com/llms.txt",
@@ -10817,7 +10826,7 @@
   {
     "name": "Staytrue",
     "domain": "https://www.staytrue.fr/",
-    "description": "Réduisez votre dépendance aux OTA avec StayTrue. Une solution simple et efficace pour générer plus de réservations directes et fidéliser vos clients.",
+    "description": "R\u00e9duisez votre d\u00e9pendance aux OTA avec StayTrue. Une solution simple et efficace pour g\u00e9n\u00e9rer plus de r\u00e9servations directes et fid\u00e9liser vos clients.",
     "llmsTxtUrl": "https://www.staytrue.fr/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=www.staytrue.fr&sz=128",
@@ -10863,7 +10872,7 @@
   {
     "name": "Strale",
     "domain": "https://strale.dev",
-    "description": "Your agent calls strale.do() and gets company data, compliance checks, financial validation — structured JSON with audit trails. 233+ capabilities, one API key.",
+    "description": "Your agent calls strale.do() and gets company data, compliance checks, financial validation \u2014 structured JSON with audit trails. 233+ capabilities, one API key.",
     "llmsTxtUrl": "https://strale.dev/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=strale.dev&sz=128",
@@ -10927,7 +10936,7 @@
   {
     "name": "Sumontuosime",
     "domain": "https://sumontuosime.lt/",
-    "description": "Vėdinimo ir rekuperacijos, santechnikos, kanalizacijos, šildymo sistemų, šilumos siurblių ir šildymo įrengimas. Dirbame Vilniaus mieste. Sumontuosime kaip sau",
+    "description": "V\u0117dinimo ir rekuperacijos, santechnikos, kanalizacijos, \u0161ildymo sistem\u0173, \u0161ilumos siurbli\u0173 ir \u0161ildymo \u012frengimas. Dirbame Vilniaus mieste. Sumontuosime kaip sau",
     "llmsTxtUrl": "https://sumontuosime.lt/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=sumontuosime.lt&sz=128",
@@ -11107,7 +11116,7 @@
   {
     "name": "Taskade AI",
     "domain": "https://www.taskade.com/",
-    "description": "Meet your AI workforce in Taskade. Build apps from a prompt. Connect tasks, data, and agents that think, plan, and act—automating work across your team.",
+    "description": "Meet your AI workforce in Taskade. Build apps from a prompt. Connect tasks, data, and agents that think, plan, and act\u2014automating work across your team.",
     "llmsTxtUrl": "https://www.taskade.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.taskade.com&sz=128",
@@ -11136,7 +11145,7 @@
   {
     "name": "Tech Mart Bangladesh",
     "domain": "https://www.techmart.com.bd/",
-    "description": "Tech Mart – Bangladesh’s online shop for Microphone, Tripod, Smartphones, Laptops, Apple products, Computer Components, Accessories & Gadgets at low prices",
+    "description": "Tech Mart \u2013 Bangladesh\u2019s online shop for Microphone, Tripod, Smartphones, Laptops, Apple products, Computer Components, Accessories & Gadgets at low prices",
     "llmsTxtUrl": "https://www.techmart.com.bd/llms.txt",
     "category": "security-identity",
     "favicon": "https://www.google.com/s2/favicons?domain=www.techmart.com.bd&sz=128",
@@ -11145,21 +11154,12 @@
   {
     "name": "Techtown",
     "domain": "https://techtown.fr/",
-    "description": "Description TechTown est un cabinet d'expertise spécialisé dans le Cloud et l'IA, basé à Nantes, France, et créé en 2025.",
+    "description": "Description TechTown est un cabinet d'expertise sp\u00e9cialis\u00e9 dans le Cloud et l'IA, bas\u00e9 \u00e0 Nantes, France, et cr\u00e9\u00e9 en 2025.",
     "llmsTxtUrl": "https://techtown.fr/llms.txt",
     "llmsFullTxtUrl": "https://techtown.fr/llms-full.txt",
     "category": "infrastructure-cloud",
     "favicon": "https://www.google.com/s2/favicons?domain=techtown.fr&sz=128",
     "publishedAt": "2026-05-31"
-  },
-  {
-    "name": "Téléassistance Sénior",
-    "domain": "https://www.tele-assistance-senior.fr",
-    "description": "Téléassistance pour 24,90 € / mois. N° 1 en France avec plus de 250 000 abonnés. Installation par nos techniciens à domicile en moins de 7 jours.",
-    "llmsTxtUrl": "https://www.tele-assistance-senior.fr/llms.txt",
-    "category": "developer-tools",
-    "favicon": "https://www.google.com/s2/favicons?domain=www.tele-assistance-senior.fr&sz=128",
-    "publishedAt": "2025-08-26"
   },
   {
     "name": "Television.AI",
@@ -11192,7 +11192,7 @@
   {
     "name": "TensorZero",
     "domain": "https://tensorzero.com",
-    "description": "TensorZero creates a feedback loop for optimizing LLM applications — turning production data into smarter, faster, and cheaper models.",
+    "description": "TensorZero creates a feedback loop for optimizing LLM applications \u2014 turning production data into smarter, faster, and cheaper models.",
     "llmsTxtUrl": "https://tensorzero.com/llms.txt",
     "llmsFullTxtUrl": "https://tensorzero.com/llms-full.txt",
     "category": "ai-ml",
@@ -11202,7 +11202,7 @@
   {
     "name": "tenue31.fr",
     "domain": "https://tenue31.fr/",
-    "description": "Musée en ligne sur l'Officier Français: uniformes et parcours militaires, grande tenue modèle 1931, transformation de l'Armée Française.",
+    "description": "Mus\u00e9e en ligne sur l'Officier Fran\u00e7ais: uniformes et parcours militaires, grande tenue mod\u00e8le 1931, transformation de l'Arm\u00e9e Fran\u00e7aise.",
     "llmsTxtUrl": "https://tenue31.fr/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=tenue31.fr&sz=128",
@@ -11221,7 +11221,7 @@
   {
     "name": "Terminal49",
     "domain": "https://terminal49.com/",
-    "description": "Terminal49 automates container and shipment tracking with real-time visibility for ocean, rail, and inland logistics—reducing fees, mitigating risks, and streamlining ops.",
+    "description": "Terminal49 automates container and shipment tracking with real-time visibility for ocean, rail, and inland logistics\u2014reducing fees, mitigating risks, and streamlining ops.",
     "llmsTxtUrl": "https://terminal49.com/docs/llms.txt",
     "llmsFullTxtUrl": "https://terminal49.com/docs/llms-full.txt",
     "category": "ai-ml",
@@ -11231,7 +11231,7 @@
   {
     "name": "THAI SPA",
     "domain": "https://thaispa.bg/",
-    "description": "Изберете тайландски масаж, ритуал, сауна или вана за вас или за двойка. Изживейте удоволствието от автентичен тайландски масаж с нашите ваучери.",
+    "description": "\u0418\u0437\u0431\u0435\u0440\u0435\u0442\u0435 \u0442\u0430\u0439\u043b\u0430\u043d\u0434\u0441\u043a\u0438 \u043c\u0430\u0441\u0430\u0436, \u0440\u0438\u0442\u0443\u0430\u043b, \u0441\u0430\u0443\u043d\u0430 \u0438\u043b\u0438 \u0432\u0430\u043d\u0430 \u0437\u0430 \u0432\u0430\u0441 \u0438\u043b\u0438 \u0437\u0430 \u0434\u0432\u043e\u0439\u043a\u0430. \u0418\u0437\u0436\u0438\u0432\u0435\u0439\u0442\u0435 \u0443\u0434\u043e\u0432\u043e\u043b\u0441\u0442\u0432\u0438\u0435\u0442\u043e \u043e\u0442 \u0430\u0432\u0442\u0435\u043d\u0442\u0438\u0447\u0435\u043d \u0442\u0430\u0439\u043b\u0430\u043d\u0434\u0441\u043a\u0438 \u043c\u0430\u0441\u0430\u0436 \u0441 \u043d\u0430\u0448\u0438\u0442\u0435 \u0432\u0430\u0443\u0447\u0435\u0440\u0438.",
     "llmsTxtUrl": "https://thaispa.bg/llms.txt",
     "llmsFullTxtUrl": "https://thaispa.bg/llms-full.txt",
     "category": "ai-ml",
@@ -11239,7 +11239,7 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "The AI Engineer’s Handbook",
+    "name": "The AI Engineer\u2019s Handbook",
     "domain": "https://handbook.exemplar.dev",
     "description": "Comprehensive guide for AI Engineers covering LLMs, Vector Databases, RAG Systems, AI Agents, Prompt Engineering, and System Design. Learn to build scalable AI applications.",
     "llmsTxtUrl": "https://handbook.exemplar.dev/llms.txt",
@@ -11345,7 +11345,7 @@
   {
     "name": "The Purest Solutions",
     "domain": "https://thepurestsolutions.com/",
-    "description": "The Purest Solutions, tüketici alışkanlıkları ve ihtiyaçları doğrultusunda geliştirilmiş olan sorun odaklı sonuç veren çözümler sunar. Formülasyonlarımızın tamamı bilimsel açıklamalar, test&analiz ve klinik çalışmalara dayanmaktadır. (SkinLab,Yeditepe)",
+    "description": "The Purest Solutions, t\u00fcketici al\u0131\u015fkanl\u0131klar\u0131 ve ihtiya\u00e7lar\u0131 do\u011frultusunda geli\u015ftirilmi\u015f olan sorun odakl\u0131 sonu\u00e7 veren \u00e7\u00f6z\u00fcmler sunar. Form\u00fclasyonlar\u0131m\u0131z\u0131n tamam\u0131 bilimsel a\u00e7\u0131klamalar, test&analiz ve klinik \u00e7al\u0131\u015fmalara dayanmaktad\u0131r. (SkinLab,Yeditepe)",
     "llmsTxtUrl": "https://thepurestsolutions.com/llms.txt",
     "llmsFullTxtUrl": "https://thepurestsolutions.com/llms-full.txt",
     "category": "data-analytics",
@@ -11355,7 +11355,7 @@
   {
     "name": "THE SANSASYONEL",
     "domain": "https://thesansasyonel.com/",
-    "description": "The Sansasyonel, sansasyonel haberler, ünlülerin dünyasından son gelişmeler ve güncel olaylar ile ilgili haberler sunar.",
+    "description": "The Sansasyonel, sansasyonel haberler, \u00fcnl\u00fclerin d\u00fcnyas\u0131ndan son geli\u015fmeler ve g\u00fcncel olaylar ile ilgili haberler sunar.",
     "llmsTxtUrl": "https://thesansasyonel.com/llms.txt",
     "llmsFullTxtUrl": "https://thesansasyonel.com/llms-full.txt",
     "category": "ai-ml",
@@ -11422,7 +11422,7 @@
   {
     "name": "Tidio",
     "domain": "https://www.tidio.com",
-    "description": "Convert more leads, provide stellar support, and boost your revenue with Tidio’s game-changing AI-driven customer service solution.",
+    "description": "Convert more leads, provide stellar support, and boost your revenue with Tidio\u2019s game-changing AI-driven customer service solution.",
     "llmsTxtUrl": "https://www.tidio.com/llms.txt",
     "llmsFullTxtUrl": "https://www.tidio.com/llms-full.txt",
     "category": "developer-tools",
@@ -11432,7 +11432,7 @@
   {
     "name": "Timepilot",
     "domain": "https://timepilot.co/",
-    "description": "Retrouvez tous les films à l'affiche, les avant-premières, les sorties de la semaine et les horaires de cinéma dans votre ville.",
+    "description": "Retrouvez tous les films \u00e0 l'affiche, les avant-premi\u00e8res, les sorties de la semaine et les horaires de cin\u00e9ma dans votre ville.",
     "llmsTxtUrl": "https://timepilot.co/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=timepilot.co&sz=128",
@@ -11468,9 +11468,9 @@
     "publishedAt": "2025-08-26"
   },
   {
-    "name": "tiskárna REPRESS.cz",
+    "name": "tisk\u00e1rna REPRESS.cz",
     "domain": "https://www.repress.cz/",
-    "description": "tiskárna REPRESS\\.cz: Reklama \\| Tiskárna \\| Knihařství • tiskárna REPRESS\\.cz",
+    "description": "tisk\u00e1rna REPRESS\\.cz: Reklama \\| Tisk\u00e1rna \\| Kniha\u0159stv\u00ed \u2022 tisk\u00e1rna REPRESS\\.cz",
     "llmsTxtUrl": "https://www.repress.cz/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.repress.cz&sz=128",
@@ -11498,7 +11498,7 @@
   {
     "name": "Tom Reinert",
     "domain": "https://tomreinert.de/",
-    "description": "Freelance UX Design in Köln – 15+ Jahre Erfahrung in UX/UI Design, Entwicklung und AI-Strategie. Verfügbar für Projekte in Köln & remote. Kostenloses Beratungsgespräch.",
+    "description": "Freelance UX Design in K\u00f6ln \u2013 15+ Jahre Erfahrung in UX/UI Design, Entwicklung und AI-Strategie. Verf\u00fcgbar f\u00fcr Projekte in K\u00f6ln & remote. Kostenloses Beratungsgespr\u00e4ch.",
     "llmsTxtUrl": "https://tomreinert.de/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=tomreinert.de&sz=128",
@@ -11536,7 +11536,7 @@
   {
     "name": "Totogi",
     "domain": "https://totogi.com/",
-    "description": "Totogi gives AI one unified understanding of your entire BSS, OSS and network stack – so it can reason, decide, and act across your telco. Learn more.",
+    "description": "Totogi gives AI one unified understanding of your entire BSS, OSS and network stack \u2013 so it can reason, decide, and act across your telco. Learn more.",
     "llmsTxtUrl": "https://totogi.com/llms.txt",
     "llmsFullTxtUrl": "https://totogi.com/llms-full.txt",
     "category": "ai-ml",
@@ -11592,7 +11592,7 @@
   {
     "name": "Transloadit",
     "domain": "https://transloadit.com",
-    "description": "Transloadit is the worldâs most advanced file uploading and processing service aimed at developers. Our API is an all-in-one tool for your users'' files.",
+    "description": "Transloadit is the world\u00e2\u0080\u0099s most advanced file uploading and processing service aimed at developers. Our API is an all-in-one tool for your users'' files.",
     "llmsTxtUrl": "https://transloadit.com/llms.txt",
     "llmsFullTxtUrl": "https://transloadit.com/llms-full.txt",
     "category": "developer-tools",
@@ -11704,7 +11704,7 @@
   {
     "name": "TuriVerde",
     "domain": "https://turiverde.com.br/",
-    "description": "Plataforma global de aluguel sem taxas. Conecte proprietários e viajantes diretamente.",
+    "description": "Plataforma global de aluguel sem taxas. Conecte propriet\u00e1rios e viajantes diretamente.",
     "llmsTxtUrl": "https://turiverde.com.br/llms.txt",
     "llmsFullTxtUrl": "https://turiverde.com.br/llms-full.txt",
     "category": "ai-ml",
@@ -11733,7 +11733,7 @@
   {
     "name": "TwoShoes",
     "domain": "https://www.twoshoes.be",
-    "description": "Discover an extensive collection of women''s shoes. Free delivery in Belgium. Brands: Geox, Tamaris, Tango, Skechers, Nø-name, Nathan-Baume.",
+    "description": "Discover an extensive collection of women''s shoes. Free delivery in Belgium. Brands: Geox, Tamaris, Tango, Skechers, N\u00f8-name, Nathan-Baume.",
     "llmsTxtUrl": "https://www.twoshoes.be/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=www.twoshoes.be&sz=128",
@@ -11758,6 +11758,15 @@
     "publishedAt": "2026-05-31"
   },
   {
+    "name": "T\u00e9l\u00e9assistance S\u00e9nior",
+    "domain": "https://www.tele-assistance-senior.fr",
+    "description": "T\u00e9l\u00e9assistance pour 24,90 \u20ac / mois. N\u00b0 1 en France avec plus de 250 000 abonn\u00e9s. Installation par nos techniciens \u00e0 domicile en moins de 7 jours.",
+    "llmsTxtUrl": "https://www.tele-assistance-senior.fr/llms.txt",
+    "category": "developer-tools",
+    "favicon": "https://www.google.com/s2/favicons?domain=www.tele-assistance-senior.fr&sz=128",
+    "publishedAt": "2025-08-26"
+  },
+  {
     "name": "U.S. Language Services",
     "domain": "https://www.uslanguageservices.com/",
     "description": "Get your documents translated for $39.00 per page or $0.12 per word. 35 Languages Supported. Available 24 hours a day, 7 days a week.",
@@ -11769,7 +11778,7 @@
   {
     "name": "UFC Velvet",
     "domain": "https://ufcvelvet.com/",
-    "description": "UFC Velvet offers delicious plant-based milk made from almonds and coconuts—creamy, dairy-free, and perfect for your healthy lifestyle.",
+    "description": "UFC Velvet offers delicious plant-based milk made from almonds and coconuts\u2014creamy, dairy-free, and perfect for your healthy lifestyle.",
     "llmsTxtUrl": "https://ufcvelvet.com/llms.txt",
     "llmsFullTxtUrl": "https://ufcvelvet.com/llms-full.txt",
     "category": "ai-ml",
@@ -11816,7 +11825,7 @@
   {
     "name": "Uni",
     "domain": "https://uni-system.com.pl",
-    "description": "Szukasz profesjonalnego montażu alarmów lub monitoringu? Uni-System oferuje nowoczesne systemy zabezpieczeń i smart home na całym Śląsku. Sprawdź wycenę!.",
+    "description": "Szukasz profesjonalnego monta\u017cu alarm\u00f3w lub monitoringu? Uni-System oferuje nowoczesne systemy zabezpiecze\u0144 i smart home na ca\u0142ym \u015al\u0105sku. Sprawd\u017a wycen\u0119!.",
     "llmsTxtUrl": "https://uni-system.com.pl/llms.txt",
     "llmsFullTxtUrl": "https://uni-system.com.pl/llms-full.txt",
     "category": "security-identity",
@@ -12001,15 +12010,6 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Văn hay trong hiện tại, chữ tốt ở tương lai",
-    "domain": "https://nhavan.vn/",
-    "description": "Nhà văn là chuyên trang nghiên cứu, phát triển văn hóa đọc, có sứ mệnh duy trì, nâng cao văn hóa đọc, cải thiện năng lực cảm thụ văn chương cho người Việt.",
-    "llmsTxtUrl": "https://nhavan.vn/llms.txt",
-    "category": "ai-ml",
-    "favicon": "https://www.google.com/s2/favicons?domain=nhavan.vn&sz=128",
-    "publishedAt": "2026-05-31"
-  },
-  {
     "name": "Vapi",
     "domain": "https://vapi.ai",
     "description": "Vapi is the platform to build, test and deploy voice agents in minutes rather than months.",
@@ -12041,7 +12041,7 @@
   {
     "name": "Vatsal Shah",
     "domain": "https://vatsalshah.in/",
-    "description": "We help companies replace legacy software with AI agents that actually ship — voice systems, workflow automation, and internal tools built for both humans and AI.",
+    "description": "We help companies replace legacy software with AI agents that actually ship \u2014 voice systems, workflow automation, and internal tools built for both humans and AI.",
     "llmsTxtUrl": "https://vatsalshah.in/llms.txt",
     "llmsFullTxtUrl": "https://vatsalshah.in/llms-full.txt",
     "category": "ai-ml",
@@ -12308,7 +12308,7 @@
   {
     "name": "Voyager Shuffle",
     "domain": "https://games.stardreamcruises.com/",
-    "description": "Play fun and interactive web games from Star Dream Cruises—designed to entertain guests and enhance the cruise experience online.",
+    "description": "Play fun and interactive web games from Star Dream Cruises\u2014designed to entertain guests and enhance the cruise experience online.",
     "llmsTxtUrl": "https://games.stardreamcruises.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=games.stardreamcruises.com&sz=128",
@@ -12362,7 +12362,16 @@
     "publishedAt": "2025-08-26"
   },
   {
-    "name": "Waitlist Software — Build a Pre-Launch Waitlist",
+    "name": "V\u0103n hay trong hi\u1ec7n t\u1ea1i, ch\u1eef t\u1ed1t \u1edf t\u01b0\u01a1ng lai",
+    "domain": "https://nhavan.vn/",
+    "description": "Nh\u00e0 v\u0103n l\u00e0 chuy\u00ean trang nghi\u00ean c\u1ee9u, ph\u00e1t tri\u1ec3n v\u0103n h\u00f3a \u0111\u1ecdc, c\u00f3 s\u1ee9 m\u1ec7nh duy tr\u00ec, n\u00e2ng cao v\u0103n h\u00f3a \u0111\u1ecdc, c\u1ea3i thi\u1ec7n n\u0103ng l\u1ef1c c\u1ea3m th\u1ee5 v\u0103n ch\u01b0\u01a1ng cho ng\u01b0\u1eddi Vi\u1ec7t.",
+    "llmsTxtUrl": "https://nhavan.vn/llms.txt",
+    "category": "ai-ml",
+    "favicon": "https://www.google.com/s2/favicons?domain=nhavan.vn&sz=128",
+    "publishedAt": "2026-05-31"
+  },
+  {
+    "name": "Waitlist Software \u2014 Build a Pre-Launch Waitlist",
     "domain": "https://waitlister.me/",
     "description": "> No-code waitlist platform for entrepreneurs and businesses to capture pre-launch interest, validate demand, and run viral referral campaigns.",
     "llmsTxtUrl": "https://waitlister.me/llms.txt",
@@ -12384,7 +12393,7 @@
   {
     "name": "Wall Street Turkish",
     "domain": "https://wallstreetturkish.com/",
-    "description": "Wall Street Turkish, Türkiye'den ve dünyadan finans haberleri, ekonomi trendlerini sunar.",
+    "description": "Wall Street Turkish, T\u00fcrkiye'den ve d\u00fcnyadan finans haberleri, ekonomi trendlerini sunar.",
     "llmsTxtUrl": "https://wallstreetturkish.com/llms.txt",
     "llmsFullTxtUrl": "https://wallstreetturkish.com/llms-full.txt",
     "category": "ai-ml",
@@ -12469,7 +12478,7 @@
   {
     "name": "WebBox",
     "domain": "https://www.webbox.digital/",
-    "description": "We’re a digital agency creating websites & marketing campaigns for health, leisure & tourism and sports organisations. Turning ambition into growth.",
+    "description": "We\u2019re a digital agency creating websites & marketing campaigns for health, leisure & tourism and sports organisations. Turning ambition into growth.",
     "llmsTxtUrl": "https://www.webbox.digital/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=www.webbox.digital&sz=128",
@@ -12478,7 +12487,7 @@
   {
     "name": "Weberei Pahl",
     "domain": "https://www.weberei-pahl.de/",
-    "description": "Handtücher, Bettwäsche und Heimtextilien in Hotelqualität direkt vom Hersteller. Seit 1933 für Bad, Bett, Küche und Kinderwelt.",
+    "description": "Handt\u00fccher, Bettw\u00e4sche und Heimtextilien in Hotelqualit\u00e4t direkt vom Hersteller. Seit 1933 f\u00fcr Bad, Bett, K\u00fcche und Kinderwelt.",
     "llmsTxtUrl": "https://www.weberei-pahl.de/llms.txt",
     "llmsFullTxtUrl": "https://www.weberei-pahl.de/llms-full.txt",
     "category": "ai-ml",
@@ -12488,7 +12497,7 @@
   {
     "name": "Webflow API and Documentation",
     "domain": "https://developers.webflow.com/",
-    "description": "Learn how to build an app, explore Webflow’s API and documentation for your use case here!",
+    "description": "Learn how to build an app, explore Webflow\u2019s API and documentation for your use case here!",
     "llmsTxtUrl": "https://developers.webflow.com/llms.txt",
     "llmsFullTxtUrl": "https://developers.webflow.com/llms-full.txt",
     "category": "developer-tools",
@@ -12508,7 +12517,7 @@
   {
     "name": "Webnif",
     "domain": "https://www.webnif.com/",
-    "description": "Web Tasarım ve SEO hizmetleri ile şirketinizi dijitalde bir adım öne taşıyoruz. Webnif, işletmenizin ihtiyaçlarına uygun modern web tasarım hizmetleri",
+    "description": "Web Tasar\u0131m ve SEO hizmetleri ile \u015firketinizi dijitalde bir ad\u0131m \u00f6ne ta\u015f\u0131yoruz. Webnif, i\u015fletmenizin ihtiya\u00e7lar\u0131na uygun modern web tasar\u0131m hizmetleri",
     "llmsTxtUrl": "https://www.webnif.com/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=www.webnif.com&sz=128",
@@ -12517,7 +12526,7 @@
   {
     "name": "Webnode Website Builder | Build Your Free Website with AI",
     "domain": "https://www.webnode.com/",
-    "description": "Create your website instantly with Webnode’s AI Website Builder. Generate text, images, and layout in seconds, or use website templates. Start for free.",
+    "description": "Create your website instantly with Webnode\u2019s AI Website Builder. Generate text, images, and layout in seconds, or use website templates. Start for free.",
     "llmsTxtUrl": "https://www.webnode.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.webnode.com&sz=128",
@@ -12608,7 +12617,7 @@
   {
     "name": "Wellness Concept",
     "domain": "https://wellness-concept.be/",
-    "description": "Magasin jacuzzi Liège Wellness Concept. Installateur de spa et spa de nage jacuzzi, piscine, piscine container, sauna, et sauna infrarouge en Belgique (Liège).",
+    "description": "Magasin jacuzzi Li\u00e8ge Wellness Concept. Installateur de spa et spa de nage jacuzzi, piscine, piscine container, sauna, et sauna infrarouge en Belgique (Li\u00e8ge).",
     "llmsTxtUrl": "https://wellness-concept.be/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=wellness-concept.be&sz=128",
@@ -12644,9 +12653,9 @@
     "publishedAt": "2025-06-18"
   },
   {
-    "name": "wh4 Design GmbH München",
+    "name": "wh4 Design GmbH M\u00fcnchen",
     "domain": "https://www.wh4.de/",
-    "description": "Werbeagentur in München für Corporate Design, Branding und Webdesign. ✓ Corporate Design ✓ Web Design ✓ Print Design ✓ Online-Marketing",
+    "description": "Werbeagentur in M\u00fcnchen f\u00fcr Corporate Design, Branding und Webdesign. \u2713 Corporate Design \u2713 Web Design \u2713 Print Design \u2713 Online-Marketing",
     "llmsTxtUrl": "https://wh4.de/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.wh4.de&sz=128",
@@ -12710,7 +12719,7 @@
   {
     "name": "Wix Interact",
     "domain": "https://wix.github.io/interact/",
-    "description": "Declarative, configuration-driven interaction library — web-native, AI-ready, and framework-agnostic.",
+    "description": "Declarative, configuration-driven interaction library \u2014 web-native, AI-ready, and framework-agnostic.",
     "llmsTxtUrl": "https://wix.github.io/interact/llms.txt",
     "llmsFullTxtUrl": "https://wix.github.io/interact/llms-full.txt",
     "category": "developer-tools",
@@ -12756,7 +12765,7 @@
   {
     "name": "WoowUp",
     "domain": "https://www.woowup.com/",
-    "description": "WoowUp permite a las empresas retail a explotar al máximo los datos de sus clientes, poniéndolos al servicio del negocio.",
+    "description": "WoowUp permite a las empresas retail a explotar al m\u00e1ximo los datos de sus clientes, poni\u00e9ndolos al servicio del negocio.",
     "llmsTxtUrl": "https://woowup-docs.gitbook.io/woowup-developer-docs/llms.txt",
     "category": "developer-tools",
     "favicon": "https://www.google.com/s2/favicons?domain=www.woowup.com&sz=128",
@@ -12813,7 +12822,7 @@
   {
     "name": "Writer",
     "domain": "https://writer.com/",
-    "description": "Build generative AI into any business process with Writer’s secure enterprise platform. Trusted by world-class enterprises.",
+    "description": "Build generative AI into any business process with Writer\u2019s secure enterprise platform. Trusted by world-class enterprises.",
     "llmsTxtUrl": "https://dev.writer.com/llms.txt",
     "llmsFullTxtUrl": "https://dev.writer.com/llms-full.txt",
     "category": "ai-ml",
@@ -12890,7 +12899,7 @@
   {
     "name": "Xootle | All-in",
     "domain": "https://www.xootle.com/en",
-    "description": "All-in-one software for hospitality & retail: POS, PMS, accounting, channel manager & booking engine. From €9.95/month. Unlimited devices, no hidden fees.",
+    "description": "All-in-one software for hospitality & retail: POS, PMS, accounting, channel manager & booking engine. From \u20ac9.95/month. Unlimited devices, no hidden fees.",
     "llmsTxtUrl": "https://www.xootle.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.xootle.com/en&sz=128",
@@ -12899,7 +12908,7 @@
   {
     "name": "xPrice",
     "domain": "https://xprice.ro/",
-    "description": "Extensie gratuită care îți arată istoricul prețului pe 2 ani în urmă, alternative mai ieftine pe alte magazine și coduri de reducere active, direct pe pagina produsului. Pentru eMAG, Altex, Flanco, Fashion Days, Dedeman, evoMAG și peste 1472 de magazine.",
+    "description": "Extensie gratuit\u0103 care \u00ee\u021bi arat\u0103 istoricul pre\u021bului pe 2 ani \u00een urm\u0103, alternative mai ieftine pe alte magazine \u0219i coduri de reducere active, direct pe pagina produsului. Pentru eMAG, Altex, Flanco, Fashion Days, Dedeman, evoMAG \u0219i peste 1472 de magazine.",
     "llmsTxtUrl": "https://xprice.ro/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=xprice.ro&sz=128",
@@ -12954,7 +12963,7 @@
   {
     "name": "YubiGeek",
     "domain": "https://www.yubigeek.com/",
-    "description": "Découvre Yubigeek, le média dédié au gaming, au streaming, aux setups gaming, à la création de contenu et à toute la culture geek moderne.",
+    "description": "D\u00e9couvre Yubigeek, le m\u00e9dia d\u00e9di\u00e9 au gaming, au streaming, aux setups gaming, \u00e0 la cr\u00e9ation de contenu et \u00e0 toute la culture geek moderne.",
     "llmsTxtUrl": "https://www.yubigeek.com/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=www.yubigeek.com&sz=128",
@@ -12971,7 +12980,7 @@
     "publishedAt": "2025-07-14"
   },
   {
-    "name": "Zap.ts ⚡️",
+    "name": "Zap.ts \u26a1\ufe0f",
     "domain": "https://zap-ts.alexandretrotel.org",
     "description": "The boilerplate to build applications as fast as a zap.",
     "llmsTxtUrl": "https://zap-ts.alexandretrotel.org/llms.txt",
@@ -13073,9 +13082,9 @@
     "publishedAt": "2025-08-26"
   },
   {
-    "name": "Δωρεάν Γνωστικά Παιχνίδια Λογικής & Μνήμης για Ενδυνάμωση του Νου",
+    "name": "\u0394\u03c9\u03c1\u03b5\u03ac\u03bd \u0393\u03bd\u03c9\u03c3\u03c4\u03b9\u03ba\u03ac \u03a0\u03b1\u03b9\u03c7\u03bd\u03af\u03b4\u03b9\u03b1 \u039b\u03bf\u03b3\u03b9\u03ba\u03ae\u03c2 & \u039c\u03bd\u03ae\u03bc\u03b7\u03c2 \u03b3\u03b9\u03b1 \u0395\u03bd\u03b4\u03c5\u03bd\u03ac\u03bc\u03c9\u03c3\u03b7 \u03c4\u03bf\u03c5 \u039d\u03bf\u03c5",
     "domain": "https://kids.braining.gr/",
-    "description": "Παίξτε 45+ δωρεάν γνωστικά παιχνίδια online για την ενδυνάμωση της μνήμης, της λογικής και της προσοχής. Επιστημονικά σχεδιασμένα παιχνίδια για παιδιά και ενήλικες.",
+    "description": "\u03a0\u03b1\u03af\u03be\u03c4\u03b5 45+ \u03b4\u03c9\u03c1\u03b5\u03ac\u03bd \u03b3\u03bd\u03c9\u03c3\u03c4\u03b9\u03ba\u03ac \u03c0\u03b1\u03b9\u03c7\u03bd\u03af\u03b4\u03b9\u03b1 online \u03b3\u03b9\u03b1 \u03c4\u03b7\u03bd \u03b5\u03bd\u03b4\u03c5\u03bd\u03ac\u03bc\u03c9\u03c3\u03b7 \u03c4\u03b7\u03c2 \u03bc\u03bd\u03ae\u03bc\u03b7\u03c2, \u03c4\u03b7\u03c2 \u03bb\u03bf\u03b3\u03b9\u03ba\u03ae\u03c2 \u03ba\u03b1\u03b9 \u03c4\u03b7\u03c2 \u03c0\u03c1\u03bf\u03c3\u03bf\u03c7\u03ae\u03c2. \u0395\u03c0\u03b9\u03c3\u03c4\u03b7\u03bc\u03bf\u03bd\u03b9\u03ba\u03ac \u03c3\u03c7\u03b5\u03b4\u03b9\u03b1\u03c3\u03bc\u03ad\u03bd\u03b1 \u03c0\u03b1\u03b9\u03c7\u03bd\u03af\u03b4\u03b9\u03b1 \u03b3\u03b9\u03b1 \u03c0\u03b1\u03b9\u03b4\u03b9\u03ac \u03ba\u03b1\u03b9 \u03b5\u03bd\u03ae\u03bb\u03b9\u03ba\u03b5\u03c2.",
     "llmsTxtUrl": "https://kids.braining.gr/llms.txt",
     "llmsFullTxtUrl": "https://kids.braining.gr/llms-full.txt",
     "category": "ai-ml",
@@ -13083,9 +13092,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "Похоронное бюро Osiris",
+    "name": "\u041f\u043e\u0445\u043e\u0440\u043e\u043d\u043d\u043e\u0435 \u0431\u044e\u0440\u043e Osiris",
     "domain": "https://osiris.memorial/",
-    "description": "Ритуальные услуги в Киеве круглосуточно ⚱️ Выгодные цены на организацию погребения от ритуальной службы Osiris ✝️ Заказать ритуальные услуги по погребению ☎️️ (093) 203 75 27",
+    "description": "\u0420\u0438\u0442\u0443\u0430\u043b\u044c\u043d\u044b\u0435 \u0443\u0441\u043b\u0443\u0433\u0438 \u0432 \u041a\u0438\u0435\u0432\u0435 \u043a\u0440\u0443\u0433\u043b\u043e\u0441\u0443\u0442\u043e\u0447\u043d\u043e \u26b1\ufe0f \u0412\u044b\u0433\u043e\u0434\u043d\u044b\u0435 \u0446\u0435\u043d\u044b \u043d\u0430 \u043e\u0440\u0433\u0430\u043d\u0438\u0437\u0430\u0446\u0438\u044e \u043f\u043e\u0433\u0440\u0435\u0431\u0435\u043d\u0438\u044f \u043e\u0442 \u0440\u0438\u0442\u0443\u0430\u043b\u044c\u043d\u043e\u0439 \u0441\u043b\u0443\u0436\u0431\u044b Osiris \u271d\ufe0f \u0417\u0430\u043a\u0430\u0437\u0430\u0442\u044c \u0440\u0438\u0442\u0443\u0430\u043b\u044c\u043d\u044b\u0435 \u0443\u0441\u043b\u0443\u0433\u0438 \u043f\u043e \u043f\u043e\u0433\u0440\u0435\u0431\u0435\u043d\u0438\u044e \u260e\ufe0f\ufe0f (093) 203 75 27",
     "llmsTxtUrl": "https://osiris.memorial/llms.txt",
     "llmsFullTxtUrl": "https://osiris.memorial/llms-full.txt",
     "category": "ai-ml",
@@ -13093,27 +13102,27 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "ابن سيرين لتفسير الأحلام",
+    "name": "\u0627\u0628\u0646 \u0633\u064a\u0631\u064a\u0646 \u0644\u062a\u0641\u0633\u064a\u0631 \u0627\u0644\u0623\u062d\u0644\u0627\u0645",
     "domain": "https://www.ibnsireen.com/ar",
-    "description": "احصل على تفسير فوري للأحلام وفق منهج ابن سيرين، مع دعم بالعربية والإنجليزية، وأسئلة متابعة، ودفتر أحلام خاص.",
+    "description": "\u0627\u062d\u0635\u0644 \u0639\u0644\u0649 \u062a\u0641\u0633\u064a\u0631 \u0641\u0648\u0631\u064a \u0644\u0644\u0623\u062d\u0644\u0627\u0645 \u0648\u0641\u0642 \u0645\u0646\u0647\u062c \u0627\u0628\u0646 \u0633\u064a\u0631\u064a\u0646\u060c \u0645\u0639 \u062f\u0639\u0645 \u0628\u0627\u0644\u0639\u0631\u0628\u064a\u0629 \u0648\u0627\u0644\u0625\u0646\u062c\u0644\u064a\u0632\u064a\u0629\u060c \u0648\u0623\u0633\u0626\u0644\u0629 \u0645\u062a\u0627\u0628\u0639\u0629\u060c \u0648\u062f\u0641\u062a\u0631 \u0623\u062d\u0644\u0627\u0645 \u062e\u0627\u0635.",
     "llmsTxtUrl": "https://www.ibnsireen.com/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.ibnsireen.com/ar&sz=128",
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "人を増やさず売上を増やす｜エクスプローラー株式会社",
+    "name": "\u4eba\u3092\u5897\u3084\u3055\u305a\u58f2\u4e0a\u3092\u5897\u3084\u3059\uff5c\u30a8\u30af\u30b9\u30d7\u30ed\u30fc\u30e9\u30fc\u682a\u5f0f\u4f1a\u793e",
     "domain": "https://ex-plorer.co.jp/",
-    "description": "板橋区と豊島区にあるBtoB中小企業専門のDX支援会社。業務自動化、Google Workspace導入、Web集客、ホームページ制作の4つのサービスで、人を増やさずに売上アップを実現。技術設定はすべて代行、定着まで伴走します。",
+    "description": "\u677f\u6a4b\u533a\u3068\u8c4a\u5cf6\u533a\u306b\u3042\u308bBtoB\u4e2d\u5c0f\u4f01\u696d\u5c02\u9580\u306eDX\u652f\u63f4\u4f1a\u793e\u3002\u696d\u52d9\u81ea\u52d5\u5316\u3001Google Workspace\u5c0e\u5165\u3001Web\u96c6\u5ba2\u3001\u30db\u30fc\u30e0\u30da\u30fc\u30b8\u5236\u4f5c\u306e4\u3064\u306e\u30b5\u30fc\u30d3\u30b9\u3067\u3001\u4eba\u3092\u5897\u3084\u3055\u305a\u306b\u58f2\u4e0a\u30a2\u30c3\u30d7\u3092\u5b9f\u73fe\u3002\u6280\u8853\u8a2d\u5b9a\u306f\u3059\u3079\u3066\u4ee3\u884c\u3001\u5b9a\u7740\u307e\u3067\u4f34\u8d70\u3057\u307e\u3059\u3002",
     "llmsTxtUrl": "https://ex-plorer.co.jp/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=ex-plorer.co.jp&sz=128",
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "北京尚拓云测科技有限公司官网",
+    "name": "\u5317\u4eac\u5c1a\u62d3\u4e91\u6d4b\u79d1\u6280\u6709\u9650\u516c\u53f8\u5b98\u7f51",
     "domain": "https://www.bjstos.com/",
-    "description": "北京尚云软件测评机构专注第三方CMA/CNAS软件测试报告服务15年，是权威的软件验收测试报告服务商。作为第三方软件测评机构，为政企、高校提供国家认可的第三方CMA/CNAS软件测试报告，测试报告验收通过率达99.99%。业务涵盖第三方软件验收测试、软件性能测试、安全漏洞测试、代码审计、等保测评等测试外包服务，助力客户完成招投标、高新申报和课题验收。",
+    "description": "\u5317\u4eac\u5c1a\u4e91\u8f6f\u4ef6\u6d4b\u8bc4\u673a\u6784\u4e13\u6ce8\u7b2c\u4e09\u65b9CMA/CNAS\u8f6f\u4ef6\u6d4b\u8bd5\u62a5\u544a\u670d\u52a115\u5e74\uff0c\u662f\u6743\u5a01\u7684\u8f6f\u4ef6\u9a8c\u6536\u6d4b\u8bd5\u62a5\u544a\u670d\u52a1\u5546\u3002\u4f5c\u4e3a\u7b2c\u4e09\u65b9\u8f6f\u4ef6\u6d4b\u8bc4\u673a\u6784\uff0c\u4e3a\u653f\u4f01\u3001\u9ad8\u6821\u63d0\u4f9b\u56fd\u5bb6\u8ba4\u53ef\u7684\u7b2c\u4e09\u65b9CMA/CNAS\u8f6f\u4ef6\u6d4b\u8bd5\u62a5\u544a\uff0c\u6d4b\u8bd5\u62a5\u544a\u9a8c\u6536\u901a\u8fc7\u7387\u8fbe99.99%\u3002\u4e1a\u52a1\u6db5\u76d6\u7b2c\u4e09\u65b9\u8f6f\u4ef6\u9a8c\u6536\u6d4b\u8bd5\u3001\u8f6f\u4ef6\u6027\u80fd\u6d4b\u8bd5\u3001\u5b89\u5168\u6f0f\u6d1e\u6d4b\u8bd5\u3001\u4ee3\u7801\u5ba1\u8ba1\u3001\u7b49\u4fdd\u6d4b\u8bc4\u7b49\u6d4b\u8bd5\u5916\u5305\u670d\u52a1\uff0c\u52a9\u529b\u5ba2\u6237\u5b8c\u6210\u62db\u6295\u6807\u3001\u9ad8\u65b0\u7533\u62a5\u548c\u8bfe\u9898\u9a8c\u6536\u3002",
     "llmsTxtUrl": "https://www.bjstos.com/llms.txt",
     "llmsFullTxtUrl": "https://www.bjstos.com/llms-full.txt",
     "category": "developer-tools",
@@ -13121,9 +13130,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "厦门杰赢网络科技有限公司",
+    "name": "\u53a6\u95e8\u6770\u8d62\u7f51\u7edc\u79d1\u6280\u6709\u9650\u516c\u53f8",
     "domain": "https://www.jeawin.com/",
-    "description": "Google SEO专家,厦门杰赢网络科技有限公司提供高性价比外贸独立站建设,谷歌SEO, AI GEO优化等外贸网络营销推广服务.数十家外贸企业放心省心合作了十多年!",
+    "description": "Google SEO\u4e13\u5bb6,\u53a6\u95e8\u6770\u8d62\u7f51\u7edc\u79d1\u6280\u6709\u9650\u516c\u53f8\u63d0\u4f9b\u9ad8\u6027\u4ef7\u6bd4\u5916\u8d38\u72ec\u7acb\u7ad9\u5efa\u8bbe,\u8c37\u6b4cSEO, AI GEO\u4f18\u5316\u7b49\u5916\u8d38\u7f51\u7edc\u8425\u9500\u63a8\u5e7f\u670d\u52a1.\u6570\u5341\u5bb6\u5916\u8d38\u4f01\u4e1a\u653e\u5fc3\u7701\u5fc3\u5408\u4f5c\u4e86\u5341\u591a\u5e74!",
     "llmsTxtUrl": "https://www.jeawin.com/llms.txt",
     "llmsFullTxtUrl": "https://www.jeawin.com/llms-full.txt",
     "category": "ai-ml",
@@ -13131,9 +13140,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "时者八字",
+    "name": "\u65f6\u8005\u516b\u5b57",
     "domain": "https://bazi.time.actor/zh",
-    "description": "时者八字是一款结合人工智能与传统命理的现代化八字分析工具，提供专业的八字命盘分析、八字合婚、姻缘解析、事业合作等智能命理服务。",
+    "description": "\u65f6\u8005\u516b\u5b57\u662f\u4e00\u6b3e\u7ed3\u5408\u4eba\u5de5\u667a\u80fd\u4e0e\u4f20\u7edf\u547d\u7406\u7684\u73b0\u4ee3\u5316\u516b\u5b57\u5206\u6790\u5de5\u5177\uff0c\u63d0\u4f9b\u4e13\u4e1a\u7684\u516b\u5b57\u547d\u76d8\u5206\u6790\u3001\u516b\u5b57\u5408\u5a5a\u3001\u59fb\u7f18\u89e3\u6790\u3001\u4e8b\u4e1a\u5408\u4f5c\u7b49\u667a\u80fd\u547d\u7406\u670d\u52a1\u3002",
     "llmsTxtUrl": "https://bazi.time.actor/llms.txt",
     "llmsFullTxtUrl": "https://bazi.time.actor/llms-full.txt",
     "category": "data-analytics",
@@ -13141,18 +13150,18 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "时者问卦",
+    "name": "\u65f6\u8005\u95ee\u5366",
     "domain": "https://gua.time.actor/",
-    "description": "集合大衍筮法和梅花易数的易经问卦系统，融合千年易经智慧与现代AI技术，提供决策深度洞察。",
+    "description": "\u96c6\u5408\u5927\u884d\u7b6e\u6cd5\u548c\u6885\u82b1\u6613\u6570\u7684\u6613\u7ecf\u95ee\u5366\u7cfb\u7edf\uff0c\u878d\u5408\u5343\u5e74\u6613\u7ecf\u667a\u6167\u4e0e\u73b0\u4ee3AI\u6280\u672f\uff0c\u63d0\u4f9b\u51b3\u7b56\u6df1\u5ea6\u6d1e\u5bdf\u3002",
     "llmsTxtUrl": "https://gua.time.actor/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=gua.time.actor&sz=128",
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "腾讯云开发",
+    "name": "\u817e\u8baf\u4e91\u5f00\u53d1",
     "domain": "https://cloudbase.net/",
-    "description": "腾讯云开发平台提供无服务器计算和云端一体化开发解决方案，涵盖云函数服务、数据库管理、存储集成及低代码开发。支持快速部署、弹性伸缩和安全可靠的特性，适用于Web应用、移动后端和物联网等场景。官网包含详细的技术文档、社区支持和成功案例，助力开发者高效构建和管理现代应用程序。",
+    "description": "\u817e\u8baf\u4e91\u5f00\u53d1\u5e73\u53f0\u63d0\u4f9b\u65e0\u670d\u52a1\u5668\u8ba1\u7b97\u548c\u4e91\u7aef\u4e00\u4f53\u5316\u5f00\u53d1\u89e3\u51b3\u65b9\u6848\uff0c\u6db5\u76d6\u4e91\u51fd\u6570\u670d\u52a1\u3001\u6570\u636e\u5e93\u7ba1\u7406\u3001\u5b58\u50a8\u96c6\u6210\u53ca\u4f4e\u4ee3\u7801\u5f00\u53d1\u3002\u652f\u6301\u5feb\u901f\u90e8\u7f72\u3001\u5f39\u6027\u4f38\u7f29\u548c\u5b89\u5168\u53ef\u9760\u7684\u7279\u6027\uff0c\u9002\u7528\u4e8eWeb\u5e94\u7528\u3001\u79fb\u52a8\u540e\u7aef\u548c\u7269\u8054\u7f51\u7b49\u573a\u666f\u3002\u5b98\u7f51\u5305\u542b\u8be6\u7ec6\u7684\u6280\u672f\u6587\u6863\u3001\u793e\u533a\u652f\u6301\u548c\u6210\u529f\u6848\u4f8b\uff0c\u52a9\u529b\u5f00\u53d1\u8005\u9ad8\u6548\u6784\u5efa\u548c\u7ba1\u7406\u73b0\u4ee3\u5e94\u7528\u7a0b\u5e8f\u3002",
     "llmsTxtUrl": "https://docs.cloudbase.net/llms.txt",
     "llmsFullTxtUrl": "https://docs.cloudbase.net/llms-full.txt",
     "category": "developer-tools",
@@ -13160,18 +13169,18 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "首页",
+    "name": "\u9996\u9875",
     "domain": "https://www.bikablo.store/",
-    "description": "通过 bikablo 的专业图形记录和视觉引导服务，发现视觉思维的力量。将会议和研讨会转化为充满活力的视觉体验。今天就探索我们的技术吧！",
+    "description": "\u901a\u8fc7 bikablo \u7684\u4e13\u4e1a\u56fe\u5f62\u8bb0\u5f55\u548c\u89c6\u89c9\u5f15\u5bfc\u670d\u52a1\uff0c\u53d1\u73b0\u89c6\u89c9\u601d\u7ef4\u7684\u529b\u91cf\u3002\u5c06\u4f1a\u8bae\u548c\u7814\u8ba8\u4f1a\u8f6c\u5316\u4e3a\u5145\u6ee1\u6d3b\u529b\u7684\u89c6\u89c9\u4f53\u9a8c\u3002\u4eca\u5929\u5c31\u63a2\u7d22\u6211\u4eec\u7684\u6280\u672f\u5427\uff01",
     "llmsTxtUrl": "https://www.bikablo.store/llms.txt",
     "category": "data-analytics",
     "favicon": "https://www.google.com/s2/favicons?domain=www.bikablo.store&sz=128",
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "香港AI法律平台",
+    "name": "\u9999\u6e2fAI\u6cd5\u5f8b\u5e73\u53f0",
     "domain": "https://www.hklawyer.ai/",
-    "description": "香港專業AI法律助手，提供免費法律諮詢、工傷賠償、刑事辯護、民事訴訟、家庭法律等服務。即時解答法律問題，連接專業律師。",
+    "description": "\u9999\u6e2f\u5c08\u696dAI\u6cd5\u5f8b\u52a9\u624b\uff0c\u63d0\u4f9b\u514d\u8cbb\u6cd5\u5f8b\u8aee\u8a62\u3001\u5de5\u50b7\u8ce0\u511f\u3001\u5211\u4e8b\u8faf\u8b77\u3001\u6c11\u4e8b\u8a34\u8a1f\u3001\u5bb6\u5ead\u6cd5\u5f8b\u7b49\u670d\u52d9\u3002\u5373\u6642\u89e3\u7b54\u6cd5\u5f8b\u554f\u984c\uff0c\u9023\u63a5\u5c08\u696d\u5f8b\u5e2b\u3002",
     "llmsTxtUrl": "https://hklawyer.ai/llms.txt",
     "llmsFullTxtUrl": "https://hklawyer.ai/llms-full.txt",
     "category": "ai-ml",
@@ -13179,9 +13188,9 @@
     "publishedAt": "2026-05-31"
   },
   {
-    "name": "高效码农",
+    "name": "\u9ad8\u6548\u7801\u519c",
     "domain": "https://www.xugj520.cn/",
-    "description": "高效码农 | 撰写、分享国内外先进的IT技术 | 专注AI技术、Python开发、机器学习等前沿IT技术分享。提供深度技术解析、开源项目推荐、实战教程，助力程序员技术成长。",
+    "description": "\u9ad8\u6548\u7801\u519c | \u64b0\u5199\u3001\u5206\u4eab\u56fd\u5185\u5916\u5148\u8fdb\u7684IT\u6280\u672f | \u4e13\u6ce8AI\u6280\u672f\u3001Python\u5f00\u53d1\u3001\u673a\u5668\u5b66\u4e60\u7b49\u524d\u6cbfIT\u6280\u672f\u5206\u4eab\u3002\u63d0\u4f9b\u6df1\u5ea6\u6280\u672f\u89e3\u6790\u3001\u5f00\u6e90\u9879\u76ee\u63a8\u8350\u3001\u5b9e\u6218\u6559\u7a0b\uff0c\u52a9\u529b\u7a0b\u5e8f\u5458\u6280\u672f\u6210\u957f\u3002",
     "llmsTxtUrl": "https://www.xugj520.cn/llms.txt",
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.xugj520.cn&sz=128",

--- a/packages/content/data/websites/autonomy-labs-storefront-llms-txt.mdx
+++ b/packages/content/data/websites/autonomy-labs-storefront-llms-txt.mdx
@@ -1,0 +1,16 @@
+---
+name: 'Autonomy Labs Storefront'
+description: 'AI-agent-ready digital products with automatic email fulfillment: prompt packs, agent kits, games, and services. Sells to humans and AI agents via llms.txt + x402.'
+website: 'https://business2-lasse-tfa.vercel.app'
+llmsUrl: 'https://business2-lasse-tfa.vercel.app/llms.txt'
+llmsFullUrl: 'https://business2-lasse-tfa.vercel.app/llms-full.txt'
+category: 'e-commerce'
+publishedAt: '2026-08-06'
+---
+
+# Autonomy Labs Storefront
+
+AI-agent-ready digital products: 40 Reusable Prompts, AI Agent Starter Kit, Zombie Slasher Game,
+Custom Three.js Scene Rebuild, AI Website Audit Report and more — 28 products, Stripe Checkout
+with automatic webhook email fulfillment, discoverable via llms.txt, agents.txt, sitemap.xml and
+/.well-known/x402.


### PR DESCRIPTION
Adds the Autonomy Labs Storefront to the llms.txt hub directory. The site ships llms.txt, llms-full.txt, agents.txt, sitemap.xml, robots.txt and /.well-known/x402, with 28 buyable digital products and automatic webhook email fulfillment — a working example of an agent-discoverable storefront. Entry file: packages/content/data/websites/autonomy-labs-storefront-llms-txt.mdx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a website directory entry for Autonomy Labs Storefront.
  * Included storefront metadata, relevant URLs, publication date, and details about its AI-agent-ready digital products, checkout, fulfillment, and discovery endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->