### PR TITLE
feat: add The Poliety

### DIFF
--- a/packages/content/data/websites/the-poliety-llms-txt.mdx
+++ b/packages/content/data/websites/the-poliety-llms-txt.mdx
@@ -1,0 +1,17 @@
+---
+name: 'The Poliety'
+description: 'A daily AI, startup and open source news briefing built to be read by agents: every story attributed to a named linked source, a stable edition JSON schema with per-item sha256 content hashes, and a public integrity chain.'
+website: 'https://poliety.com'
+llmsUrl: 'https://poliety.com/llms.txt'
+llmsFullUrl: ''
+category: 'ai-ml'
+publishedAt: '2026-08-09'
+---
+
+# The Poliety
+
+A daily AI, startup, developer tools and open source news briefing built to be read by agents as well as people. The site is fully static with no scripts, no cookies and no third-party requests, and every story is attributed to a named source you can click.
+
+Machine-readable surfaces sit alongside the HTML: a full edition document at /api/latest.json on the stable poliety.edition.v1 schema, a per-day archive, JSON Feed and RSS, and schema.org NewsArticle markup on articles. Every wire item and brief carries a sha256 content hash so a reader can detect changes across polls.
+
+The llms.txt itself carries the day's briefs, the structured endpoints, a machine-checkable freshness beacon and the free-versus-paid rule written as a branch an agent can execute rather than as prose.


### PR DESCRIPTION
Adds [The Poliety](https://poliety.com) as a new `.mdx` entry under `packages/content/data/websites/`. Per CONTRIBUTING I have not touched `data/websites.json`, since it is generated.

**What it is:** a daily AI, startup, developer tools and open source news briefing built to be read by agents as well as people. Fully static, no scripts, no cookies, no third-party requests, and every story attributed to a named source you can click.

**Why the llms.txt is worth indexing:** it is hand-shaped rather than generated. Alongside the usual index it carries the day's briefs, the structured endpoints, a machine-checkable freshness beacon (`builtAt`, `staleAfter`, trailing averages, ok/degraded) and the free-versus-paid rule written as an if/elif branch an agent can execute rather than as marketing prose.

**Entry details:**

| Field | Value |
| --- | --- |
| name | The Poliety |
| website | https://poliety.com |
| llmsUrl | https://poliety.com/llms.txt |
| llmsFullUrl | (none) |
| category | `ai-ml` |

Happy to adjust the category or trim the description if `ai-ml` is not the best fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP7MtcHRRZ4z2MaQfhy5e5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AI-readable content description for The Poliety.
  * Included metadata, publication details, endpoint information, content-integrity verification, freshness data, and access rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->