### PR TITLE
feat(community): add AI Website Pipeline

### DIFF
--- a/packages/content/data/websites/aiwebsitepipeline-llms-txt.mdx
+++ b/packages/content/data/websites/aiwebsitepipeline-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'AI Website Pipeline'
+description: 'An agentic pipeline that turns one keyword into a small static utility site, running on your own machine, with layer contracts and machine-evaluable gates that can halt a build.'
+website: 'https://aiwebsitepipeline.com/'
+llmsUrl: 'https://aiwebsitepipeline.com/llms.txt'
+llmsFullUrl: ''
+category: 'ai-ml'
+publishedAt: '2026-08-08'
+---
+
+# AI Website Pipeline
+
+AI Website Pipeline is an automated agentic pipeline that takes a single keyword and produces a small static utility site. It runs locally on the operator's own machine rather than as a hosted service. Its stated argument is that nothing between the keyword and the deploy can tell you no, and that the missing part is a machine that says no — so the pipeline is built around layer contracts and machine-evaluable gates, including a demonstration gate that deliberately fails rather than assume absent flags are clean.
+
+## About the llms.txt Implementation
+
+`llms.txt` indexes the home page, the method and niche-score pages, an essay on domain availability, the FAQ, order lookup and terms. It also documents the open-source libraries published alongside the product, and notes that the whole domain is open to crawlers except `/dl/`, which holds delivered product archives.
+
+## Coverage
+
+- Documented subjects: RDAP, keyword difficulty distribution, keyword maps, information gain, Search Console coverage, IndexNow, GEO sprint stages and JSON Schema
+- `gate-contract` — Rust library for fail-closed gate contracts, where a blocking gate halts the run both when it fails and when it cannot be evaluated, and a `Known<T>` type propagates `Unknown` instead of decaying to a default
+- `indexnowkit` — D library that builds and validates IndexNow submissions against the published protocol constraints


### PR DESCRIPTION
## What

Adds a single new community entry: **AI Website Pipeline** (`aiwebsitepipeline.com`).

- `packages/content/data/websites/aiwebsitepipeline-llms-txt.mdx`

## llms.txt

- `https://aiwebsitepipeline.com/llms.txt` — live, returns 200, plain text.
- No `llms-full.txt` yet, so `llmsFullUrl` is intentionally left empty rather than pointed at a URL that does not exist.

## Notes

- Category: `ai-ml`.
- `data/websites.json` is deliberately untouched — per `CONTRIBUTING.md` it is generated and manual edits are rejected.
- This replaces #1472, which bundled three unrelated sites into one PR. I have closed that one; this PR is one site only, and correctly titled `feat(community):` so PR Intake actually runs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an AI Website Pipeline entry with descriptive metadata and content.
  * Documented its llms.txt implementation, covered subjects, and related open-source libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->