### PR TITLE
docs: add llms-txt-generator to Developer Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ We organize projects into primary categories (🤖 **AI & ML**, 💻 **Developer
 | ⚡ **Raycast Extension**  | Search and explore llms.txt files directly in Raycast           | [Raycast Store](https://www.raycast.com/thedaviddias/llms-txt)                                                |
 | ⚡ **LLMs.txt Generator** | Generate llms.txt from sitemap, crawled pages and AI            | [LLMs.txt Generator](https://llmstxtgenerator.co/)                                                            |
 | 🛠 **llmstxt-cli**        | Install llms.txt docs as skills into 35+ AI coding agents       | [npm](https://www.npmjs.com/package/llmstxt-cli) · [README](packages/cli/README.md)                           |
+| ⚙️ **llms-txt-generator** | CLI + GitHub Action that generates spec-compliant llms.txt manifests from your repo's markdown docs on every push, zero dependencies | [GitHub](https://github.com/thedarkbeet/llms-txt-generator) |
 
 <!-- LLMS-LIST:START - Do not remove or modify this section -->
 ## LLM Tools and Resources


### PR DESCRIPTION
Adds llms-txt-generator (https://github.com/thedarkbeet/llms-txt-generator) to the Developer Tools table.

It's a CLI + GitHub Action that generates a spec-compliant `llms.txt` manifest from a repo's markdown docs on every push — zero dependencies, no external API calls. Distinct from the two existing generator-category entries: it's CI/CD-native (runs as a GitHub Action on push, not a hosted web app like LLMs.txt Generator) and it authors the manifest itself rather than installing existing docs as agent skills (unlike llmstxt-cli).

Single-line addition to the README, no changes to the auto-generated `data/websites.json` or the MDX website entries.

(Resubmission of #1557, which was inadvertently auto-closed when its source fork was deleted during unrelated cleanup — no maintainer feedback was given on that PR, content is identical.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added `llms-txt-generator` to the Developer Tools list.
  - Documented its CLI and GitHub Action for generating `llms.txt` manifests from repository documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->