### PR TITLE
Fill in the blank llmsFullUrl on the VibeKit.bot entry

### DIFF
--- a/packages/content/data/websites/vibekit-bot-llms-txt.mdx
+++ b/packages/content/data/websites/vibekit-bot-llms-txt.mdx
@@ -3,7 +3,7 @@ name: 'VibeKit.bot'
 description: 'VibeKit gives every app its own persistent AI coding agent that builds, hosts, and keeps improving the app over time — database and a live domain included — driven from your phone, Telegram, or CLI.'
 website: 'https://vibekit.bot'
 llmsUrl: 'https://vibekit.bot/llms.txt'
-llmsFullUrl: ''
+llmsFullUrl: 'https://vibekit.bot/llms-full.txt'
 category: 'developer-tools'
 publishedAt: '2026-06-28'
 ---


### PR DESCRIPTION
The VibeKit.bot entry has been carrying an empty `llmsFullUrl` since it was added back in June. That was accurate at the time; it isn't any more. We've been serving a full file for a while and I only noticed the field was still blank when I went looking at how other entries were filled in.

Verified before opening this:

- `https://vibekit.bot/llms-full.txt` — 200, `text/plain`, ~7.5 KB
- `https://vibekit.bot/llms.txt` — 200, unchanged, still the short llmstxt.org-spec index

One field changed, nothing else touched. Happy to adjust if you'd rather the full file be trimmed or restructured first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the full LLMs.txt URL for the VibeKit.bot website entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->