### PR TITLE
Add Locize, i18next and translate.i18next.com

### DIFF
--- a/packages/content/data/websites/i18next-llms-txt.mdx
+++ b/packages/content/data/websites/i18next-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'i18next'
+description: 'Internationalization framework for JavaScript: translation functions, plurals, interpolation, formatting and framework integrations.'
+website: 'https://www.i18next.com'
+llmsUrl: 'https://www.i18next.com/llms.txt'
+llmsFullUrl: 'https://www.i18next.com/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-09-02'
+---
+
+# i18next
+
+i18next is an internationalization framework for JavaScript and its ecosystem (React, Vue, Next.js, Node.js and more).

--- a/packages/content/data/websites/locize-llms-txt.mdx
+++ b/packages/content/data/websites/locize-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Locize'
+description: 'Translation management system for i18next and other i18n frameworks: CDN delivery, AI translation, review workflow and in-context editing.'
+website: 'https://www.locize.com'
+llmsUrl: 'https://www.locize.com/llms.txt'
+llmsFullUrl: 'https://www.locize.com/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-09-02'
+---
+
+# Locize
+
+Locize is the translation management system built by the creators of i18next.

--- a/packages/content/data/websites/translate-i18next-llms-txt.mdx
+++ b/packages/content/data/websites/translate-i18next-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'translate.i18next.com'
+description: 'Free browser tools for i18next JSON files: a resource translator and an i18n health check that run without uploading anything.'
+website: 'https://translate.i18next.com'
+llmsUrl: 'https://translate.i18next.com/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-09-02'
+---
+
+# translate.i18next.com
+
+Free browser tools for i18next translation files by the team behind i18next and Locize.


### PR DESCRIPTION
Adds three llms.txt entries from the i18next / Locize team, all in developer-tools:

- locize.com (llms.txt + llms-full.txt), the translation management system by the i18next creators
- i18next.com (llms.txt + llms-full.txt), the i18next documentation
- translate.i18next.com (llms.txt), free browser tools for i18next translation files

I maintain all three sites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Content**
  - Added website listings for i18next, Locize, and translate.i18next.com.
  - Included descriptions, website links, llms.txt endpoints, categories, publication dates, and introductory information for each listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->