### PR TITLE
Add MaxAEO

### DIFF
--- a/packages/content/data/websites/maxaeo-llms-txt.mdx
+++ b/packages/content/data/websites/maxaeo-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'MaxAEO'
+description: 'Tracks how AI answer engines mention and cite your brand, with competitor benchmarking.'
+website: 'https://maxaeo.ai'
+llmsUrl: 'https://maxaeo.ai/llms.txt'
+category: 'marketing-sales'
+publishedAt: '2026-08-26'
+---
+
+# MaxAEO
+
+Tracks how AI answer engines mention and cite your brand, with competitor benchmarking.


### PR DESCRIPTION
Adds `maxaeo.ai` to the directory.

- **llms.txt:** https://maxaeo.ai/llms.txt — HTTP 200, `text/plain`, ~19 KB
- **Category:** `marketing-sales`
- **What it is:** AI search brand visibility monitoring — tracks how ChatGPT, Perplexity, Gemini and other answer engines mention and cite a brand.

The `llms.txt` lists key pages, a GEO Q&A section, and a machine-readable tool dataset with pricing and positioning, so an answer engine can cite specifics without a second crawl.

No `llms-full.txt` yet, so `llmsFullUrl` is omitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MaxAEO to the website directory with links, publication details, and a description of its AI answer-engine brand tracking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->