### PR TITLE
feat(websites): add Supermem

### DIFF
--- a/packages/content/data/websites/supermem-llms-txt.mdx
+++ b/packages/content/data/websites/supermem-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Supermem'
+description: 'Private, persistent memory for AI coding agents over MCP. Save decisions in one agent and recall them in another.'
+website: 'https://supermem.cloud/'
+llmsUrl: 'https://supermem.cloud/llms.txt'
+llmsFullUrl: 'https://supermem.cloud/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-26'
+---
+
+# Supermem
+
+Supermem gives Codex, GitHub Copilot, Claude Code, OpenCode, Cursor, Antigravity, and any MCP-compatible client one shared memory across sessions.
+
+## Key Focus Areas
+
+- Private, per-user memory for AI coding agents
+- Cross-session recall over Streamable HTTP MCP
+- Project-scoped preferences, decisions, and debugging context
+- Setup guides for OpenCode, Claude Code, and other MCP clients
+
+## About llms.txt Implementation
+
+Supermem publishes a concise `llms.txt` index and a complete `llms-full.txt` reference with setup instructions, MCP tool schemas, security rules, and troubleshooting.


### PR DESCRIPTION
## Summary

Add Supermem, a private persistent-memory service for AI coding agents over MCP, with verified `llms.txt` and `llms-full.txt` resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a website entry for Supermem.
  * Documented its persistent memory service for AI coding agents, supported MCP clients, focus areas, relevant links, publication details, and available documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->