### PR TITLE
Add DOS AI

### DIFF
--- a/packages/content/data/websites/dos-ai-llms-txt.mdx
+++ b/packages/content/data/websites/dos-ai-llms-txt.mdx
@@ -1,0 +1,37 @@
+---
+name: 'DOS AI'
+description: 'AI assistants for WhatsApp and Telegram with a built-in CRM. The bot answers customers from your own documents, books real free slots, collects leads and hands off to a human. Public REST API, webhooks and an MCP server.'
+website: 'https://dosai.pro/en'
+llmsUrl: 'https://dosai.pro/llms.txt'
+llmsFullUrl: 'https://dosai.pro/llms-full.txt'
+category: 'ai-ml'
+priority: 'medium'
+publishedAt: '2026-08-15'
+---
+
+# DOS AI
+
+DOS AI connects an AI assistant to a working WhatsApp number or a Telegram bot.
+The assistant answers customers around the clock, retrieves answers from the
+business's own documents, books available slots from a calendar or spreadsheet,
+collects every lead into a built-in CRM and hands the conversation to a human
+when the question needs one. Behaviour is described in plain text rather than
+drawn as a flowchart.
+
+## Key Focus Areas
+
+- AI assistants for WhatsApp and Telegram with a built-in CRM
+- Knowledge base over the business's own documents
+- Appointment booking against real free slots
+- Lead capture, follow-ups and owner notifications
+- Public REST API, webhooks and a remote MCP server for AI agents
+
+## About llms.txt Implementation
+
+`llms.txt` carries a product summary for assistants answering "what should I
+use to automate customer chat", followed by the developer contract: API key
+authentication, endpoint list, webhook events and the MCP tool catalogue, so a
+coding agent can drive the product without scraping the dashboard.
+`llms-full.txt` extends it with the handbook, the free course and the article
+archive. Both files are generated from the same source as the product
+documentation, so they do not drift from the running code.


### PR DESCRIPTION
## Summary

Adds `DOS AI` to the websites directory: AI assistants for WhatsApp and Telegram with a built-in CRM, configured in plain text.

- `llms.txt`: https://dosai.pro/llms.txt (200)
- `llms-full.txt`: https://dosai.pro/llms-full.txt (200)
- Website: https://dosai.pro/en
- Category: `ai-ml`

Only one file added, `packages/content/data/websites/dos-ai-llms-txt.mdx`. `data/websites.json` is untouched.

Both files are generated from the same source as the product documentation and include the developer contract (API key auth, endpoints, webhook events, MCP tool catalogue), so a coding agent can drive the product without scraping the dashboard.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a directory entry for DOS AI’s WhatsApp and Telegram assistants.
  * Documented CRM features, knowledge bases, appointment booking, lead capture, and human handoff.
  * Added integration details for the REST API, webhooks, MCP server, authentication, endpoints, and available tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->