### PR TITLE
Add ProofLines (prooflines.org)

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -9222,6 +9222,15 @@
     "publishedAt": "2026-05-31"
   },
   {
+    "name": "ProofLines",
+    "domain": "https://prooflines.org",
+    "description": "Monad network intelligence: validator-program tracker, stake-geography and concentration analytics, live network feeds, and an x402 pay-per-call data endpoint for AI agents",
+    "llmsTxtUrl": "https://prooflines.org/llms.txt",
+    "category": "data-analytics",
+    "favicon": "https://www.google.com/s2/favicons?domain=prooflines.org&sz=128",
+    "publishedAt": "2026-08-09"
+  },
+  {
     "name": "Propertyfinder",
     "domain": "https://propertyfinder.bg/",
     "description": "Вашият експертен гид за имоти в чужбина. Анализи, ръководства и съвети за умна инвестиция в Дубай, Испания, Гърция и др. Създаден специално за български инвеститори.",


### PR DESCRIPTION
Adding ProofLines to the data-analytics category.

- **Site:** https://prooflines.org — independent Monad network observer: validator-program tracker, stake-geography and concentration analytics, live network feeds, Telegram alerting, and an x402 pay-per-call data endpoint for AI agents.
- **llms.txt:** https://prooflines.org/llms.txt — indexes the free feeds, the paid x402 resources, and the writing.
- Note for link checkers: two links in the file intentionally return HTTP 402 (they are x402 pay-per-call resources with machine-readable payment instructions); the other ten resolve 200.

Inserted alphabetically into data/websites.json, one entry, no other changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ProofLines to the website directory with Monad network intelligence and data analytics details.
  * Included its favicon, llms.txt link, and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->