### PR TITLE
Add Trent AI

### DIFF
--- a/packages/content/data/websites/trent-ai-llms-txt.mdx
+++ b/packages/content/data/websites/trent-ai-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Trent AI'
+description: 'Agentic AI security platform that continuously assesses AI agents, MCP servers, LLM and AI-native applications, and code shipped with AI coding tools, traces attack chains, and verifies proposed fixes landed.'
+website: 'https://trent.ai'
+llmsUrl: 'https://trent.ai/llms.txt'
+llmsFullUrl: ''
+category: 'security-identity'
+publishedAt: '2026-08-06'
+---
+
+# Trent AI
+
+Agentic AI security platform. Context-aware security guidance and adaptive threat detection for LLM and AI agent workflows.


### PR DESCRIPTION
Adds Trent AI to the directory.

- Site: https://trent.ai
- llms.txt: https://trent.ai/llms.txt (200, text/plain, ~25 KB)
- Category: security-identity

Note: the llmstxthub.com submission form returned "Verification unavailable" on two attempts over two days, so filing directly per CONTRIBUTING. The llms.txt URL serves 200 to all user agents. Only the new .mdx is added; data/websites.json untouched.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new website content entry for Trent AI, including metadata such as title, URLs, publication date, category, and platform description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->