### PR TITLE
feat(community): add Nexus Shell to llms.txt hub

### DIFF
--- a/packages/content/data/websites/nexus-shell-llms-txt.mdx
+++ b/packages/content/data/websites/nexus-shell-llms-txt.mdx
@@ -1,0 +1,17 @@
+---
+name: 'Nexus Shell'
+description: 'Native macOS workspace for SSH, SFTP, Docker, server and network monitoring, with local-first security and an optional Agent Bridge.'
+website: 'https://nexusshell.app/'
+llmsUrl: 'https://nexusshell.app/llms.txt'
+llmsFullUrl: 'https://nexusshell.app/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-12'
+---
+
+# Nexus Shell
+
+Nexus Shell is a native SwiftUI workspace for managing remote servers from macOS. It combines SSH terminals, dual-pane SFTP, SSH key management, Docker controls, live server and network monitoring, encrypted local session logs, and optional iCloud sync.
+
+## About llms.txt Implementation
+
+The public llms.txt links to canonical product documentation, release metadata, pricing and legal pages, installation instructions, and the optional local Agent Bridge. The expanded llms-full.txt provides the complete public knowledge base in one fetch.


### PR DESCRIPTION
Adds Nexus Shell, a native macOS SSH and server-management workspace, to the Developer Tools category.

- Website: https://nexusshell.app/
- llms.txt: https://nexusshell.app/llms.txt
- llms-full.txt: https://nexusshell.app/llms-full.txt
- Both resources return HTTP 200 with text/markdown.
- The entry follows the current MDX schema and does not modify generated data.

Disclosure: I am the developer of Nexus Shell. The entry text and submission checks were prepared with Codex assistance and manually verified against the public site and current repository guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added website metadata for Nexus Shell.
  * Added an overview of its macOS workspace features and documentation endpoints for AI-readable access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->