### PR TITLE
feat(content): add a few apps

### DIFF
--- a/packages/content/data/websites/babyduet-llms-txt.mdx
+++ b/packages/content/data/websites/babyduet-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'babyduet'
+description: 'babyduet is a private iOS baby-name discovery and decision app for partners.'
+website: 'https://babyduet.com'
+llmsUrl: 'https://babyduet.com/llms.txt'
+llmsFullUrl: ''
+category: 'other'
+publishedAt: '2026-08-21'
+---
+
+# babyduet
+
+babyduet is a private iOS baby-name discovery and decision app for partners.

--- a/packages/content/data/websites/beepcrowd-llms-txt.mdx
+++ b/packages/content/data/websites/beepcrowd-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Beepcrowd'
+description: 'Beepcrowd is a store-neutral music release promotion marketplace and education resource for independent artists and labels.'
+website: 'https://www.beepcrowd.com'
+llmsUrl: 'https://www.beepcrowd.com/llms.txt'
+llmsFullUrl: ''
+category: 'marketing-sales'
+publishedAt: '2026-08-21'
+---
+
+# Beepcrowd
+
+Beepcrowd is a store-neutral music release promotion marketplace and education resource for independent artists and labels.

--- a/packages/content/data/websites/coiloop-llms-txt.mdx
+++ b/packages/content/data/websites/coiloop-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'CoiLoop'
+description: 'CoiLoop is subcontractor COI tracking software for general contractors, with document collection, review, expiration tracking, and renewal reminders.'
+website: 'https://www.coiloop.com'
+llmsUrl: 'https://www.coiloop.com/llms.txt'
+llmsFullUrl: ''
+category: 'business-operations'
+publishedAt: '2026-08-21'
+---
+
+# CoiLoop
+
+CoiLoop is subcontractor COI tracking software for general contractors, with document collection, review, expiration tracking, and renewal reminders.

--- a/packages/content/data/websites/colorkind-llms-txt.mdx
+++ b/packages/content/data/websites/colorkind-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'ColorKind'
+description: 'ColorKind is an iPhone and iPad app that creates age-appropriate, print-ready coloring pages from a parent''s idea or chosen photo.'
+website: 'https://www.colorkind.app'
+llmsUrl: 'https://www.colorkind.app/llms.txt'
+llmsFullUrl: 'https://www.colorkind.app/llms-full.txt'
+category: 'other'
+publishedAt: '2026-08-21'
+---
+
+# ColorKind
+
+ColorKind is an iPhone and iPad app that creates age-appropriate, print-ready coloring pages from a parent's idea or chosen photo.

--- a/packages/content/data/websites/duplical-llms-txt.mdx
+++ b/packages/content/data/websites/duplical-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Duplical'
+description: 'Duplical mirrors accepted events that cross a person''s work-life boundary as private blocks on another Google Calendar.'
+website: 'https://www.duplical.app'
+llmsUrl: 'https://www.duplical.app/llms.txt'
+llmsFullUrl: ''
+category: 'automation-workflow'
+publishedAt: '2026-08-21'
+---
+
+# Duplical
+
+Duplical mirrors accepted events that cross a person's work-life boundary as private blocks on another Google Calendar.

--- a/packages/content/data/websites/engraveprep-llms-txt.mdx
+++ b/packages/content/data/websites/engraveprep-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'EngravePrep'
+description: 'EngravePrep is an iPhone and iPad app that prepares photos for laser engraving entirely on-device.'
+website: 'https://www.engraveprep.com'
+llmsUrl: 'https://www.engraveprep.com/llms.txt'
+llmsFullUrl: 'https://www.engraveprep.com/llms-full.txt'
+category: 'other'
+publishedAt: '2026-08-21'
+---
+
+# EngravePrep
+
+EngravePrep is an iPhone and iPad app that prepares photos for laser engraving entirely on-device.

--- a/packages/content/data/websites/keepcardalive-llms-txt.mdx
+++ b/packages/content/data/websites/keepcardalive-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'KeepCardAlive'
+description: 'KeepCardAlive runs automatic micro-charges on unused credit cards to help prevent closure for inactivity.'
+website: 'https://www.keepcardalive.com'
+llmsUrl: 'https://www.keepcardalive.com/llms.txt'
+llmsFullUrl: ''
+category: 'finance-fintech'
+publishedAt: '2026-08-21'
+---
+
+# KeepCardAlive
+
+KeepCardAlive runs automatic micro-charges on unused credit cards to help prevent closure for inactivity.

