### PR TITLE
Add cc8.cc

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -13186,5 +13186,14 @@
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.xugj520.cn&sz=128",
     "publishedAt": "2026-05-31"
+  },
+  {
+    "name": "C位 · cc8.cc",
+    "domain": "https://www.cc8.cc",
+    "description": "Public pay-to-rank product leaderboard — rank is your bid, ¥1 entry, and every amount on the board resets to ¥1 at 00:00 Beijing time daily. Bilingual (zh/en) with self-contained Markdown mirrors for every category board.",
+    "llmsTxtUrl": "https://www.cc8.cc/llms.txt",
+    "category": "developer-tools",
+    "favicon": "https://www.google.com/s2/favicons?domain=www.cc8.cc&sz=128",
+    "publishedAt": "2026-08-26"
   }
 ]

--- a/packages/content/data/websites/cc8-cc-llms-txt.mdx
+++ b/packages/content/data/websites/cc8-cc-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'C位 · cc8.cc'
+description: 'Public pay-to-rank product leaderboard — rank is your bid, ¥1 entry, and every amount on the board resets to ¥1 at 00:00 Beijing time daily. Bilingual (zh/en) with self-contained Markdown mirrors for every category board.'
+website: 'https://www.cc8.cc'
+llmsUrl: 'https://www.cc8.cc/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-08-26'
+---
+
+# C位 · cc8.cc
+
+A fully public product leaderboard starting at ¥1 with a daily drop-the-handkerchief reset. Pin a money amount on an App Store app, a website, or an X handle — that amount is its rank. Every day at 00:00 Beijing time all amounts reset to ¥1 (nobody is delisted, every seat reopens); at a tie the newer bid ranks ahead. Settlement via WeChat Pay; paid links are rel=sponsored; llms.txt is bilingual (zh/en) and links self-contained Markdown mirrors of all 16 category boards.


### PR DESCRIPTION
Adding https://www.cc8.cc — a public pay-to-rank product leaderboard with a bilingual (zh/en) llms.txt and self-contained Markdown mirrors for every category board (e.g. https://www.cc8.cc/md/zh/category/developer-tools.md).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added C位 · cc8.cc to the website directory with its description, category, favicon, publication date, and `llms.txt` link.
  * Added detailed bilingual information covering leaderboard rules, daily reset timing, bidding and tie-ranking behavior, payment settlement, sponsored-link labels, and Markdown mirrors for 16 category boards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->