### PR TITLE
feat(community): add AgentsKit llms.txt

### DIFF
--- a/packages/content/data/websites/agentskit-llms-txt.mdx
+++ b/packages/content/data/websites/agentskit-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'AgentsKit'
+description: 'Provider-independent JavaScript toolkit for agents, with composable packages for runtimes, tools, memory, RAG, observability, evaluation, sandboxing, and UI.'
+website: 'https://www.agentskit.io'
+llmsUrl: 'https://www.agentskit.io/llms.txt'
+llmsFullUrl: 'https://www.agentskit.io/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-06'
+---
+
+# AgentsKit
+
+AgentsKit is an open-source JavaScript toolkit built around small, explicit contracts. Its machine-readable documentation links the framework with the wider AgentsKit ecosystem, including Chat, Registry, Doc Bridge, Playbook, and Code Review.


### PR DESCRIPTION
## Summary

Add AgentsKit to the developer-tools directory using its public `llms.txt` and `llms-full.txt` endpoints.

The main index links the wider AgentsKit ecosystem, including Chat, Registry, Doc Bridge, Playbook, and Code Review, so this submission stays focused on one canonical entry.

## Validation

- `pnpm check:frontmatter`
- verified the website, `llms.txt`, and `llms-full.txt` return HTTP 200
- confirmed there is no existing AgentsKit entry or open submission

`pnpm check:websites` also detects five unrelated baseline errors on upstream `main`; none involves this entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the AgentsKit website to the directory with its metadata, documentation links, publication date, category, and introductory description.
  * Highlighted its JavaScript toolkit and related ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->