### PR TITLE
feat(community): add API Acre to llms.txt hub

### DIFF
--- a/packages/content/data/websites/api-acre-llms-txt.mdx
+++ b/packages/content/data/websites/api-acre-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'API Acre'
+description: '74 pay-per-call JSON APIs and 73 MCP tools for web, document, developer, research, and public-data workflows. x402 USDC on Base and Solana; no accounts or API keys.'
+website: 'https://apiacre.com'
+llmsUrl: 'https://apiacre.com/llms.txt'
+llmsFullUrl: 'https://apiacre.com/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-09-01'
+---
+
+# API Acre
+
+74 pay-per-call JSON APIs and 73 MCP tools for web, document, developer, research, and public-data workflows. x402 USDC on Base and Solana; no accounts or API keys.


### PR DESCRIPTION
## Summary

Adds API Acre to the Developer Tools collection with its live `llms.txt` and `llms-full.txt` resources. The entry describes its 74 pay-per-call JSON APIs, 73 MCP tools, and exact x402 USDC support on Base and Solana.

## Validation

- Confirmed the website, `llms.txt`, and `llms-full.txt` URLs return HTTP 200
- `pnpm test:repo` (110 tests passed)
- `pnpm typecheck`
- `pnpm --filter web build:content`
- `pnpm test` (1,356 tests passed; 4 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an API Acre directory listing with service details, website links, category information, and publication metadata.
  - Describes access to 74 pay-per-call JSON APIs and 73 MCP tools using x402 USDC payments on Base and Solana.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->