### PR TITLE
feat(community): add AIHubMix to llms.txt hub

### DIFF
--- a/packages/content/data/websites/aihubmix-llms-txt.mdx
+++ b/packages/content/data/websites/aihubmix-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'AIHubMix'
+description: 'Unified AI model gateway: 500+ models from OpenAI, Anthropic, Google, Qwen and leading open-source providers behind one API key, speaking four wire protocols. Every model ships its own machine-readable llms.txt integration guide.'
+website: 'https://aihubmix.com'
+llmsUrl: 'https://aihubmix.com/llms.txt'
+llmsFullUrl: 'https://aihubmix.com/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-08-24'
+---
+
+# AIHubMix
+
+Unified AI model gateway: 500+ models from OpenAI, Anthropic, Google, Qwen and leading open-source providers behind one API key, speaking four wire protocols (OpenAI Chat Completions & Responses, Anthropic Messages, Google Gemini). Every model has a per-model llms.txt at `/model/{id}/llms.txt` with verified capabilities, pricing and runnable examples, plus an agent onboarding guide at `/agents.md`.


### PR DESCRIPTION
Adds AIHubMix (https://aihubmix.com) — a unified AI model gateway (500+ models from OpenAI, Anthropic, Google, Qwen and open-source providers behind one API key, four wire protocols).

llms.txt: https://aihubmix.com/llms.txt
llms-full.txt: https://aihubmix.com/llms-full.txt (all verified per-model guides in one file)
Agent onboarding: https://aihubmix.com/agents.md
Per-model guides: https://aihubmix.com/model/{id}/llms.txt

Category: ai-ml. Both files return 200 with text/plain and follow the llms.txt spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AIHubMix to the website directory with metadata, access links, publication details, and category information.
  * Included an overview of its unified multi-provider API and model-specific integration documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->