### PR TITLE
feat(community): add simplelogin-mcp to llms.txt hub

### DIFF
--- a/packages/content/data/websites/simplelogin-mcp-llms-txt.mdx
+++ b/packages/content/data/websites/simplelogin-mcp-llms-txt.mdx
@@ -1,0 +1,22 @@
+---
+name: 'simplelogin-mcp'
+description: 'An independent, self-hostable MCP server for existing SimpleLogin users to manage aliases, contacts, mailboxes, and account settings.'
+website: 'https://simplelogin-mcp.com'
+llmsUrl: 'https://simplelogin-mcp.com/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-27'
+---
+
+# simplelogin-mcp
+
+An independent, self-hostable MCP server for existing SimpleLogin users. It lets an MCP client manage aliases, contacts, mailboxes, custom domains, notifications, and account settings through the SimpleLogin API, running locally over stdio or as a Streamable HTTP service.
+
+## Key Focus Areas
+
+- Alias, contact, and mailbox management through the SimpleLogin API
+- Local stdio or self-hosted Streamable HTTP transport
+- API key read from environment, scoped only to the SimpleLogin API origin
+
+## About llms.txt Implementation
+
+simplelogin-mcp publishes llms.txt covering installation, client setup, API coverage, and the full MCP tool catalog, so agents can configure and operate the server without scraping the docs site.


### PR DESCRIPTION
Adds simplelogin-mcp under developer-tools.

An independent, self-hostable MCP server for existing SimpleLogin users to manage aliases, contacts, mailboxes, custom domains, notifications, and account settings. llms.txt at https://simplelogin-mcp.com/llms.txt. New .mdx only, data/websites.json untouched per the contributing guide.

Disclosure: I am the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an llms.txt entry for the SimpleLogin MCP server.
  * Documented supported management capabilities, connection transports, API-key handling, and coverage details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->