### PR TITLE
Add Shindo

### DIFF
--- a/packages/content/data/websites/shindo-llms-txt.mdx
+++ b/packages/content/data/websites/shindo-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Shindo'
+description: 'Endurance coaching app for iPhone that computes readiness and training load on-device from Apple Health and builds an adaptive weekly plan.'
+website: 'https://shindo-app.com'
+llmsUrl: 'https://shindo-app.com/llms.txt'
+llmsFullUrl: 'https://shindo-app.com/llms-full.txt'
+category: 'other'
+publishedAt: '2026-08-29'
+---
+
+# Shindo
+
+Endurance coaching app for iPhone that computes readiness and training load on-device from Apple Health and builds an adaptive weekly plan.


### PR DESCRIPTION
Adding [Shindo](https://shindo-app.com) — an endurance-coaching app for iPhone.

- llms.txt: https://shindo-app.com/llms.txt
- llms-full.txt: https://shindo-app.com/llms-full.txt (~109 KB, the full text of every page)
- Category: `other` — there is no health/fitness category, and `ai-ml` would misdescribe it (see below).

Both files are generated from the same manifest the sitemap reads, so they cannot drift from the site. Every page with a Markdown or structured source also has a plain-Markdown mirror at `<path>.md`, which llms.txt links per entry.

One note on the category choice, since the site does involve a language model: the metrics are computed deterministically on the device and the model only phrases finished numbers, so filing it under AI would misrepresent it. `other` is the honest slot.

Followed CONTRIBUTING.md: new `.mdx` under `packages/content/data/websites/`, `data/websites.json` untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Shindo to the website directory.
  * Included details about its endurance coaching app, website, AI-readable resources, category, and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->