### PR TITLE
Add Lodestar Stamp llms.txt

### DIFF
--- a/packages/content/data/websites/lodestar-stamp-llms-txt.mdx
+++ b/packages/content/data/websites/lodestar-stamp-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Lodestar Stamp'
+description: 'The agent trust layer: a dated receipt on a named entity. Any agent calls before it acts. We attest. We do not approve the booking. Lookup free through 2026. Chicago HVAC beachhead.'
+website: 'https://lodestarstamp.com'
+llmsUrl: 'https://lodestarstamp.com/llms.txt'
+llmsFullUrl: ''
+category: 'other'
+publishedAt: '2026-09-02'
+---
+
+# Lodestar Stamp
+
+Lodestar Stamp is the agent trust layer: a dated receipt on a named entity. Any agent calls before it acts. We attest. We do not approve the booking. No rank, grade, award, or paid placement. Lookup free through 2026. Chicago HVAC beachhead. Ten-minute REST path at https://lodestarstamp.com/docs. Discovery card at https://lodestarstamp.com/.well-known/mcp.json is not a Cursor MCP server.


### PR DESCRIPTION
Adds Lodestar Stamp to the llms.txt hub.

- Website: https://lodestarstamp.com
- llms.txt: https://lodestarstamp.com/llms.txt
- Docs: https://lodestarstamp.com/docs

Lodestar Stamp is the agent trust layer: a dated receipt on a named entity. Any agent calls before it acts. We attest. We do not approve the booking. Lookup free through 2026.

Contact: watch@lodestarstamp.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added a website entry for Lodestar Stamp, including publication details and an LLMs URL.
  * Added information about its agent trust receipt service, Chicago HVAC focus, free lookup period, REST documentation, and MCP discovery-card clarification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->