### PR TITLE
feat(community): add Zovo and BeLikeNative

### DIFF
--- a/packages/content/data/websites/belikenative-llms-txt.mdx
+++ b/packages/content/data/websites/belikenative-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'BeLikeNative'
+description: 'AI writing assistant that fixes, rephrases, translates and adjusts the tone of text on any web page, with L1-aware corrections across 80+ languages.'
+website: 'https://belikenative.com/'
+llmsUrl: 'https://belikenative.com/llms.txt'
+llmsFullUrl: 'https://belikenative.com/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-08-08'
+---
+
+# BeLikeNative
+
+BeLikeNative is a Chrome extension and a set of free browser tools for editing text with AI: grammar correction, paraphrasing, translation, summarisation, simplification and tone adjustment. Corrections are L1-aware, meaning they account for the writer's first language, and the tools cover 80+ languages.
+
+## About the llms.txt Implementation
+
+`llms.txt` indexes the product pages, the documentation and FAQ sections, and each of the free online tools under `belikenative.com/tools/`. `llms-full.txt` serves the expanded version of the same documentation set.
+
+## Coverage
+
+- Free online tools: grammar checker, paraphraser, translator, summariser, text simplifier, tone changer, punctuation checker
+- Writing helpers: APA and MLA citation generators, email reply and email template generators
+- Documentation, FAQ and blog sections covering setup and feature usage

--- a/packages/content/data/websites/belikenative-llms-txt.mdx
+++ b/packages/content/data/websites/belikenative-llms-txt.mdx
@@ -18,6 +18,6 @@ BeLikeNative is a Chrome extension and a set of free browser tools for editing t
 
 ## Coverage
 
-- Free online tools: grammar checker, paraphraser, translator, summariser, text simplifier, tone changer, punctuation checker
+- Free online tools include: grammar checker, paraphraser, translator, summariser, text simplifier, tone changer, punctuation checker
 - Writing helpers: APA and MLA citation generators, email reply and email template generators
 - Documentation, FAQ and blog sections covering setup and feature usage

--- a/packages/content/data/websites/zovo-llms-txt.mdx
+++ b/packages/content/data/websites/zovo-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'Zovo'
+description: 'Privacy-first Chrome extensions for productivity, development, writing and design, built on Manifest V3 with no tracking or data collection.'
+website: 'https://zovo.one/'
+llmsUrl: 'https://zovo.one/llms.txt'
+llmsFullUrl: 'https://zovo.one/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-08'
+---
+
+# Zovo
+
+Zovo builds Chrome extensions for productivity, development, writing and design. The extensions target Google Chrome and Chromium-based browsers including Edge, Brave, Arc and Opera, and are built on Manifest V3.
+
+## About the llms.txt Implementation
+
+`llms.txt` gives a short overview of the catalogue and links each extension's documentation page under `zovo.one/tools/`. `llms-full.txt` carries the expanded documentation for the same set of pages.
+
+## Coverage
+
+- Per-extension documentation pages grouped by category (productivity, development, writing, design)
+- Flagship extension entries such as Tab Suspender Pro, JSON Formatter Pro, Clipboard History Pro and Color Picker Pro
+- Stated privacy position: no tracking, no analytics, no data collection, with extension data kept on the user's device


### PR DESCRIPTION
Adds two entries under `packages/content/data/websites/` per CONTRIBUTING.md Option 2. `data/websites.json` is untouched.

| site | llms.txt | llms-full.txt | category |
|---|---|---|---|
| https://zovo.one/ | 200 | 200 | developer-tools |
| https://belikenative.com/ | 200 | 200 | ai-ml |

Both files were verified live with curl before submitting. Descriptions are drawn from each site's own llms.txt; no metrics are restated.

- Zovo — Chrome extensions for productivity, development, writing and design (MV3).
- BeLikeNative — AI writing assistant for grammar, paraphrasing, translation and tone, plus free browser tools.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added BeLikeNative website metadata and `llms.txt` documentation, including AI writing features, supported languages, resources, and integrations.
  * Added Zovo website metadata and `llms.txt` documentation covering privacy-focused browser extensions, supported browsers, products, and documentation links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->