### PR TITLE
feat: add Arkite UI

### DIFF
--- a/packages/content/data/websites/arkite-ui-llms-txt.mdx
+++ b/packages/content/data/websites/arkite-ui-llms-txt.mdx
@@ -1,9 +1,9 @@
 ---
 name: 'Arkite UI'
 description: 'Production-ready React components for multi-tenant SaaS admin panels — Tailwind CSS v4 + Radix UI + TypeScript, with machine-readable docs generated from the type-checked API on every build.'
-website: 'https://daith.github.io/arkite-ui/'
-llmsUrl: 'https://daith.github.io/arkite-ui/llms.txt'
-llmsFullUrl: 'https://daith.github.io/arkite-ui/llms-full.txt'
+website: 'https://ui.foson.co/'
+llmsUrl: 'https://ui.foson.co/llms.txt'
+llmsFullUrl: 'https://ui.foson.co/llms-full.txt'
 category: 'developer-tools'
 publishedAt: '2026-08-08'
 ---

--- a/packages/content/data/websites/arkite-ui-llms-txt.mdx
+++ b/packages/content/data/websites/arkite-ui-llms-txt.mdx
@@ -1,0 +1,17 @@
+---
+name: 'Arkite UI'
+description: 'Production-ready React components for multi-tenant SaaS admin panels — Tailwind CSS v4 + Radix UI + TypeScript, with machine-readable docs generated from the type-checked API on every build.'
+website: 'https://daith.github.io/arkite-ui/'
+llmsUrl: 'https://daith.github.io/arkite-ui/llms.txt'
+llmsFullUrl: 'https://daith.github.io/arkite-ui/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-08'
+---
+
+# Arkite UI
+
+70 React components for multi-tenant SaaS back-offices — admin layouts with mobile bottom-nav support, data tables with a server-side mode and state hook, filter bars, stat dashboards, OTP inputs. Dogfooded by nine production SaaS products before every release.
+
+## About llms.txt Implementation
+
+Both files are regenerated on every build from the library's type-checked public-API snapshot and its machine-readable design spec, so they cannot drift from the code. `llms.txt` carries setup, design rules for generated code, core usage patterns, and the full export inventory; `llms-full.txt` adds the complete design-system spec and typed signatures for every export. Both also ship inside the npm package (`node_modules/@arkite-ui/core/llms-full.txt`) so coding agents can read them offline.


### PR DESCRIPTION
Adds **Arkite UI** — a React component library for multi-tenant SaaS admin panels (Tailwind CSS v4 + Radix UI + TypeScript).

- Website: https://daith.github.io/arkite-ui/
- llms.txt: https://daith.github.io/arkite-ui/llms.txt
- llms-full.txt: https://daith.github.io/arkite-ui/llms-full.txt

Both files are regenerated from the library's type-checked public-API snapshot on every build (so they can't drift from the code) and also ship inside the npm package for offline agent use. Entry follows the existing template (category `developer-tools`, same as Ant Design).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added Arkite UI website metadata and documentation content.
  - Included links to available LLM documentation files and publication details.
  - Documented the component overview and distribution of `llms.txt` and `llms-full.txt` files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->