### PR TITLE
feat: add AI Daily Insights

### DIFF
--- a/packages/content/data/websites/ai-daily-insights-llms-txt.mdx
+++ b/packages/content/data/websites/ai-daily-insights-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'AI Daily Insights'
+description: 'Bilingual daily AI news briefing, built for both human readers and AI agents.'
+website: 'https://www.aidailyinsights.cn'
+llmsUrl: 'https://www.aidailyinsights.cn/llms.txt'
+llmsFullUrl: 'https://www.aidailyinsights.cn/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-08-15'
+---
+
+# AI Daily Insights
+
+Bilingual daily AI news briefing, built for both human readers and AI agents.


### PR DESCRIPTION
Adds **AI Daily Insights** — a bilingual (Chinese/English) daily AI news briefing built to be consumed by both people and agents.

- Website: https://www.aidailyinsights.cn
- llms.txt: https://www.aidailyinsights.cn/llms.txt
- llms-full.txt: https://www.aidailyinsights.cn/llms-full.txt
- Category: `ai-ml`

The llms.txt documents machine-readable endpoints (JSON index, per-article JSON, full-text search API, RSS for both languages), lists topic timeline pages, and points to the English edition. There is also a CLI (`npx ai-daily-insights`) and an official MCP server (`ai-daily-insights-mcp`, listed in the official MCP Registry).

Only adds one `.mdx` file under `packages/content/data/websites/` per CONTRIBUTING.md; `data/websites.json` untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AI Daily Insights metadata page with bilingual news briefing details.
  * Included website and LLM URLs, category, publication date, and an introductory heading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->