### PR TITLE
docs: add llms-txt-check to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ We organize projects into primary categories (🤖 **AI & ML**, 💻 **Developer
 | ⚡ **Raycast Extension**  | Search and explore llms.txt files directly in Raycast           | [Raycast Store](https://www.raycast.com/thedaviddias/llms-txt)                                                |
 | ⚡ **LLMs.txt Generator** | Generate llms.txt from sitemap, crawled pages and AI            | [LLMs.txt Generator](https://llmstxtgenerator.co/)                                                            |
 | 🛠 **llmstxt-cli**        | Install llms.txt docs as skills into 35+ AI coding agents       | [npm](https://www.npmjs.com/package/llmstxt-cli) · [README](packages/cli/README.md)                           |
+| ✅ **llms-txt-check**    | Validate a site's llms.txt against what it actually serves, in CI | [npm](https://www.npmjs.com/package/llms-txt-check) · [GitHub](https://github.com/portdeveloper/llms-txt-check)  |
 
 <!-- LLMS-LIST:START - Do not remove or modify this section -->
 ## LLM Tools and Resources


### PR DESCRIPTION
hey! adding [llms-txt-check](https://github.com/portdeveloper/llms-txt-check) to the Developer Tools table: a zero-dependency npm CLI + library that validates a deployed site's llms.txt against what the site actually serves (dead links, empty bodies, .md routes returning HTML shells). built for CI so the deploy that breaks a route goes red. it found 71 dead links in Drizzle ORM's llms.txt in its first week (drizzle-team/drizzle-orm-docs#705), plus broken files at tRPC, Grafana, and LiteLLM.

reproduce any of those with `npx llms-txt-check <site url>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `llms-txt-check` developer tool to the README.
  * Standardized line endings and formatting across several directory entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->