### PR TITLE
Add Hatchloop (hatchloop.dev)

### DIFF
--- a/packages/content/data/websites/hatchloop-llms-txt.mdx
+++ b/packages/content/data/websites/hatchloop-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Hatchloop'
+description: 'Free llms.txt generator for any site, plus a 0-100 AI-visibility score for ChatGPT, Perplexity and Gemini, and a Shopify app that writes AI-ready product data.'
+website: 'https://hatchloop.dev'
+llmsUrl: 'https://hatchloop.dev/llms.txt'
+llmsFullUrl: 'https://hatchloop.dev/llms-full.txt'
+category: 'marketing-sales'
+publishedAt: '2026-08-16'
+---
+
+# Hatchloop
+
+Hatchloop measures and improves how visible a business is to AI answer engines and AI shopping agents. Its free llms.txt generator (https://hatchloop.dev/llms-txt-generator/) produces a valid llms.txt file in seconds from any URL. Also includes a free 0-100 AI-Visibility check, a $99 one-time AEO audit, and a Shopify app that writes AI-ready product descriptions and auto-injects JSON-LD schema.


### PR DESCRIPTION
Adds Hatchloop via the manual-PR flow: one new MDX entry in packages/content/data/websites, category marketing-sales. llms.txt is live at https://hatchloop.dev/llms.txt (HTTP 200); llms-full.txt is also live at https://hatchloop.dev/llms-full.txt.

Hatchloop's free llms.txt generator (https://hatchloop.dev/llms-txt-generator/) produces a valid llms.txt file in seconds from any URL. Hatchloop also runs a free 0-100 AI-visibility checker and a $99 one-time AEO audit for Shopify stores.

Disclosure: I'm affiliated with Hatchloop — self-submission per the contribution options in CONTRIBUTING.md. Happy to adjust category or wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added Hatchloop website metadata and descriptive content.
  * Highlights Hatchloop’s llms.txt generator, AI visibility scoring, AEO audits, and Shopify app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->