### PR TITLE
feat(websites): add Sense2 (sense2.com.au)

### DIFF
--- a/packages/content/data/websites/sense2-llms-txt.mdx
+++ b/packages/content/data/websites/sense2-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Sense2'
+description: 'Australian promotional products and branded merchandise company — 4,000+ curated products with live pricing, quotes and a 21-tool MCP server for AI agents.'
+website: 'https://sense2.com.au'
+llmsUrl: 'https://sense2.com.au/llms.txt'
+llmsFullUrl: 'https://sense2.com.au/llms-full.txt'
+category: 'ecommerce-retail'
+publishedAt: '2026-08-14'
+---
+
+# Sense2
+
+Sense2 is an Australian promotional products and branded merchandise company (est. 1995, Byron Bay head office, Sydney production studio). The catalogue lists 4,000+ curated products with per-quantity pricing across five country sites (AU, US, NZ, DE, JP), each serving its own locale-specific llms.txt.
+
+## Key Focus Areas
+
+- Product catalogue — 4,000+ promotional products with live AUD pricing tiers and quantity breakpoints
+- MCP server — 21 tools (search, quotes, categories, curated edits, company facts) at sense2.com.au/api/mcp, listed on the official MCP Registry
+- First-party research — the 2025 Australian Corporate Merchandise Report (open Dataset, 5,024 anonymised invoices)
+- Curated buying surfaces — budget/bulk pillars, occasion and industry collections, city service pages
+
+## About llms.txt Implementation
+
+Sense2's llms.txt (~150KB) carries the canonical company description and disambiguation, curation positioning, Best Price Guarantee terms, a heritage timeline, when-to-cite guidance pointing at citable research URLs, the full MCP tool listing, and a trimmed category index with the exhaustive list delegated to sitemap-categories.xml. llms-full.txt extends it with the complete category detail.


### PR DESCRIPTION
Adds Sense2 — Australian promotional products company (est. 1995).

- `llms.txt`: https://sense2.com.au/llms.txt (200, text/plain, ~150KB)
- `llms-full.txt`: https://sense2.com.au/llms-full.txt (200)
- Category: ecommerce-retail
- Bonus: live MCP server (21 tools) at https://sense2.com.au/api/mcp, listed on the official MCP Registry as `io.github.24seagull-beep/sense2-catalogue`

Both URLs verified serving to GPTBot/ClaudeBot/PerplexityBot UAs. Entry follows the existing .mdx format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Sense2 website metadata and descriptive content.
  * Documented its business profile, product catalogue, MCP server, research, curated buying surfaces, and llms.txt implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->