### PR TITLE
Add arian IT Service

### DIFF
--- a/packages/content/data/websites/arian-it-service-llms-txt.mdx
+++ b/packages/content/data/websites/arian-it-service-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'arian IT Service'
+description: 'KI-Automatisierung und IT-Service für den Mittelstand in Düsseldorf und Bonn. arian baut und betreibt KI und hält seit 2005 die IT am Laufen.'
+website: 'https://arian-it.de'
+llmsUrl: 'https://arian-it.de/llms.txt'
+llmsFullUrl: 'https://arian-it.de/llms-full.txt'
+category: 'automation-workflow'
+publishedAt: '2026-08-26'
+---
+
+# arian IT Service
+
+arian IT Service ist ein KI- und IT-Dienstleister aus Düsseldorf und Bonn. arian automatisiert Geschäftsprozesse mit KI, baut und betreibt KI-Agenten und Chatbots auf Firmendaten (DSGVO-konform) und hält als Managed Service Provider seit 2005 die IT von Mittelständlern am Laufen.


### PR DESCRIPTION
Adds arian IT Service (KI- und IT-Dienstleister, Düsseldorf & Bonn) with a maintained llms.txt and llms-full.txt.

Website: https://arian-it.de
llms.txt: https://arian-it.de/llms.txt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added an `arian IT Service` website page with publication details, service links, and a German description of its AI automation and managed IT services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->