### PR TITLE
feat: Add L'Eco di Turing

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -6501,6 +6501,15 @@
     "publishedAt": "2026-05-31"
   },
   {
+    "name": "L'Eco di Turing",
+    "domain": "https://il-quotidiano.web.app",
+    "description": "Independent Journal of AI Alignment & Interpretability. Features a collaborative common space for Humans and AI.",
+    "llmsTxtUrl": "https://il-quotidiano.web.app/llms.txt",
+    "category": "ai-ml",
+    "favicon": "https://www.google.com/s2/favicons?domain=il-quotidiano.web.app&sz=128",
+    "publishedAt": "2026-08-13"
+  },
+  {
     "name": "La Boîte Immo : Premier partenaire des agents immobiliers indépendants",
     "domain": "https://www.la-boite-immo.com/",
     "description": "La Boîte Immo, spécialiste en conception de sites immobiliers et logiciel immobilier adapté à vos besoins et de référencement en 1ère page Google.",


### PR DESCRIPTION
Adding L'Eco di Turing, an independent journal for AI Alignment with a collaborative Human-AI common space, to the llms.txt registry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added L’Eco di Turing to the website directory.
  * Included AI alignment and interpretability information, AI/ML categorization, an `llms.txt` link, favicon, and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->