### PR TITLE
Add Try Apify

### DIFF
--- a/packages/content/data/websites/tryapify-llms-txt.mdx
+++ b/packages/content/data/websites/tryapify-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Try Apify'
+description: 'Independent directory of 1,900+ tested Apify actors (web scrapers) with real pricing, user counts, and reviews, plus tutorials and comparisons.'
+website: 'https://tryapify.com/'
+llmsUrl: 'https://tryapify.com/llms.txt'
+llmsFullUrl: 'https://tryapify.com/llms-full.txt'
+category: 'data-analytics'
+publishedAt: '2026-08-24'
+---
+
+# Try Apify
+
+Independent directory of 1,900+ tested Apify actors (web scrapers) with real pricing, user counts, and reviews, plus tutorials and comparisons.


### PR DESCRIPTION
This PR adds Try Apify to the llms.txt hub.

Website: https://tryapify.com
llms.txt: https://tryapify.com/llms.txt
llms-full.txt: https://tryapify.com/llms-full.txt
Category: data-analytics

Try Apify is an independent directory of 1,900+ tested Apify actors (web scrapers) with real pricing, user counts, and reviews. Both llms.txt files are live and refreshed automatically from platform data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Content**
  - Added the Try Apify website to the directory.
  - Included its URLs, category, publication date, and introductory description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->