### PR TITLE
Add Duvo llms.txt

### DIFF
--- a/packages/content/data/websites/duvo-llms-txt.mdx
+++ b/packages/content/data/websites/duvo-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Duvo'
+description: 'Execution platform for grocery and retail operations'
+website: 'https://www.duvo.ai'
+llmsUrl: 'https://www.duvo.ai/llms.txt'
+llmsFullUrl: 'https://www.duvo.ai/llms-full.txt'
+category: 'automation-workflow'
+publishedAt: '2026-08-14'
+priority: 'high'
+---
+
+# Duvo
+
+Execution platform for grocery and retail operations. Duvo captures how the work actually runs, including what never lands in a WMS, ERP, or TMS, then runs it. Every solution is guaranteed 5x the price of the run in measured results, or Duvo is free.
+
+## Key Focus Areas
+
+- Grocery and retail operations
+- Freight and payables audit
+- Process catalogues and verified outcomes
+
+## About llms.txt Implementation
+
+Duvo publishes https://www.duvo.ai/llms.txt (and https://www.duvo.ai/llms-full.txt) so agents can cite the execution-platform positioning, proof pages, and developer resources.


### PR DESCRIPTION
Adds Duvo (https://www.duvo.ai) to the directory. Live file: https://www.duvo.ai/llms.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Duvo website entry with descriptive metadata, platform information, focus areas, and links to its AI-readable resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->