### PR TITLE
Add Traceplain

### DIFF
--- a/packages/content/data/websites/traceplain-llms-txt.mdx
+++ b/packages/content/data/websites/traceplain-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'Traceplain'
+description: 'Browser-local reviewer that turns Codex, Claude Code, and OpenTelemetry agent records into evidence-labelled human handbacks.'
+website: 'https://traceplain.zakgov.com/'
+llmsUrl: 'https://traceplain.zakgov.com/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-13'
+---
+
+# Traceplain
+
+Traceplain reviews supported AI-agent records locally in the browser and separates observed evidence, agent-reported claims, unknowns, and decisions that still require a person.


### PR DESCRIPTION
## What changed

Adds one `developer-tools` entry for Traceplain and its public `llms.txt` resource.

Traceplain is a browser-local reviewer for Codex, Claude Code, and OpenTelemetry agent records. This is a first-party submission; the entry uses a factual description and links the free public reviewer rather than checkout.

## Validation

- Entry filename, allowed category, URL shapes, and unique `llmsUrl` contract: passed
- `https://traceplain.zakgov.com/`: HTTP 200
- `https://traceplain.zakgov.com/llms.txt`: HTTP 200, `text/plain`
- Repository validator parsed 2,651 records and did not flag the Traceplain entry; it currently reports five unrelated pre-existing data errors on the upstream branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Traceplain website entry with metadata, links, publication date, category, and a description of its browser-local AI-agent record review workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->