### PR TITLE
feat(community): add LLM Latency Tracker to llms.txt hub

### DIFF
--- a/packages/content/data/websites/llm-latency-tracker-llms-txt.mdx
+++ b/packages/content/data/websites/llm-latency-tracker-llms-txt.mdx
@@ -1,13 +1,13 @@
 ---
 name: 'LLM Latency Tracker'
-description: 'Independent, provider-neutral latency & uptime for ~45 AI inference APIs, measured from 4 regions. Free, open data (CC-BY-4.0) with a JSON API and an MCP server.'
+description: 'Independent, provider-neutral latency and uptime for ~45 AI inference APIs, measured continuously from 4 regions. Open data (CC-BY-4.0), JSON API, MCP server, and a model deprecation calendar.'
 website: 'https://llmlatency.dev'
 llmsUrl: 'https://llmlatency.dev/llms.txt'
 llmsFullUrl: 'https://llmlatency.dev/llms-full.txt'
-category: 'developer-tools'
-publishedAt: '2026-07-23'
+category: 'ai-ml'
+publishedAt: '2026-08-16'
 ---
 
 # LLM Latency Tracker
 
-Independent, provider-neutral latency and uptime for ~45 AI inference APIs, measured (not scraped) from four regions. Free, open data (CC-BY-4.0) with a JSON API and an MCP server.
+Independent, provider-neutral latency and uptime for ~45 AI inference APIs, measured continuously from 4 regions. Open data (CC-BY-4.0), JSON API, MCP server, and a model deprecation calendar.


### PR DESCRIPTION
Adds **LLM Latency Tracker** to the directory.

- **Site:** https://llmlatency.dev
- **llms.txt:** https://llmlatency.dev/llms.txt
- **llms-full.txt:** https://llmlatency.dev/llms-full.txt
- **Category:** `ai-ml`

Independent, provider-neutral latency and uptime for ~45 AI inference APIs, measured continuously from 4 regions (Germany, US Central, Tokyo, São Paulo). The measurement archive is open data under CC-BY-4.0, and there is a JSON API, an MCP server, and a model deprecation calendar.

Both llms files are generated from the live measurement database on every build, so they stay in sync with the site rather than being hand-maintained.

Checked against `scripts/validate-websites.ts` before opening: filename pattern, allowed category, URL shapes for both llms resources, no duplicate `llmsUrl`, and the site is not already listed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated the LLM Latency Tracker directory page with continuous measurements from four regions.
  * Added information about the model deprecation calendar.
  * Updated the category and publication details.
  * Includes links to the website and developer resources.
  * Highlights regional latency and uptime data, licensing, JSON API access, and MCP server availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->