### PR TITLE
feat(community): add Motion Menu to llms.txt hub

### DIFF
--- a/packages/content/data/websites/motion-menu-llms-txt.mdx
+++ b/packages/content/data/websites/motion-menu-llms-txt.mdx
@@ -1,0 +1,16 @@
+---
+name: 'Motion Menu'
+description: '596 motion/3D UI patterns as ready HTML/CSS/JS, served over MCP and plain URLs. Free tier + $149 lifetime.'
+website: 'https://motion-menu-two.vercel.app'
+llmsUrl: 'https://motion-menu-two.vercel.app/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-08-09'
+---
+
+# Motion Menu
+
+596 interactive motion patterns — scroll-driven WebGL, shader passes, spring choreography — as
+transplantable HTML/CSS/JS an agent reads directly and drops into a page. Served over an MCP
+endpoint (streamable-http, no key needed to browse or use the free tier) and a plain HTTP API.
+Free tier: 26 patterns, no card, no expiry. Lifetime: $149 once, everything, forever.

--- a/packages/content/data/websites/motion-menu-llms-txt.mdx
+++ b/packages/content/data/websites/motion-menu-llms-txt.mdx
@@ -13,4 +13,4 @@ publishedAt: '2026-08-09'
 597 interactive motion patterns — scroll-driven WebGL, shader passes, spring choreography — as
 transplantable HTML/CSS/JS an agent reads directly and drops into a page. Served over an MCP
 endpoint (streamable-http, no key needed to browse or use the free tier) and a plain HTTP API.
-Free tier: 26 patterns, no card, no expiry. Lifetime: $149 once, everything, forever.
+Free: the entire library — every pattern, every framework wrapper. No card, no key.

--- a/packages/content/data/websites/motion-menu-llms-txt.mdx
+++ b/packages/content/data/websites/motion-menu-llms-txt.mdx
@@ -1,8 +1,8 @@
 ---
 name: 'Motion Menu'
-description: '596 motion/3D UI patterns as ready HTML/CSS/JS, served over MCP and plain URLs. Free tier + $149 lifetime.'
-website: 'https://motion-menu-two.vercel.app'
-llmsUrl: 'https://motion-menu-two.vercel.app/llms.txt'
+description: '597 motion/3D UI patterns as ready HTML/CSS/JS, served over MCP and plain URLs. Free tier + $149 lifetime.'
+website: 'https://www.motionmenu.ca'
+llmsUrl: 'https://www.motionmenu.ca/llms.txt'
 llmsFullUrl: ''
 category: 'developer-tools'
 publishedAt: '2026-08-09'
@@ -10,7 +10,7 @@ publishedAt: '2026-08-09'
 
 # Motion Menu
 
-596 interactive motion patterns — scroll-driven WebGL, shader passes, spring choreography — as
+597 interactive motion patterns — scroll-driven WebGL, shader passes, spring choreography — as
 transplantable HTML/CSS/JS an agent reads directly and drops into a page. Served over an MCP
 endpoint (streamable-http, no key needed to browse or use the free tier) and a plain HTTP API.
 Free tier: 26 patterns, no card, no expiry. Lifetime: $149 once, everything, forever.


### PR DESCRIPTION
Adds Motion Menu — 596 motion/3D UI patterns as ready HTML/CSS/JS, served over an MCP endpoint and plain URLs.

- Website: https://motion-menu-two.vercel.app
- llms.txt: https://motion-menu-two.vercel.app/llms.txt
- Free tier: 26 patterns, no card; Lifetime: $149 once

Category: developer-tools, matching the format of existing entries (e.g. Vercel, Glama).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Updated Motion Menu’s directory listing to reflect 597 available patterns.
  * Replaced outdated website and AI-readable content links with the current Motion Menu URLs.
  * Updated pricing information to indicate that the full library is free, with no card or access key required.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->