### PR TITLE
feat: add Claude Network

### DIFF
--- a/packages/content/data/websites/claude-network-llms-txt.mdx
+++ b/packages/content/data/websites/claude-network-llms-txt.mdx
@@ -1,0 +1,14 @@
+---
+name: Claude Network
+description: Independent tracker of the Claude ecosystem - status incidents, usage limits and releases, each with a date and a source.
+website: https://claudenetwork.com
+llmsUrl: https://claudenetwork.com/llms.txt
+llmsFullUrl:
+category: developer-tools
+publishedAt: 2026-08-24
+priority: medium
+---
+
+# Claude Network — a dated archive of the Claude ecosystem
+
+Claude Network tracks Claude status, usage limits and releases, turning each change into a permanent page with a date and a link to the source. The llms.txt file is generated from live database content rather than hand-written, so it stays current as pages are added. Not affiliated with Anthropic.

--- a/packages/content/data/websites/claude-network-llms-txt.mdx
+++ b/packages/content/data/websites/claude-network-llms-txt.mdx
@@ -5,7 +5,7 @@ website: https://claudenetwork.com
 llmsUrl: https://claudenetwork.com/llms.txt
 llmsFullUrl:
 category: developer-tools
-publishedAt: 2026-08-24
+publishedAt: '2026-08-24'
 priority: medium
 ---
 


### PR DESCRIPTION
Adds Claude Network, an independent tracker of the Claude ecosystem. The llms.txt is generated from live database content rather than hand-written.

- llms.txt verified live: https://claudenetwork.com/llms.txt
- No llms-full.txt, field left empty
- Category: developer-tools

Did not touch data/websites.json per CONTRIBUTING.md.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Content**
  * Added a website entry for the Claude Network, including metadata, links, publication details, category, priority, and a description of its Claude ecosystem archive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->