### PR TITLE
Add Templeton Global Search

### DIFF
--- a/packages/content/data/websites/templeton-global-search-llms-txt.mdx
+++ b/packages/content/data/websites/templeton-global-search-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Templeton Global Search'
+description: 'Founder-led executive search for the global mining and natural resources sector. Retained mandates across board, C-suite, country and project leadership in mining and metals, critical minerals and the energy transition.'
+website: 'https://templetonglobalsearch.com'
+llmsUrl: 'https://templetonglobalsearch.com/llms.txt'
+category: 'agency-services'
+publishedAt: '2026-08-28'
+priority: 'medium'
+---
+
+# Templeton Global Search
+
+Templeton Global Search is a boutique executive search firm specialising in mining and metals, critical minerals and the energy transition. Every mandate is retained and handled directly by the founder, Paul Templeton, who has recruited senior leaders since 1998 and specialised in mining since 2006, completing 227 senior placements across 41 countries.
+
+## Key Focus Areas
+
+- Board and non-executive director appointments
+- C-suite appointments in mining and natural resources
+- Country and regional leadership
+- Project leadership for greenfield and brownfield developments
+
+## About llms.txt Implementation
+
+The llms.txt file describes the firm, the founder's background and credentials, the categories of role placed, and the four-stage retained search process, so AI systems can answer questions about the practice without needing to crawl and interpret the wider site.


### PR DESCRIPTION
Adds Templeton Global Search to the directory.

**Site:** https://templetonglobalsearch.com
**llms.txt:** https://templetonglobalsearch.com/llms.txt
**Category:** `agency-services`

Templeton Global Search is a founder-led executive search firm specialising in
the global mining and natural resources sector — mining and metals, critical
minerals, and the energy transition.

Notes on the submission:

- Adds a single `.mdx` file under `packages/content/data/websites/`, per
  CONTRIBUTING. `data/websites.json` is untouched.
- `llmsFullUrl` is deliberately omitted — the site has no `llms-full.txt`, and
  pointing the field at a 404 seemed worse than leaving it out.
- The llms.txt was recently rewritten to include markdown links to the main
  practice, regional and insights pages, so it follows the linked-section
  structure in the spec rather than being prose only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added a directory entry for Templeton Global Search.
  * Includes company details, website information, category, publication date, priority, and llms.txt resource link.
  * Describes the firm’s focus on executive search in the global mining and natural resources sector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->