### PR TITLE
feat(community): add Reboot Hub llms.txt

### DIFF
--- a/packages/content/data/websites/reboot-hub-llms-txt.mdx
+++ b/packages/content/data/websites/reboot-hub-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Reboot Hub'
+description: 'Global drone lifecycle company publishing repair resources, grading standards, Drone Wiki references, and public used-drone data.'
+website: 'https://reboot-hub.com/'
+llmsUrl: 'https://reboot-hub.com/llms.txt'
+llmsFullUrl: 'https://reboot-hub.com/llms-full.txt'
+category: 'ecommerce-retail'
+publishedAt: '2026-08-10'
+---
+
+# Reboot Hub
+
+Reboot Hub publishes AI-readable documentation for drone repair, graded pre-owned equipment, parts, public datasets, and the Drone Wiki.


### PR DESCRIPTION
Adds Reboot Hub's public root-level `llms.txt` and `llms-full.txt` files to the ecommerce and retail directory.

- Website: https://reboot-hub.com/
- llms.txt: https://reboot-hub.com/llms.txt
- llms-full.txt: https://reboot-hub.com/llms-full.txt
- Both resources return HTTP 200 as `text/markdown`
- Adds one MDX entry only; generated website data is untouched

Disclosure: I am submitting this entry on behalf of Reboot Hub.