### PR TITLE
Add Gandr to AI & Machine Learning

### DIFF
--- a/packages/content/data/websites/gandr-llms-txt.mdx
+++ b/packages/content/data/websites/gandr-llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
 name: 'Gandr'
-description: 'Text to speech API for voice agents. Reads numbers and dates right, one cloned voice in 23 languages, every render watermarked.'
+description: 'Text-to-speech API for voice agents. Reads numbers and dates right, one cloned voice in 23 languages, every render watermarked.'
 website: 'https://gandr.ai'
 llmsUrl: 'https://gandr.ai/llms.txt'
 llmsFullUrl: ''
@@ -10,4 +10,4 @@ publishedAt: '2026-08-12'
 
 # Gandr
 
-Text to speech API for voice agents. Reads numbers and dates right, one cloned voice in 23 languages, every render watermarked.
+Text-to-speech API for voice agents. Reads numbers and dates right, one cloned voice in 23 languages, every render watermarked.

--- a/packages/content/data/websites/gandr-llms-txt.mdx
+++ b/packages/content/data/websites/gandr-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Gandr'
+description: 'Text to speech API for voice agents. Reads numbers and dates right, one cloned voice in 23 languages, every render watermarked.'
+website: 'https://gandr.ai'
+llmsUrl: 'https://gandr.ai/llms.txt'
+llmsFullUrl: ''
+category: 'ai-ml'
+publishedAt: '2026-08-12'
+---
+
+# Gandr
+
+Text to speech API for voice agents. Reads numbers and dates right, one cloned voice in 23 languages, every render watermarked.


### PR DESCRIPTION
Adds [Gandr](https://gandr.ai) (text to speech API for voice agents) with a live [llms.txt](https://gandr.ai/llms.txt) (verified 200 on 2026-08-12). Single new MDX entry under packages/content/data/websites/, no other files touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Gandr to the website directory.
  * Included metadata, relevant links, publication details, and AI/ML categorization.
  * Added an overview of Gandr’s text-to-speech API, helping readers quickly understand its capabilities and relevance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Disclosure: I work on Gandr.