--- a/packages/content/data/websites/moonrise-moment-llms-txt.mdx
+++ b/packages/content/data/websites/moonrise-moment-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Moonrise Moment'
+description: 'Moonrise Moment is an iPhone app and educational site for planning the next visible moonrise from a specific location.'
+website: 'https://www.moonrisemoment.com'
+llmsUrl: 'https://www.moonrisemoment.com/llms.txt'
+llmsFullUrl: ''
+category: 'data-analytics'
+publishedAt: '2026-08-21'
+---
+
+# Moonrise Moment
+
+Moonrise Moment is an iPhone app and educational site for planning the next visible moonrise from a specific location.

--- a/packages/content/data/websites/pasur-llms-txt.mdx
+++ b/packages/content/data/websites/pasur-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Pâsur'
+description: 'Pâsur is a real-time, two-player iPhone and web app for the classic Persian fishing card game.'
+website: 'https://playpasur.com'
+llmsUrl: 'https://playpasur.com/llms.txt'
+llmsFullUrl: ''
+category: 'content-media'
+publishedAt: '2026-08-21'
+---
+
+# Pâsur
+
+Pâsur is a real-time, two-player iPhone and web app for the classic Persian fishing card game.

--- a/packages/content/data/websites/stencildrop-llms-txt.mdx
+++ b/packages/content/data/websites/stencildrop-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'StencilDrop'
+description: 'StencilDrop is a private, on-device tattoo stencil maker for iPhone and iPad.'
+website: 'https://www.stencildrop.com'
+llmsUrl: 'https://www.stencildrop.com/llms.txt'
+llmsFullUrl: 'https://www.stencildrop.com/llms-full.txt'
+category: 'other'
+publishedAt: '2026-08-21'
+---
+
+# StencilDrop
+
+StencilDrop is a private, on-device tattoo stencil maker for iPhone and iPad.

--- a/packages/content/data/websites/trackdme-llms-txt.mdx
+++ b/packages/content/data/websites/trackdme-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'TrackDME'
+description: 'TrackDME is equipment-tracking software for durable medical equipment and home medical equipment providers.'
+website: 'https://www.trackdme.com'
+llmsUrl: 'https://www.trackdme.com/llms.txt'
+llmsFullUrl: ''
+category: 'business-operations'
+publishedAt: '2026-08-21'
+---
+
+# TrackDME
+
+TrackDME is equipment-tracking software for durable medical equipment and home medical equipment providers.

--- a/packages/content/data/websites/vendorprint-llms-txt.mdx
+++ b/packages/content/data/websites/vendorprint-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'vendorprint'
+description: 'vendorprint is an open-source command-line tool that turns public DNS records into reviewable GTM technology signals.'
+website: 'https://www.vendorprintcli.com'
+llmsUrl: 'https://www.vendorprintcli.com/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-08-21'
+---
+
+# vendorprint
+
+vendorprint is an open-source command-line tool that turns public DNS records into reviewable GTM technology signals.


### PR DESCRIPTION
## Summary

Adds 12 products I maintain:

- ColorKind
- StencilDrop
- Pâsur
- EngravePrep
- babyduet
- Moonrise Moment
- TrackDME
- CoiLoop
- KeepCardAlive
- vendorprint
- Duplical
- Beepcrowd

Each entry uses the product’s canonical website and public `llms.txt` URL. ColorKind, StencilDrop, and EngravePrep also include their public `llms-full.txt` URLs. This is a disclosed owner submission.

## Verification

- [x] All 12 website URLs return HTTP 200
- [x] All 12 `llms.txt` URLs return HTTP 200
- [x] All three declared `llms-full.txt` URLs return HTTP 200
- [x] Frontmatter fields and categories validated locally
- [x] `git diff --check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added 12 new website listings to the directory, including BabyDuet, Beepcrowd, CoiLoop, ColorKind, Duplical, EngravePrep, KeepCardAlive, Moonrise Moment, Pâsur, StencilDrop, TrackDME, and Vendorprint.
  - Each listing now includes its website and AI-readable URL, category, publication date, title, and introductory description.
  - Added content highlighting products such as baby-name planning, coloring pages, calendar mirroring, finance tools, and tattoo stencil creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->