### PR TITLE
Add FireApproved

### DIFF
--- a/packages/content/data/websites/fireapproved-llms-txt.mdx
+++ b/packages/content/data/websites/fireapproved-llms-txt.mdx
@@ -3,6 +3,7 @@ name: 'FireApproved'
 description: 'Citation directory for wildfire-resistant construction and plants — product listings, WUI code adoption, and plant-flammability evidence, every status linked to its source.'
 website: 'https://fireapproved.com'
 llmsUrl: 'https://fireapproved.com/llms.txt'
+llmsFullUrl: 'https://fireapproved.com/llms-full.txt'
 category: 'data-analytics'
 publishedAt: '2026-08-25'
 ---
@@ -20,4 +21,4 @@ FireApproved is a static citation directory for wildfire-resistant construction 
 
 ## About llms.txt Implementation
 
-FireApproved's llms.txt lists the canonical entry points (methodology, findings, plants, materials, states, requirements) as markdown links per the spec. Every public entity also publishes a static JSON twin: the `.json` replaces the page's trailing slash, so `/plants/{id}/` is served as JSON at `/plants/{id}.json`. Assistants can retrieve structured, sourced records directly.
+FireApproved's llms.txt lists the canonical entry points (methodology, findings, plants, materials, states, requirements) as markdown links per the spec. Every public entity also publishes a static JSON twin: the `.json` replaces the page's trailing slash, so `/plants/{id}/` is served as JSON at `/plants/{id}.json`. Assistants can retrieve structured, sourced records directly. `llms-full.txt` expands the index with every guide and dataset description and the full glossary.

--- a/packages/content/data/websites/fireapproved-llms-txt.mdx
+++ b/packages/content/data/websites/fireapproved-llms-txt.mdx
@@ -9,15 +9,15 @@ publishedAt: '2026-08-25'
 
 # FireApproved
 
-FireApproved is a static citation directory for wildfire-resistant construction and plant flammability: about 4,650 pages across materials, plants, states, and guides. Every status and claim links to the source document it came from, and the site issues no ratings of its own — the evidence is the product.
+FireApproved is a static citation directory for wildfire-resistant construction and plant flammability: about 7,200 pages across materials, plants, states, and guides. Every status and claim links to the source document it came from, and the site issues no ratings of its own — the evidence is the product.
 
 ## Key Focus Areas
 
 - Materials — listed and tested home-hardening products (OSFM Building Materials Listing, ICC-ES reports, ASTM test protocols) with listing IDs and source URLs
-- Plants — 2,123 plants carrying 5,008 flammability evidence rows, with classifications computed from the evidence by a published method
+- Plants — 3,801 plants carrying 26,878 flammability evidence rows, with classifications computed from the evidence by a published method
 - States and requirements — WUI code adoption status (for example ORSC R327) cited to the ordinance or the state list
 - Open data — CC BY 4.0 datasets, with a static JSON twin for every public entity
 
 ## About llms.txt Implementation
 
-FireApproved's llms.txt lists the canonical entry points (methodology, findings, plants, materials, states, requirements) as markdown links per the spec. Every public entity also publishes a static JSON twin at the same URL plus `.json`, so assistants can retrieve structured, sourced records directly.
+FireApproved's llms.txt lists the canonical entry points (methodology, findings, plants, materials, states, requirements) as markdown links per the spec. Every public entity also publishes a static JSON twin: the `.json` replaces the page's trailing slash, so `/plants/{id}/` is served as JSON at `/plants/{id}.json`. Assistants can retrieve structured, sourced records directly.

--- a/packages/content/data/websites/fireapproved-llms-txt.mdx
+++ b/packages/content/data/websites/fireapproved-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'FireApproved'
+description: 'Citation directory for wildfire-resistant construction and plants — product listings, WUI code adoption, and plant-flammability evidence, every status linked to its source.'
+website: 'https://fireapproved.com'
+llmsUrl: 'https://fireapproved.com/llms.txt'
+category: 'data-analytics'
+publishedAt: '2026-08-25'
+---
+
+# FireApproved
+
+FireApproved is a static citation directory for wildfire-resistant construction and plant flammability: about 4,650 pages across materials, plants, states, and guides. Every status and claim links to the source document it came from, and the site issues no ratings of its own — the evidence is the product.
+
+## Key Focus Areas
+
+- Materials — listed and tested home-hardening products (OSFM Building Materials Listing, ICC-ES reports, ASTM test protocols) with listing IDs and source URLs
+- Plants — 2,123 plants carrying 5,008 flammability evidence rows, with classifications computed from the evidence by a published method
+- States and requirements — WUI code adoption status (for example ORSC R327) cited to the ordinance or the state list
+- Open data — CC BY 4.0 datasets, with a static JSON twin for every public entity
+
+## About llms.txt Implementation
+
+FireApproved's llms.txt lists the canonical entry points (methodology, findings, plants, materials, states, requirements) as markdown links per the spec. Every public entity also publishes a static JSON twin at the same URL plus `.json`, so assistants can retrieve structured, sourced records directly.


### PR DESCRIPTION
Adds FireApproved (https://fireapproved.com), a citation directory for wildfire-resistant construction and plants.

- llms.txt: https://fireapproved.com/llms.txt (canonical entry points as markdown links per the spec)
- Every public entity also has a static JSON twin (same URL + .json)
- Structured data is CC BY 4.0

Category: data-analytics. Entry follows the existing MDX template; no llms-full.txt yet, so that field is omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a FireApproved `llms.txt` metadata page and linked `llms-full.txt`.
  * Documented citation resources covering wildfire-resistant construction, plant flammability, materials, WUI requirements, and open datasets.
  * Clarified that the full text file includes every guide, dataset description, and the complete glossary.
  * Listed canonical Markdown resources and corresponding JSON versions for public entities.
  * Updated page and plant evidence counts and clarified `.json` plant URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->