### PR TITLE
feat: add Ouafff (ouafff.fr)

### DIFF
--- a/packages/content/data/websites/ouafff-llms-txt.mdx
+++ b/packages/content/data/websites/ouafff-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Ouafff'
+description: 'French independent website dedicated to small dog breeds: 53 encyclopedic breed profiles (temperament, training, health, grooming, budget) plus care guides on feeding, hygiene, transport, training and bedding for small dogs.'
+website: 'https://ouafff.fr/'
+llmsUrl: 'https://ouafff.fr/llms.txt'
+llmsFullUrl: 'https://ouafff.fr/llms-full.txt'
+category: 'content-media'
+publishedAt: '2026-08-30'
+---
+
+# Ouafff
+
+French independent website dedicated to small dog breeds: 53 encyclopedic breed profiles (temperament, training, health, grooming, budget) plus care guides on feeding, hygiene, transport, training and bedding for small dogs.


### PR DESCRIPTION
Adds **Ouafff** — a French independent website dedicated to small dog breeds (53 encyclopedic breed profiles + care guides).

- Website: https://ouafff.fr/
- llms.txt: https://ouafff.fr/llms.txt (verified 200, valid format with H1 + blockquote summary)
- llms-full.txt: https://ouafff.fr/llms-full.txt (56 KB, one self-contained block per breed with canonical URL)
- Category: content-media

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ouafff to the website directory.
  * Included its description, category, publication date, website URL, and links to its `llms.txt` resources.
  * Added a summary highlighting its French small-dog breed profiles and care guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->