### PR TITLE
Add github-morestar-skill: open-source GitHub star growth playbook + GEO/SEO

### DIFF
--- a/packages/content/data/websites/github-morestar-skill-llms-txt.mdx
+++ b/packages/content/data/websites/github-morestar-skill-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'github-morestar-skill'
+description: 'AI skill: grow GitHub stars for open-source projects — positioning, README landing-page, one concentrated multi-channel Launch Day (Hacker News / Product Hunt / Reddit / awesome-lists / 知乎/CSDN/掘金), retention, plus a GEO/SEO long-tail engine (llms.txt, GitHub Pages, AI citation, directories). Chinese-first, illustrated, with 2026 platform rules and copy-paste templates.'
+website: 'https://everest-an.github.io/github-morestar-skill'
+llmsUrl: 'https://everest-an.github.io/github-morestar-skill/llms.txt'
+llmsFullUrl: 'https://everest-an.github.io/github-morestar-skill/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-08-28'
+---
+
+# github-morestar-skill
+
+Open-source AI skill (MIT) that turns "grow my GitHub stars" into a systematic 4-step playbook: positioning & business-model diagnosis → README-as-landing-page polish → ONE concentrated multi-channel Launch Day (Hacker News Show HN, Product Hunt, Reddit, awesome-lists, X, Chinese channels) → traffic catch & retention. Since 2026-08 it also ships a GEO/SEO long-tail engine: llms.txt + GitHub Pages + citable research summary + llms.txt directory submissions + GitHub topics, so the project keeps receiving AI-search and search-engine traffic after the launch pulse. Ships copy-paste templates and a full Launch Day kit.


### PR DESCRIPTION
Adds [github-morestar-skill](https://github.com/everest-an/github-morestar-skill) to the llms.txt directory.

**What it is**: open-source AI skill (MIT) for growing GitHub stars — 4-step playbook (positioning, README landing page, concentrated multi-channel Launch Day, retention) + GEO/SEO long-tail engine (llms.txt, GitHub Pages, citable research summary, llms.txt directories, GitHub topics).

**llms.txt**: https://everest-an.github.io/github-morestar-skill/llms.txt
**llms-full.txt**: https://everest-an.github.io/github-morestar-skill/llms-full.txt
**Category**: developer-tools

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `github-morestar-skill` website entry with metadata, categorization, publication details, and relevant links.
  * Added a Chinese-first four-step playbook for growing GitHub stars, including launch-day, retention, GEO, and SEO guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->