### PR TITLE
feat(community): add Bot Ledger to llms.txt hub

### DIFF
--- a/packages/content/data/websites/bot-ledger-llms-txt.mdx
+++ b/packages/content/data/websites/bot-ledger-llms-txt.mdx
@@ -1,0 +1,22 @@
+---
+name: 'Bot Ledger'
+description: 'Free, static directory of AI crawlers (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, and more) with a client-side generator for robots.txt and llms.txt policies. No signup required.'
+website: 'https://farrelldan.github.io/ai-bot-directory/'
+llmsUrl: 'https://farrelldan.github.io/ai-bot-directory/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-07'
+---
+
+# Bot Ledger
+
+Bot Ledger tracks which AI companies operate web crawlers, what each crawler is used for (training, live answering, or both), and lets site owners generate a robots.txt or llms.txt file reflecting their chosen policy — allow all, block training only, or block all.
+
+## Key Focus Areas
+
+- AI crawler directory (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, and more)
+- robots.txt generator
+- llms.txt generator
+
+## About llms.txt Implementation
+
+Bot Ledger provides an `llms.txt` file with AI-readable information about its data and purpose.


### PR DESCRIPTION
Adds Bot Ledger, a free static directory of AI crawlers (GPTBot, ClaudeBot, PerplexityBot, Google-Extended, and more) with a client-side robots.txt and llms.txt generator. No signup or backend.

- Website: https://farrelldan.github.io/ai-bot-directory/
- llms.txt: https://farrelldan.github.io/ai-bot-directory/llms.txt
- Category: developer-tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Bot Ledger content page featuring an overview of its AI crawler directory.
  * Included information about robots.txt and llms.txt generators, key focus areas, and Bot Ledger’s llms.txt implementation.
  * Added metadata, publication details, and relevant links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->