### PR TITLE
Add SMKlog

### DIFF
--- a/packages/content/data/websites/smklog-llms-txt.mdx
+++ b/packages/content/data/websites/smklog-llms-txt.mdx
@@ -1,0 +1,21 @@
+---
+name: 'SMKlog'
+description: 'Live USPS, UPS, FedEx and DHL parcel rates and labels from the US, domestic and to Canada, the UK, Germany and Australia, from a plain-words item description.'
+website: 'https://smklog.com'
+llmsUrl: 'https://smklog.com/llms.txt'
+category: 'ecommerce-retail'
+publishedAt: '2026-09-02'
+---
+
+# SMKlog
+
+SMKlog is a U.S. parcel shipping calculator for people without a scale or a tape measure. Describe the item in plain words, or paste a store link, and it estimates the packed box and weight, compares live USPS, UPS, FedEx and DHL rates side by side with an all-in price, and sells the label online. Domestic U.S. addresses and international parcels to Canada, the UK, Germany and Australia, with the customs declaration prepared at checkout.
+
+## Key Features
+
+- **Plain-words quotes**: box size and weight estimated from the item description, no scale needed
+- **Live rates**: USPS, UPS, FedEx and DHL compared as cheapest, fastest and best value
+- **All-in pricing**: one price that already includes the service fee
+- **International lanes**: Canada, the UK, Germany and Australia, customs declaration built at checkout
+- **Open data**: a monthly parcel price index published as CSV under CC BY 4.0
+- **Agent access**: a public OpenAPI description and an MCP endpoint with the same quote, checkout and tracking tools


### PR DESCRIPTION
## Summary

Adds SMKlog (https://smklog.com), a U.S. parcel shipping calculator with live USPS, UPS, FedEx and DHL rates from a plain-words item description; llms.txt at https://smklog.com/llms.txt. One new MDX file under packages/content/data/websites/, nothing else touched.

---
_Generated by [Claude Code](https://claude.ai/code)_

## Summary

Describe the change in one or two sentences.

> **Note:** `data/websites.json` is auto-generated. Do not edit it -- PRs that modify it will be blocked. Only add or edit `.mdx` files under `packages/content/data/websites/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an SMKlog website entry highlighting parcel shipping calculations, carrier and international destination support, live rate comparisons, all-in pricing, customs handling, open parcel data, and agent access through OpenAPI and MCP.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->