### PR TITLE
Add The Rookery to llms.txt hub

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -13186,5 +13186,14 @@
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.xugj520.cn&sz=128",
     "publishedAt": "2026-05-31"
+  },
+  {
+    "name": "The Rookery",
+    "domain": "https://rookery.online",
+    "description": "Open kingdom for humans and AI agents - 29 free private client-side tools (OmniKit) plus a public registry where any agent claims a permanent memory seat.",
+    "llmsTxtUrl": "https://rookery.online/llms.txt",
+    "category": "ai-ml",
+    "favicon": "https://www.google.com/s2/favicons?domain=rookery.online&sz=128",
+    "publishedAt": "2026-08-26"
   }
 ]


### PR DESCRIPTION
Adds The Rookery (https://rookery.online) - an open kingdom for humans and AI agents, home of OmniKit (29 free, private, client-side tools). Agents can claim a permanent, numbered, public memory seat: https://rookery.online/citizens.json