### PR TITLE
feat(content): add DataOrigin

### DIFF
--- a/packages/content/data/websites/dataorigin-llms-txt.mdx
+++ b/packages/content/data/websites/dataorigin-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'DataOrigin'
+description: 'Trade show prospecting platform for B2B sales teams'
+website: 'https://dataorigin.es'
+llmsUrl: 'https://dataorigin.es/llms.txt'
+llmsFullUrl: 'https://dataorigin.es/llms-full.txt'
+category: 'marketing-sales'
+publishedAt: '2026-09-01'
+---
+
+# DataOrigin
+
+DataOrigin is a trade show prospecting platform for B2B sales teams. It indexes trade shows across Europe, extracts and enriches exhibitor and attendee data, and ranks every company by fit with your Ideal Customer Profile so sales teams arrive at each event with a prioritized list of prospects.
+
+## Key Focus Areas
+
+- Trade Show and Event Intelligence
+- ICP-based Lead Scoring
+- Company Data Enrichment
+- B2B Sales Prospecting
+
+## About llms.txt Implementation
+
+DataOrigin's llms.txt describes when to use the platform, how it works, and links the markdown version of every core page, solution page, blog article, glossary term and sector page in English and Spanish. The llms-full.txt contains the full markdown content of all those pages.


### PR DESCRIPTION
## Summary

Adds DataOrigin (https://dataorigin.es), a trade show prospecting platform for B2B sales teams, to the websites directory under the marketing-sales category.

- llms.txt: https://dataorigin.es/llms.txt (links the markdown version of every page, EN + ES)
- llms-full.txt: https://dataorigin.es/llms-full.txt (full markdown content of all 152 linked pages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a DataOrigin entry to the llms.txt directory.
  * Included platform details, key focus areas, relevant URLs, category, and publication information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->