### PR TITLE
feat(community): add trello-mcp to llms.txt hub

### DIFF
--- a/packages/content/data/websites/trello-mcp-llms-txt.mdx
+++ b/packages/content/data/websites/trello-mcp-llms-txt.mdx
@@ -3,6 +3,7 @@ name: 'trello-mcp'
 description: 'A self-hosted, auditable Model Context Protocol server for broad Trello automation.'
 website: 'https://trello-mcp.com'
 llmsUrl: 'https://trello-mcp.com/llms.txt'
+llmsFullUrl: 'https://trello-mcp.com/llms-full.txt'
 category: 'developer-tools'
 publishedAt: '2026-08-27'
 ---

--- a/packages/content/data/websites/trello-mcp-llms-txt.mdx
+++ b/packages/content/data/websites/trello-mcp-llms-txt.mdx
@@ -3,7 +3,6 @@ name: 'trello-mcp'
 description: 'A self-hosted, auditable Model Context Protocol server for broad Trello automation.'
 website: 'https://trello-mcp.com'
 llmsUrl: 'https://trello-mcp.com/llms.txt'
-llmsFullUrl: 'https://trello-mcp.com/llms-full.txt'
 category: 'developer-tools'
 publishedAt: '2026-08-27'
 ---

--- a/packages/content/data/websites/trello-mcp-llms-txt.mdx
+++ b/packages/content/data/websites/trello-mcp-llms-txt.mdx
@@ -1,0 +1,22 @@
+---
+name: 'trello-mcp'
+description: 'A self-hosted, auditable Model Context Protocol server for broad Trello automation.'
+website: 'https://trello-mcp.com'
+llmsUrl: 'https://trello-mcp.com/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-27'
+---
+
+# trello-mcp
+
+A self-hosted, auditable Model Context Protocol server for broad Trello automation. It is an independent, community-maintained project, not affiliated with or endorsed by Trello or Atlassian, and runs over stdio or Streamable HTTP.
+
+## Key Focus Areas
+
+- 77 Trello MCP tools covering boards, cards, checklists, and workflow automation
+- Self-hosted stdio or Streamable HTTP transport with Docker Compose support
+- Auditable, open-source design with a documented security and data-flow model
+
+## About llms.txt Implementation
+
+trello-mcp publishes llms.txt covering installation, client setup, API coverage, and the full 77-tool catalog, so agents can configure and operate the server without scraping the docs site.


### PR DESCRIPTION
Adds trello-mcp under developer-tools.

A self-hosted, auditable Model Context Protocol server for broad Trello automation, independent and community-maintained. llms.txt at https://trello-mcp.com/llms.txt. New .mdx only, data/websites.json untouched per the contributing guide.

Disclosure: I am the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a website listing for Trello MCP.
  - Included details about its Trello automation tools, transport options, self-hosted setup, and `llms.txt` support.
  - Added relevant metadata, including category, website URL, documentation URL, full documentation URL, and publication date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->