### PR TITLE
feat(community): add OzCalc to llms.txt hub

### DIFF
--- a/packages/content/data/websites/ozcalc-llms-txt.mdx
+++ b/packages/content/data/websites/ozcalc-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'OzCalc'
+description: 'Australian tax, property and superannuation calculators. Every calculator publishes its formula, its current rate tables, the government source each rate came from, and the date that rate was last verified.'
+website: 'https://ozcalc.com.au'
+llmsUrl: 'https://ozcalc.com.au/llms.txt'
+llmsFullUrl: ''
+category: 'finance-fintech'
+publishedAt: '2026-08-26'
+---
+
+# OzCalc
+
+Independent Australian tax, property and superannuation calculators — income tax and take-home
+pay, PAYG withholding, GST, capital gains, HECS, super contributions, salary sacrifice, land tax
+and stamp duty for every mainland state.
+
+Every rate, bracket and threshold is stored as versioned data tagged with the government page it
+came from and the date it was last verified, and every calculation engine is regression-tested
+against worked examples the relevant authority itself published (ATO bracket and withholding
+tables, state revenue office calculators) before it ships. No quote walls, no sign-ups, no lead
+generation.
+
+The `llms.txt` file lists each calculator with what it covers, the methodology statement, and the
+sourcing rule the whole site follows.


### PR DESCRIPTION
## Summary

Adds OzCalc (https://ozcalc.com.au), a set of independent Australian tax, property and superannuation calculators, under `finance-fintech`. Its llms.txt is live at https://ozcalc.com.au/llms.txt and lists every calculator with what it covers, plus the site's methodology and sourcing rule.

Single new file: `packages/content/data/websites/ozcalc-llms-txt.mdx`. `data/websites.json` is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference page for the OzCalc website and its Australian tax, property, and superannuation calculators.
  * Documented government-sourced rates, verification dates, regression testing, and available calculator listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->