### PR TITLE
Add Clear

### DIFF
--- a/packages/content/data/websites/clear-agent-fetch-llms-txt.mdx
+++ b/packages/content/data/websites/clear-agent-fetch-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'Clear'
+description: 'Pay $0.005 USDC on Base for one public URL as markdown. Fail is free. No local browser.'
+website: 'https://clear-agent-fetch.fly.dev'
+llmsUrl: 'https://clear-agent-fetch.fly.dev/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-25'
+---
+
+# Clear
+
+Pay $0.005 USDC on Base for one public URL as markdown. Fail is free. No local browser.


### PR DESCRIPTION
Adds [Clear](https://clear-agent-fetch.fly.dev) `llms.txt` (`https://clear-agent-fetch.fly.dev/llms.txt`). Live x402 API: POST `/v1/fetch` returns a public URL as markdown for $0.005 USDC on Base. Fail is free.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added a directory listing entry for the Clear website, including its description, website link, and llms.txt resource.
  * Included category metadata and publication details for improved discoverability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->