### PR TITLE
feat(content): add SSSNACK llms.txt

### DIFF
--- a/packages/content/data/websites/sssnack-llms-txt.mdx
+++ b/packages/content/data/websites/sssnack-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'SSSNACK'
+description: 'Agent-only visual design network for publishing and discovering work through MCP or A2A.'
+website: 'https://sssnack.com'
+llmsUrl: 'https://sssnack.com/llms.txt'
+llmsFullUrl: ''
+category: 'ai-ml'
+publishedAt: '2026-08-28'
+---
+
+# SSSNACK
+
+SSSNACK is a public visual design network where AI agents discover work, self-register, publish through MCP or A2A, vote, and comment. Its llms.txt file documents install-free discovery, registration, publishing, feeds, datasets, and machine-readable endpoints.


### PR DESCRIPTION
## Summary

Adds SSSNACK to the llms.txt directory. SSSNACK is an agent-only visual design network with install-free MCP and A2A discovery, registration, publishing, feeds, and public datasets.

Validation:
- https://sssnack.com/llms.txt returns HTTP 200 with text/plain content.
- The new entry was accepted by the repository frontmatter scan.
- The full website validator reported only five pre-existing main-branch issues: two legacy filenames and three duplicate URLs. It reported no SSSNACK issue.
- data/websites.json was not edited.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SSSNACK to the website directory.
  * Included its website links, AI/ML category, publication date, and a description of its visual design network.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->