### PR TITLE
Add defend.network

### DIFF
--- a/packages/content/data/websites/defend-network-llms-txt.mdx
+++ b/packages/content/data/websites/defend-network-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'defend.network'
+description: 'Free, no-login cybersecurity intelligence: daily AI threat briefings and weekly vulnerability reports, every CVE verified against NVD and the CISA KEV catalog.'
+website: 'https://defend.network'
+llmsUrl: 'https://defend.network/llms.txt'
+llmsFullUrl: ''
+category: 'security-identity'
+publishedAt: '2026-08-25'
+---
+
+# defend.network
+
+Free, no-login cybersecurity intelligence: daily AI-generated threat briefings and weekly vulnerability reports, with every CVE cross-checked against NVD and the CISA KEV catalog, structured by threat type, industry, and severity.


### PR DESCRIPTION
Adds **defend.network** to the Security & Identity category.

defend.network is a free, no-login cybersecurity intelligence site: daily AI-generated threat briefings and weekly vulnerability reports, with every CVE cross-checked against NVD and the CISA KEV catalog. It publishes a well-formed llms.txt with citation guidance.

- Website: https://defend.network
- llms.txt: https://defend.network/llms.txt
- Category: security-identity

Adds a single `.mdx` file under `packages/content/data/websites/` per CONTRIBUTING (websites.json left untouched).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added defend.network to the websites directory.
  * Included details about its free cybersecurity intelligence service, daily AI threat briefings, and weekly vulnerability reports.
  * Added its website link, llms.txt resource, category, description, and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->