### PR TITLE
content: add Agent QA llms.txt

### DIFF
--- a/packages/content/data/websites/agent-qa-llms-txt.mdx
+++ b/packages/content/data/websites/agent-qa-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Agent QA'
+description: 'The self-improving QA agent for software teams, with natural-language web and mobile tests, persistent test memory, and CLI/MCP workflows.'
+website: 'https://vostride.com'
+llmsUrl: 'https://vostride.com/llms.txt'
+llmsFullUrl: 'https://vostride.com/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-16'
+---
+
+# Agent QA
+
+The self-improving QA agent for software teams, with natural-language web and mobile tests, persistent test memory, and CLI/MCP workflows.


### PR DESCRIPTION
## Summary

Add Vostride's Agent QA site to the canonical MDX catalog under Developer Tools.

## Entry details

- Website: `https://vostride.com`
- `llms.txt`: `https://vostride.com/llms.txt`
- `llms-full.txt`: `https://vostride.com/llms-full.txt`
- Category: `developer-tools`, matching the catalog's existing test-automation entries

Both machine-readable endpoints return HTTP 200 and identify Agent QA as a source-available QA harness for natural-language web and mobile testing. The current FSL-1.1-ALv2 license converts to Apache-2.0 after two years. I am affiliated with Vostride and Agent QA.

## Validation

- `pnpm check:frontmatter agent-qa-llms-txt.mdx` passes without rewriting the entry.
- `pnpm check:websites` scans all 2,651 entries and reports five pre-existing dataset errors in other files (two legacy filenames and three duplicate legacy URLs); it reports no Agent QA error.
- `pnpm check:websites:warnings` likewise reports only the existing warnings and errors in other entries, with no warning for the Agent QA description.
- `pnpm test:repo` passes all 110 tests across the three repository suites.
- `git diff --check` passes.
- Only the canonical source MDX file is added; generated `data/websites.json` and README output remain unchanged as required.
- Repository content, issues, and pull requests contain no existing Vostride or Agent QA entry or proposal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added an Agent QA website entry with its title, description, category, publication date, and relevant URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->