### PR TITLE
feat(community): add Project Cost Estimator to llms.txt hub

### DIFF
--- a/packages/content/data/websites/project-cost-estimator-llms-txt.mdx
+++ b/packages/content/data/websites/project-cost-estimator-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Project Cost Estimator'
+description: 'Free 9-engine website cost calculator with 2026 prices for WordPress, Shopify, Magento and custom builds, calibrated against 600+ project quotes across 6 markets.'
+website: 'https://projectcostestimator.com'
+llmsUrl: 'https://projectcostestimator.com/llms.txt'
+llmsFullUrl: 'https://projectcostestimator.com/llms-full.txt'
+category: 'finance-fintech'
+publishedAt: '2026-09-03'
+---
+
+# Project Cost Estimator
+
+Free 9-engine website cost calculator with 2026 prices for WordPress, Shopify, Magento and custom builds, calibrated against 600+ project quotes across 6 markets.

--- a/packages/content/data/websites/project-cost-estimator-llms-txt.mdx
+++ b/packages/content/data/websites/project-cost-estimator-llms-txt.mdx
@@ -4,7 +4,7 @@ description: 'Free 9-engine website cost calculator with 2026 prices for WordPre
 website: 'https://projectcostestimator.com'
 llmsUrl: 'https://projectcostestimator.com/llms.txt'
 llmsFullUrl: 'https://projectcostestimator.com/llms-full.txt'
-category: 'finance-fintech'
+category: 'developer-tools'
 publishedAt: '2026-09-03'
 ---
 


### PR DESCRIPTION
Adds Project Cost Estimator (https://projectcostestimator.com), a free website/app cost calculator, to the directory.

- `llms.txt`: https://projectcostestimator.com/llms.txt (live)
- `llms-full.txt`: https://projectcostestimator.com/llms-full.txt (live)
- Category: `finance-fintech`, matching the existing precedent for calculator sites (MilitaryCalc, GovCalcs, Amortization).

Disclosure: I'm affiliated with this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new “Project Cost Estimator” website entry, including its description, URLs, category, and publication date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->