### PR TITLE
feat(websites): add ToolsThatRank, handsofflinks and AI Website Pipeline

### DIFF
--- a/packages/content/data/websites/aiwebsitepipeline-llms-txt.mdx
+++ b/packages/content/data/websites/aiwebsitepipeline-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'AI Website Pipeline'
+description: 'An agentic pipeline that turns one keyword into a small static utility site, running on your own machine, with layer contracts and machine-evaluable gates that can halt a build.'
+website: 'https://aiwebsitepipeline.com/'
+llmsUrl: 'https://aiwebsitepipeline.com/llms.txt'
+llmsFullUrl: ''
+category: 'ai-ml'
+publishedAt: '2026-08-08'
+---
+
+# AI Website Pipeline
+
+AI Website Pipeline is an automated agentic pipeline that takes a single keyword and produces a small static utility site. It runs locally on the operator's own machine rather than as a hosted service. Its stated argument is that nothing between the keyword and the deploy can tell you no, and that the missing part is a machine that says no — so the pipeline is built around layer contracts and machine-evaluable gates, including a demonstration gate that deliberately fails rather than assume absent flags are clean.
+
+## About the llms.txt Implementation
+
+`llms.txt` indexes the home page, the method and niche-score pages, an essay on domain availability, the FAQ, order lookup and terms. It also documents the open-source libraries published alongside the product, and notes that the whole domain is open to crawlers except `/dl/`, which holds delivered product archives.
+
+## Coverage
+
+- Documented subjects: RDAP, keyword difficulty distribution, keyword maps, information gain, Search Console coverage, IndexNow, GEO sprint stages and JSON Schema
+- `gate-contract` — Rust library for fail-closed gate contracts, where a blocking gate halts the run both when it fails and when it cannot be evaluated, and a `Known<T>` type propagates `Unknown` instead of decaying to a default
+- `indexnowkit` — D library that builds and validates IndexNow submissions against the published protocol constraints

--- a/packages/content/data/websites/handsofflinks-llms-txt.mdx
+++ b/packages/content/data/websites/handsofflinks-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'handsofflinks'
+description: 'A link pipeline that builds assets, publishes them through platform APIs, and reads the link attribute off the served HTML before a row may be recorded as live. No outreach email.'
+website: 'https://handsofflinks.com/'
+llmsUrl: 'https://handsofflinks.com/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-08-08'
+---
+
+# handsofflinks
+
+handsofflinks is a link-building pipeline whose framing is that the common factor in bad paid links is that somebody had to say yes to them; it calls its alternative "Counterparty-Zero Publishing". The described cycle runs weekly in four steps — research, build for real, publish through APIs, then verify and write it down — and outreach is explicitly not one of them. The site states that failures are shown at the same size as wins and that dead links stay on the chart.
+
+## About the llms.txt Implementation
+
+`llms.txt` indexes the home, refund, terms and privacy pages, documents the two open-source libraries published alongside the product, and records that the domain is fully open to crawlers with AI retrieval crawlers named explicitly in robots.txt.
+
+## Coverage
+
+- Product overview: the four-step cycle, the per-day link chart, and the channels that worked versus the ones that did not
+- `followability` — Rust library that parses a rel token list, a robots meta tag and any `X-Robots-Tag` headers, combines them most-restrictive-wins, and names which signal withheld the follow
+- `linkfollow` — the same resolution in D, with header beating meta beating rel, optional user-agent prefixes, and noindex reported separately from nofollow

--- a/packages/content/data/websites/toolsthatrank-llms-txt.mdx
+++ b/packages/content/data/websites/toolsthatrank-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'ToolsThatRank'
+description: 'An SEO pipeline that builds tool sites: give it a niche and it ships calculators, converters and live data trackers, validating every value against a primary source before publishing.'
+website: 'https://toolsthatrank.com/'
+llmsUrl: 'https://toolsthatrank.com/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-08-08'
+---
+
+# ToolsThatRank
+
+ToolsThatRank describes itself as an SEO pipeline that builds tool sites. You give it a niche and it generates calculators, converters and live data trackers for that niche. Its stated operating rule is that a value is measured rather than asserted: research happens before writing, values are validated, and pages are generated against a checked bundle. It is aimed at solo operators, SEO agencies and indie hackers.
+
+## About the llms.txt Implementation
+
+`llms.txt` covers the home, terms and privacy pages, and documents the open-source libraries published alongside the product. The file also notes that the domain is fully open to crawlers and that its robots.txt names AI crawlers explicitly.
+
+## Coverage
+
+- Product overview: what the pipeline is, who it is for, and how a page gets made
+- `serp-ctr` — Rust library for search-console arithmetic: click-through rate, impression-weighted average position, pooled totals, and projection against a caller-supplied CTR curve
+- `serpcurve` — D library that fits an impression-weighted power-law CTR curve to observed position, impression and click rows, and raises an error rather than returning a fit when the input cannot support one


### PR DESCRIPTION
Adds three entries under `packages/content/data/websites/` per CONTRIBUTING.md Option 2. `data/websites.json` is untouched (auto-generated).

| site | llms.txt | category |
|---|---|---|
| https://toolsthatrank.com/ | 200, text/plain | developer-tools |
| https://handsofflinks.com/ | 200, text/plain | developer-tools |
| https://aiwebsitepipeline.com/ | 200, text/plain | ai-ml |

All three llms.txt files were fetched with curl and confirmed HTTP 200 with a `text/plain` content type before submitting. None of the three serves an `llms-full.txt` yet, so `llmsFullUrl` is left empty rather than pointing at a 404.

Descriptions are drawn from each site's own llms.txt; no metrics, prices or adoption figures are restated.

- ToolsThatRank — SEO pipeline that generates calculators, converters and data trackers for a given niche.
- handsofflinks — link pipeline that publishes via platform APIs and verifies the rel attribute on served HTML.
- AI Website Pipeline — local agentic pipeline that turns one keyword into a static utility site, gated by layer contracts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added directory entries for AI Website Pipeline, handsofflinks, and ToolsThatRank.
  * Included descriptive metadata, supported subjects, publishing workflows, crawler-access details, and `llms.txt` implementation information.
  * Documented related open-source libraries for each newly added website.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->