### PR TITLE
feat: add Arena by Dravensoft

### DIFF
--- a/packages/content/data/websites/arena-by-dravensoft-llms-txt.mdx
+++ b/packages/content/data/websites/arena-by-dravensoft-llms-txt.mdx
@@ -1,0 +1,20 @@
+---
+name: 'Arena by Dravensoft'
+description: 'A design system published twice, as React and Angular component libraries over one shared Tailwind layer, each component bound to a contract.'
+website: 'https://arena.dravensoft.org'
+llmsUrl: 'https://arena.dravensoft.org/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-21'
+---
+
+# Arena by Dravensoft
+
+A design system published twice, as `@dravensoft/arena-react` and `@dravensoft/arena-angular` over
+one shared Tailwind layer. What a component is called, what it takes and the accessibility pattern
+it binds are contract files rather than documentation, and gates fail the build when the code, the
+docs or the published package stop answering them.
+
+The index at `/llms.txt` routes to the rules of the design language and then to one corpus per
+framework. There is deliberately no `llms-full.txt`: every component ships under both framework
+names and the two documents are not interchangeable, so a combined corpus would carry each
+component twice in two idioms.


### PR DESCRIPTION
Adds [Arena by Dravensoft](https://arena.dravensoft.org) as a new `.mdx` under `packages/content/data/websites/`. `data/websites.json` is untouched, as CONTRIBUTING requires.

- **llms.txt**: https://arena.dravensoft.org/llms.txt
- **Category**: `developer-tools`
- **llmsFullUrl**: omitted on purpose. Arena publishes the same components under both React and Angular and the two documents are not interchangeable, so instead of one combined file it ships a corpus per layer, [React](https://arena.dravensoft.org/llms-react.txt) and [Angular](https://arena.dravensoft.org/llms-angular.txt). The schema takes `llmsFullUrl` as optional, so the entry leaves it out rather than pointing at a file that would misrepresent what is served.

Name is 19 characters, the description is 141 and ends with a period, and the category is one of the slugs in `apps/web/lib/categories.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Content**
  - Added an entry for Arena by Dravensoft to the website directory.
  - Highlights its React and Angular component libraries, shared Tailwind foundation, accessibility practices, and contract-based consistency.
  - Includes links to the website and `llms.txt` resources, along with developer-tools categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->