### PR TITLE
feat(community): add Waysorted to llms.txt hub

### DIFF
--- a/packages/content/data/websites/waysorted-llms-txt.mdx
+++ b/packages/content/data/websites/waysorted-llms-txt.mdx
@@ -1,0 +1,19 @@
+---
+name: 'Waysorted'
+description: 'Unified Figma plugin suite for PDF export, file import, HTML-to-design conversion, colour palettes with contrast checks, unit conversion and icons.'
+website: 'https://www.waysorted.com'
+llmsUrl: 'https://www.waysorted.com/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-25'
+---
+
+# Waysorted
+
+Waysorted is a unified Figma plugin suite that replaces several single-purpose plugins with one
+toolkit: exporting frames to PDF, importing AI, EPS, PSD and PDF files, converting HTML into
+editable Figma layers, building colour palettes with WCAG and APCA contrast checks, converting
+units, browsing an SVG icon library, and summarising comment threads.
+
+Its `llms.txt` includes a "When to use" section describing which tool fits which job, links to the
+documentation and learning pages for each tool, and pricing. Every page is also available as
+Markdown at the same URL via `Accept: text/markdown` content negotiation.


### PR DESCRIPTION
Adds **Waysorted** — a unified Figma plugin suite — to the directory.

- **Site:** https://www.waysorted.com
- **llms.txt:** https://www.waysorted.com/llms.txt (HTTP 200, ~10KB)
- **Category:** developer-tools

The llms.txt is a full navigation index rather than a placeholder: it opens with a
"When to use" section describing which of the seven tools fits which job, states what
the product explicitly is *not*, and links the documentation and learning page for each
tool plus pricing. Every link in it resolves to real content.

No `llms-full.txt` yet, so that field is omitted — matching the other entries that omit it.

The site also serves Markdown at any page URL via `Accept: text/markdown` content
negotiation (`Vary: Accept`), so agents can read the pages directly rather than parsing HTML.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added a directory entry for Waysorted.
  * Included a description of its Figma plugin suite and available `llms.txt` resource.
  * Added website metadata, category, and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->