### PR TITLE
Add PennyOCR

### DIFF
--- a/packages/content/data/websites/pennyocr-llms-txt.mdx
+++ b/packages/content/data/websites/pennyocr-llms-txt.mdx
@@ -1,0 +1,17 @@
+---
+name: 'PennyOCR'
+description: 'OCR API for developers and agents: PDFs and images to markdown or plain text at $0.75 per 1,000 pages, with an MCP server and a fully documented agent signup flow.'
+website: 'https://pennyocr.com'
+llmsUrl: 'https://pennyocr.com/llms.txt'
+category: 'developer-tools'
+priority: 'medium'
+publishedAt: '2026-08-21'
+---
+
+# PennyOCR
+
+Great OCR for pennies. POST a document (PDF/PNG/JPEG/WebP/TIFF) and get its full
+contents back as markdown (tables preserved) or plain text. First 100 pages each
+month are free; zero data retention by default. The llms.txt documents the whole
+agent path: MCP server, OpenAI-compatible endpoint, keyless signup steps and
+machine-readable pricing.


### PR DESCRIPTION
This PR adds PennyOCR to the llms.txt hub.

Website: https://pennyocr.com
llms.txt: https://pennyocr.com/llms.txt
Category: developer-tools

PennyOCR is an OCR API (documents → markdown/plain text). Its llms.txt documents the full agent path: MCP server, OpenAI-compatible endpoint, keyless signup flow and plain-text pricing. Disclosure: I'm the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a PennyOCR website entry covering its OCR API, supported document formats, pricing, free usage, data-retention policy, MCP server, compatible endpoint, signup process, and machine-readable pricing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->