### PR TITLE
feat(websites): add Mnemoverse

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -7591,16 +7591,6 @@
     "publishedAt": "2024-12-01"
   },
   {
-    "name": "Mnemoverse",
-    "domain": "https://mnemoverse.com",
-    "description": "Persistent memory API for AI agents, shared across Claude Code, Cursor, VS Code and ChatGPT over MCP",
-    "llmsTxtUrl": "https://mnemoverse.com/docs/llms.txt",
-    "llmsFullTxtUrl": "https://mnemoverse.com/docs/llms-full.txt",
-    "category": "ai-ml",
-    "favicon": "https://www.google.com/s2/favicons?domain=mnemoverse.com&sz=128",
-    "publishedAt": "2026-08-25"
-  },
-  {
     "name": "Mobile Kitchen Rental Leader",
     "domain": "https://www.mobileculinaire.com/",
     "description": "Mobile Culinaire Is A Leading US Mobile Kitchen Rental Provider. Our Units Are Ready-To-Use, Commercial-Grade, And Built To Code. FAST QUOTE.",

--- a/data/websites.json
+++ b/data/websites.json
@@ -7591,6 +7591,16 @@
     "publishedAt": "2024-12-01"
   },
   {
+    "name": "Mnemoverse",
+    "domain": "https://mnemoverse.com",
+    "description": "Persistent memory API for AI agents, shared across Claude Code, Cursor, VS Code and ChatGPT over MCP",
+    "llmsTxtUrl": "https://mnemoverse.com/docs/llms.txt",
+    "llmsFullTxtUrl": "https://mnemoverse.com/docs/llms-full.txt",
+    "category": "ai-ml",
+    "favicon": "https://www.google.com/s2/favicons?domain=mnemoverse.com&sz=128",
+    "publishedAt": "2026-08-25"
+  },
+  {
     "name": "Mobile Kitchen Rental Leader",
     "domain": "https://www.mobileculinaire.com/",
     "description": "Mobile Culinaire Is A Leading US Mobile Kitchen Rental Provider. Our Units Are Ready-To-Use, Commercial-Grade, And Built To Code. FAST QUOTE.",

--- a/packages/content/data/websites/mnemoverse-llms-txt.mdx
+++ b/packages/content/data/websites/mnemoverse-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Mnemoverse'
+description: 'Persistent memory API for AI agents, shared across Claude Code, Cursor, VS Code and ChatGPT over MCP.'
+website: 'https://mnemoverse.com'
+llmsUrl: 'https://mnemoverse.com/docs/llms.txt'
+llmsFullUrl: 'https://mnemoverse.com/docs/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-08-25'
+---
+
+# Mnemoverse
+
+Persistent memory API for AI agents, shared across Claude Code, Cursor, VS Code and ChatGPT over MCP.


### PR DESCRIPTION
## What

Adds Mnemoverse to `data/websites.json`, inserted in alphabetical order between Mixo and Mobile Kitchen Rental Leader.

## The site

Mnemoverse is a persistent memory API for AI agents: one memory reachable over MCP from Claude Code, Cursor, VS Code and ChatGPT, so what an agent learns in one tool is there in the next.

| | |
|---|---|
| `llms.txt` | https://mnemoverse.com/docs/llms.txt — 30 KB |
| `llms-full.txt` | https://mnemoverse.com/docs/llms-full.txt — 1.9 MB |
| Category | `ai-ml` |

## Verification

Both files return HTTP 200 today. Every one of the 114 links inside `llms.txt` was fetched and resolves 200, with a single known redirect (`/llms-full.txt` → `/docs/llms-full.txt`, 301).

Disclosure: I work on Mnemoverse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a website entry for Mnemoverse.
  * Included metadata, documentation links, publication date, and an overview of its persistent-memory API for AI agents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->