### PR TITLE
Add Emisoras de Colombia llms.txt entry

### DIFF
--- a/packages/content/data/websites/emisoras-de-colombia-llms-txt.mdx
+++ b/packages/content/data/websites/emisoras-de-colombia-llms-txt.mdx
@@ -1,0 +1,21 @@
+---
+name: 'Emisoras de Colombia'
+description: 'Directorio de 264 emisoras de radio colombianas en vivo, con ciudad, dial, género y una dirección de escucha estable para cada una.'
+website: 'https://emisorasdecolombia.com'
+llmsUrl: 'https://emisorasdecolombia.com/llms.txt'
+category: 'content-media'
+publishedAt: '2026-08-20'
+---
+
+# Emisoras de Colombia
+
+Directorio de 264 emisoras de radio colombianas en vivo, con su ciudad, dial, género y una
+dirección de escucha estable para cada una.
+
+Además de `llms.txt`, el sitio publica:
+
+- Una versión markdown de cada página, en la misma URL con `.md`
+- El catálogo completo en `/datos/v1/emisoras.json`, con CORS abierto
+- Una especificación OpenAPI en `/openapi.json`
+- Un servidor MCP en `/api/mcp`, registrado en el registro oficial como
+  `com.emisorasdecolombia/radio`


### PR DESCRIPTION
Adds `emisoras-de-colombia-llms-txt.mdx` under `packages/content/data/websites/`.

**Emisoras de Colombia** — a directory of 264 Colombian radio stations, live, with city, dial frequency, genre and a stable listening address for each.

- Website: https://emisorasdecolombia.com
- llms.txt: https://emisorasdecolombia.com/llms.txt
- Category: `content-media`

Beyond llms.txt the site also serves a markdown twin of every page (same URL with `.md`), a CORS-open JSON catalogue at `/datos/v1/emisoras.json`, an OpenAPI spec at `/openapi.json`, and an MCP server at `/api/mcp` published in the official MCP Registry as `com.emisorasdecolombia/radio`.

`llmsFullUrl` is omitted rather than set to an empty string, because the site does not publish an `llms-full.txt` and listing one would point at a 404.

Submitted here because the web form returned "Verification unavailable — we could not safely verify this site right now". The site is reachable: GPTBot, ClaudeBot, PerplexityBot and Googlebot all receive HTTP 200 with the full file, in ~0.5s.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference page for Emisoras de Colombia’s directory of 264 Colombian live radio stations.
  * Documented available machine-readable resources, including Markdown pages, a JSON catalog, an OpenAPI specification, and an MCP server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->