### PR TITLE
feat: add USDCtoFiat and Peerlytics

### DIFF
--- a/packages/content/data/websites/peerlytics-llms-txt.mdx
+++ b/packages/content/data/websites/peerlytics-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'Peerlytics'
+description: 'The analytics explorer for Peer (peer.xyz) and the ZKP2P protocol. Explorer, orderbook, and an aggregated user liquidity API for developers and AI agents.'
+website: 'https://peerlytics.xyz'
+llmsUrl: 'https://peerlytics.xyz/llms.txt'
+llmsFullUrl: 'https://peerlytics.xyz/llms-full.txt'
+category: 'data-analytics'
+publishedAt: '2026-08-24'
+---
+
+# Peerlytics
+
+The analytics explorer for Peer (peer.xyz) and the ZKP2P protocol. Etherscan-style explorer for P2P deposits, intents, takers, and delegates on Base, a live orderbook, and a paid aggregated user liquidity API with API-key and x402 pay-per-request authentication - built for developers and AI agents.
+
+## Key Focus Areas
+
+- ZKP2P protocol explorer and orderbook
+- Aggregated user liquidity API (REST, OpenAPI, remote MCP server)
+- USDC P2P trading guides
+
+## About llms.txt Implementation
+
+Peerlytics provides `llms.txt` and `llms-full.txt` files with AI-readable information about its explorer, API reference, and developer documentation.

--- a/packages/content/data/websites/usdctofiat-llms-txt.mdx
+++ b/packages/content/data/websites/usdctofiat-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'USDCtoFiat'
+description: 'Non-custodial USDC off-ramp on Base. Convert USDC to USD, EUR, or GBP straight to your bank or payment app via the ZKP2P protocol - no exchange account required.'
+website: 'https://usdctofiat.xyz/usdc-to-fiat/'
+llmsUrl: 'https://usdctofiat.xyz/llms.txt'
+llmsFullUrl: 'https://usdctofiat.xyz/llms-full.txt'
+category: 'finance-fintech'
+publishedAt: '2026-08-24'
+---
+
+# USDCtoFiat
+
+Non-custodial USDC off-ramp and CCTP bridge on Base. Sell USDC for USD, EUR, or GBP straight to a bank account, Venmo, PayPal, Revolut, Wise, or Zelle through the ZKP2P protocol - no exchange account, no custodial deposits. Ships the @usdctofiat/offramp SDK and agent skills for automated cash-out.
+
+## Key Focus Areas
+
+- USDC to fiat conversion guides and payment-method documentation
+- Developer SDK (@usdctofiat/offramp) and agent cash-out skills
+- CCTP bridging to Base
+
+## About llms.txt Implementation
+
+USDCtoFiat provides `llms.txt` and `llms-full.txt` files with AI-readable information about its guides, payment methods, and developer documentation.


### PR DESCRIPTION
Adds two websites that ship both `llms.txt` and `llms-full.txt`:

- **USDCtoFiat** (https://usdctofiat.xyz/usdc-to-fiat/) - non-custodial USDC off-ramp on Base via the ZKP2P protocol. Category: finance-fintech.
- **Peerlytics** (https://peerlytics.xyz) - analytics explorer and liquidity API for the ZKP2P protocol. Category: data-analytics.

Both llms.txt / llms-full.txt URLs return 200:
- https://usdctofiat.xyz/llms.txt / https://usdctofiat.xyz/llms-full.txt
- https://peerlytics.xyz/llms.txt / https://peerlytics.xyz/llms-full.txt

Entries follow the template format under `packages/content/data/websites/`. I operate both sites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added documentation pages for Peerlytics and USDCtoFiat.
  * Peerlytics content covers its explorer, orderbook, liquidity API, key focus areas, and AI-readable documentation.
  * USDCtoFiat content covers non-custodial USDC off-ramps, CCTP bridging, supported currencies and payment services, developer tools, and AI-readable documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->