### PR TITLE
Add FillTrust

### DIFF
--- a/packages/content/data/websites/filltrust-llms-txt.mdx
+++ b/packages/content/data/websites/filltrust-llms-txt.mdx
@@ -1,0 +1,14 @@
+---
+name: 'FillTrust'
+description: 'Answers vendor security questionnaires from your own SOC 2, ISO 27001 and policy documents, citing the passage behind every answer and leaving the cell blank when the documents do not support one.'
+website: 'https://www.filltrust.com'
+llmsUrl: 'https://www.filltrust.com/llms.txt'
+category: 'security-identity'
+publishedAt: '2026-09-03'
+---
+
+# FillTrust
+
+Answers vendor security questionnaires (CAIQ, SIG Lite, ISO 27001 Annex A, bespoke spreadsheets) from a company's own documentation. Every answer cites the passage it came from, and a question the documents do not support is left blank rather than filled with something plausible.
+
+The `llms.txt` maps the public corpus: a page per questionnaire question explaining what it is really asking, which document answers it and how it usually goes wrong, the same corpus over MCP at `/api/mcp`, and the company's own machine-readable security posture at `/trust/posture.json` and `/trust/oscal.json`.


### PR DESCRIPTION
Adds `packages/content/data/websites/filltrust-llms-txt.mdx`, per the manual pull request route in CONTRIBUTING. `data/websites.json` is untouched.

- **Website:** https://www.filltrust.com
- **llms.txt:** https://www.filltrust.com/llms.txt (200, ~6 KB)
- **Category:** `security-identity`

No `llms-full.txt`, so `llmsFullUrl` is omitted rather than pointed at a 404.

FillTrust answers vendor security questionnaires from a company's own SOC 2, ISO 27001 and policy documents. The llms.txt is generated from the same source as the site rather than maintained by hand, and maps the public corpus: a page per questionnaire question, the same corpus over MCP at `/api/mcp`, and the company's own machine-readable security posture at `/trust/posture.json` and `/trust/oscal.json`.

Prepared by an agent on the site owner's behalf.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added a FillTrust website entry with service metadata and questionnaire-answering information.
  * Included details about the public `llms.txt` corpus and MCP endpoint.
  * Added machine-readable security posture resource links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->