### PR TITLE
feat(community): add antoinemenard.com to llms.txt hub

### DIFF
--- a/packages/content/data/websites/antoine-menard-llms-txt.mdx
+++ b/packages/content/data/websites/antoine-menard-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'Antoine Menard'
+description: 'Engineering manager and technical leader with 15+ years spanning product engineering, people leadership, performance, reliability, and quality.'
+website: 'https://www.antoinemenard.com'
+llmsUrl: 'https://www.antoinemenard.com/llms.txt'
+llmsFullUrl: 'https://www.antoinemenard.com/llms-full.txt'
+category: 'personal'
+publishedAt: '2026-08-27'
+---
+
+# Antoine Menard
+
+Antoine Menard is an engineering manager and technical leader with a 15+ year career spanning hands-on product engineering, people leadership, performance, reliability, and product quality.
+
+## Key Focus Areas
+
+- Engineering leadership and team management
+- Product engineering and reliability
+- Performance and product quality
+
+## About llms.txt Implementation
+
+antoinemenard.com publishes llms.txt and llms-full.txt summarizing background, focus areas, and contact details for agents referencing the site.

--- a/packages/content/data/websites/antoine-menard-llms-txt.mdx
+++ b/packages/content/data/websites/antoine-menard-llms-txt.mdx
@@ -1,5 +1,5 @@
 ---
-name: 'Antoine Menard'
+name: 'Antoine Ménard'
 description: 'Engineering manager and technical leader with 15+ years spanning product engineering, people leadership, performance, reliability, and quality.'
 website: 'https://www.antoinemenard.com'
 llmsUrl: 'https://www.antoinemenard.com/llms.txt'
@@ -8,9 +8,9 @@ category: 'personal'
 publishedAt: '2026-08-27'
 ---
 
-# Antoine Menard
+# Antoine Ménard
 
-Antoine Menard is an engineering manager and technical leader with a 15+ year career spanning hands-on product engineering, people leadership, performance, reliability, and product quality.
+Antoine Ménard is an engineering manager and technical leader with a 15+ year career spanning hands-on product engineering, people leadership, performance, reliability, and product quality.
 
 ## Key Focus Areas
 


### PR DESCRIPTION
Adds antoinemenard.com under personal.

Antoine Menard's personal site: engineering manager and technical leader with a 15+ year career spanning product engineering, people leadership, performance, reliability, and quality. llms.txt at https://www.antoinemenard.com/llms.txt (llms-full.txt also available). New .mdx only, data/websites.json untouched per the contributing guide.

Disclosure: I am the author.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Content**
  * Added a profile page for Antoine Ménard with professional background, focus areas, and site metadata.
  * Included references to the site’s `llms.txt` and `llms-full.txt` resources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->