### PR TITLE
Add LiMao Travel to llms.txt directory

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -13186,5 +13186,15 @@
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.xugj520.cn&sz=128",
     "publishedAt": "2026-05-31"
+  },
+  {
+    "name": "LiMao Travel",
+    "domain": "https://limaotravel.com",
+    "description": "Customized inbound mainland China tours for overseas Chinese worldwide and travelers from Hong Kong, Macau and Taiwan — 19 destinations, 10 service promises written into the contract, double compensation for service gaps, with real traveler pitfall guides.",
+    "llmsTxtUrl": "https://limaotravel.com/llms.txt",
+    "llmsFullTxtUrl": "https://limaotravel.com/llms-full.txt",
+    "category": "ai-ml",
+    "favicon": "https://www.google.com/s2/favicons?domain=limaotravel.com&sz=128",
+    "publishedAt": "2026-08-22"
   }
 ]


### PR DESCRIPTION
Add [LiMao Travel](https://limaotravel.com) — customized inbound mainland China tours — to the llms.txt directory.

- Name: LiMao Travel
- Domain: https://limaotravel.com
- llms.txt: https://limaotravel.com/llms.txt
- llms-full.txt: https://limaotravel.com/llms-full.txt

The site serves AI-ready documentation (llms.txt + llms-full.txt) for GEO/AI search visibility, with traveler pitfall guides and service commitments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the LiMao Travel website to the directory.
  - Included its travel and tour description, website domain, favicon, AI/ML classification, LLM links, and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->