### PR TITLE
feat(content): add SpecterAI llms.txt entry

### DIFF
--- a/packages/content/data/websites/specterai-llms-txt.mdx
+++ b/packages/content/data/websites/specterai-llms-txt.mdx
@@ -1,0 +1,25 @@
+---
+name: 'SpecterAI'
+description: 'German legal AI platform for legal information, document analysis, source-oriented research, drafting, deadline awareness, and structured next steps.'
+website: 'https://www.specterlaw.ai/'
+llmsUrl: 'https://www.specterlaw.ai/llms.txt'
+llmsFullUrl: 'https://www.specterlaw.ai/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-08-30'
+priority: 'medium'
+---
+
+# SpecterAI
+
+SpecterAI is a German legal AI platform for private individuals, lawyers, law firms, and in-house legal teams.
+
+## Key Focus Areas
+
+- German legal information
+- Document analysis
+- Source-oriented legal research
+- Drafting and deadline-aware workflows
+
+## About llms.txt Implementation
+
+SpecterAI provides an `llms.txt` file with product guidance, public resource links, source-access details, and explicit limits for AI systems. A more extensive `llms-full.txt` file is also available.


### PR DESCRIPTION
Adds SpecterAI's public `llms.txt` and `llms-full.txt` endpoints to the AI & ML catalogue through one focused MDX entry. The entry uses a factual description of the German legal AI platform and leaves the generated website index unchanged.

I am affiliated with SpecterAI and am submitting this entry on its behalf.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a directory listing for SpecterAI, a German legal AI platform.
  * Included platform details, website links, category information, and links to its `llms.txt` resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->