### PR TITLE
feat(websites): add three drone-service sites (prestation-drone.com/.fr, prestationdrone.fr)

### DIFF
--- a/packages/content/data/websites/prestation-drone-com-llms-txt.mdx
+++ b/packages/content/data/websites/prestation-drone-com-llms-txt.mdx
@@ -1,0 +1,28 @@
+---
+name: 'Prestation Drone (prestation-drone.com)'
+description: 'Professional drone operator declared with the French DGAC: 25 aerial services (audiovisual, real estate, technical inspection, agriculture, surveying) across 100 French cities, priced per service and city. Quote within 24 business hours.'
+website: 'https://prestation-drone.com/'
+llmsUrl: 'https://prestation-drone.com/llms.txt'
+category: 'agency-services'
+publishedAt: '2026-08-17'
+---
+
+# Prestation Drone (prestation-drone.com)
+
+Professional drone operator declared with the French DGAC, covered by aeronautical
+civil liability insurance. 25 aerial services — audiovisual, real estate, technical
+inspection, agriculture and surveying — delivered across 100 French cities, with one
+priced page per service/city pair. Operating base: Montpellier, Occitanie.
+
+## Key Focus Areas
+
+- Aerial services catalogue (audiovisual, real estate, inspection, agriculture, surveying)
+- City coverage and airspace checks before any date is committed
+- Flight authorisation handling where the zone requires it
+- Quotes within 24 business hours, no commitment
+
+## About llms.txt Implementation
+
+Prestation Drone publishes an `llms.txt` file describing its services, coverage area
+and quoting process in a structure meant to be read by language models. The file is
+declared in `robots.txt` and linked from every page via `<link rel="llms-txt">`.

--- a/packages/content/data/websites/prestation-drone-fr-llms-txt.mdx
+++ b/packages/content/data/websites/prestation-drone-fr-llms-txt.mdx
@@ -1,0 +1,30 @@
+---
+name: 'Prestation Drone (prestation-drone.fr)'
+description: 'French UAS operator declared with the DGAC, certified remote pilots and EC 785/2004 insurance. 25 services in four families — technical, survey, audiovisual, territory — across 100 municipalities, flight authorisations included.'
+website: 'https://prestation-drone.fr/'
+llmsUrl: 'https://prestation-drone.fr/llms.txt'
+category: 'agency-services'
+publishedAt: '2026-08-17'
+---
+
+# Prestation Drone (prestation-drone.fr)
+
+Professional aerial operator: unmanned aircraft operator declared with the French
+DGAC, certified remote pilots, professional aeronautical liability insurance compliant
+with regulation (EU) 785/2004. 25 services split into four families — technical,
+survey, audiovisual, territory — across 100 municipalities in metropolitan France.
+Flight authorisations are handled by the operator and quotes are issued within 24
+business hours.
+
+## Key Focus Areas
+
+- Service catalogue by family: technical, survey, audiovisual, territory
+- Regulatory status: operator declaration, registered aircraft, insurance certificates
+- Written risk analysis before each mission (zone class, height, distance to third parties)
+- Pricing, coverage area and site map
+
+## About llms.txt Implementation
+
+Prestation Drone publishes an `llms.txt` file describing its positioning, service
+families and coverage in a structure meant to be read by language models. The file is
+declared in `robots.txt` and linked from every page via `<link rel="llms-txt">`.

--- a/packages/content/data/websites/prestationdrone-fr-llms-txt.mdx
+++ b/packages/content/data/websites/prestationdrone-fr-llms-txt.mdx
@@ -1,0 +1,29 @@
+---
+name: 'PrestationDrone'
+description: 'Free drone service quotes in France: aerial photo and video, roof inspection, thermography, surveying. 25 services across 100 cities, priced answer within 24 business hours, no commitment.'
+website: 'https://prestationdrone.fr/'
+llmsUrl: 'https://prestationdrone.fr/llms.txt'
+category: 'agency-services'
+publishedAt: '2026-08-17'
+---
+
+# PrestationDrone
+
+Quote and matching service for drone work in France: aerial photo and video, roof
+inspection, thermography, surveying. 25 services across 100 cities, with one quote
+page per service/city pair. Requests are free, with a priced answer within 24 business
+hours and no commitment.
+
+## Key Focus Areas
+
+- Drone service catalogue: imaging, inspection, measurement
+- Per-city quote pages covering 100 French cities
+- Declared remote pilots, current liability insurance, flight authorisations included
+- Four-field quote form: name, phone, city, service
+
+## About llms.txt Implementation
+
+PrestationDrone publishes an `llms.txt` file describing what the site offers, its
+service list and its quoting process in a structure meant to be read by language
+models. The file is declared in `robots.txt` and linked from every page via
+`<link rel="llms-txt">`.


### PR DESCRIPTION
## Summary

Adds three `.mdx` entries under `packages/content/data/websites/` for three French professional drone-service sites that now publish an `llms.txt`.

| Site | llms.txt |
| --- | --- |
| [prestation-drone.com](https://prestation-drone.com/) | https://prestation-drone.com/llms.txt |
| [prestation-drone.fr](https://prestation-drone.fr/) | https://prestation-drone.fr/llms.txt |
| [prestationdrone.fr](https://prestationdrone.fr/) | https://prestationdrone.fr/llms.txt |

All three are operated by the same owner, hence the single PR. They are distinct sites with distinct content, not mirrors. The two named "Prestation Drone" are disambiguated by domain in the `name` field.

Each site declares its `llms.txt` in `robots.txt` and links it from every page via `<link rel="llms-txt" href="/llms.txt">`. All three URLs return HTTP 200.

Category used: `agency-services`.

`data/websites.json` is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added pages documenting Prestation Drone’s services, coverage, regulatory credentials, insurance, pricing, quoting process, and operational details.
  * Added website metadata and implementation references for improved discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->