### PR TITLE
feat: add StackerScan website entry

### DIFF
--- a/packages/content/data/websites/stackerscan-llms-txt.mdx
+++ b/packages/content/data/websites/stackerscan-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'StackerScan'
+description: 'Precious-metals stack tracker with live spot prices, historical charts, observed dealer premiums, and a fully open no-auth read API for agents.'
+website: 'https://www.stackerscan.com'
+llmsUrl: 'https://www.stackerscan.com/llms.txt'
+category: 'finance-fintech'
+publishedAt: '2026-08-24'
+---
+
+# StackerScan
+
+Precious-metals stack tracker with live spot prices, historical charts, observed dealer premiums, and a fully open no-auth read API for agents.


### PR DESCRIPTION
Adds StackerScan to the websites directory.

- **Website**: https://www.stackerscan.com
- **llms.txt**: https://www.stackerscan.com/llms.txt (live, plain-text, follows the llms.txt conventions)
- **Category**: finance-fintech
- StackerScan also publishes markdown twins for its main pages and a fully open (no auth, CORS `*`) OpenAPI 3.1 read API at https://www.stackerscan.com/openapi.json — all indexed from the llms.txt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added StackerScan to the website directory.
  * Included its description, category, website link, AI resource link, publish date, and summary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->