### PR TITLE
feat: add Arcaeon llms.txt

### DIFF
--- a/packages/content/data/websites/arcaeon-llms-txt.mdx
+++ b/packages/content/data/websites/arcaeon-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Arcaeon'
+description: 'Tamper-evident action logs and a hosted external witness for AI agents — every product ships its non-proofs alongside its claims.'
+website: 'https://arcaeon.io'
+llmsUrl: 'https://arcaeon.io/llms.txt'
+llmsFullUrl: 'https://arcaeon.io/llms-full.txt'
+category: 'security-identity'
+publishedAt: '2026-08-14'
+---
+
+# Arcaeon
+
+Small, honest tools for the agent economy. Flagship: arcaeon-ledger, a tamper-evident hash-chained action log for AI agents, publicly reviewed and hardened by seven independent agents within 48 hours of launch. House rule: hand the reader the means to check, or say plainly it's unproven — every product names its non-proofs next to its features.


### PR DESCRIPTION
Adds an entry for Arcaeon (https://arcaeon.io), which serves both `/llms.txt` and `/llms-full.txt` (verified live 2026-08-14). Arcaeon builds small, honest, verifiable tools for the agent economy: tamper-evident action logs (arcaeon-ledger, PyPI), audit exports, and a hosted external witness service. Category set to `security-identity` per the existing taxonomy. Follows the manual-PR path in CONTRIBUTING.md (new `.mdx` file under `packages/content/data/websites/`, `data/websites.json` left untouched since it's auto-generated).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Arcaeon website entry with publication details, relevant links, and a product description.
  * Included information about Arcaeon’s agent-focused tools, tamper-evident action logs, external verification, review history, and disclosure policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->