### PR TITLE
feat(community): add Corank to llms.txt hub

### DIFF
--- a/packages/content/data/websites/corank-llms-txt.mdx
+++ b/packages/content/data/websites/corank-llms-txt.mdx
@@ -1,0 +1,17 @@
+---
+name: 'Corank'
+description: 'AI visibility audits and recurring monitoring across ChatGPT, Perplexity, Claude, Gemini, and Google AI Overviews.'
+website: 'https://corank.ai'
+llmsUrl: 'https://corank.ai/llms.txt'
+llmsFullUrl: ''
+category: 'ai-ml'
+publishedAt: '2026-08-10'
+---
+
+# Corank
+
+Corank provides AI visibility audits and recurring monitoring across ChatGPT, Perplexity, Claude, Gemini, and Google AI Overviews. It analyzes brand mentions, citations, source roles, and opportunities for improving discoverability.
+
+## About llms.txt Implementation
+
+Corank's public llms.txt summarizes the service, supported AI search surfaces, methodology, key pages, pricing, and contact information for AI systems.


### PR DESCRIPTION
## Summary

Adds Corank to llms.txt Hub using its canonical public `llms.txt` endpoint. The change adds one focused MDX entry under `packages/content/data/websites/` and does not modify generated files.

## Validation

- Website: https://corank.ai (HTTP 200)
- llms.txt: https://corank.ai/llms.txt (HTTP 200, text/plain)
- `llmsFullUrl` is intentionally blank because Corank does not currently publish that endpoint.
- Category: `ai-ml`
- Description and page copy are neutral and factual.

## Affiliation

I’m affiliated with Corank. This is an unpaid directory submission with no affiliate link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Corank website entry with publication details and metadata.
  * Documented its public `llms.txt` implementation, supported AI platforms, auditing capabilities, methodology, pricing, and contact information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->