### PR TITLE
Add Epovest

### DIFF
--- a/packages/content/data/websites/epovest-llms-txt.mdx
+++ b/packages/content/data/websites/epovest-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'Epovest'
+description: 'Measures how AI assistants answer the questions your market asks, which sources shape those answers, and where to act.'
+website: 'https://epovest.com'
+llmsUrl: 'https://epovest.com/llms.txt'
+category: 'marketing-sales'
+publishedAt: '2026-08-21'
+---
+
+# Epovest
+
+With Epovest, businesses make AIs recommend them. From the questions their customers ask to the sources that shape the answers, everything is measured, dated and verifiable. And everything leads to action: where to appear, what to fix, and proof of what changed.


### PR DESCRIPTION
Adds Epovest to the directory.

- Website: https://epovest.com
- llms.txt: https://epovest.com/llms.txt (200, ~39 KB, opens on the summary then the sections)
- Category: `marketing-sales`

Epovest measures how AI assistants answer the questions a market asks, which sources shape those answers, and where to act. The llms.txt is generated from the same reference text the site is written from, so it stays in step with the pages.

Happy to adjust the wording or the category if another one fits better.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added an Epovest website listing with publication details, relevant URLs, category information, and a description of its AI recommendation measurement tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->