### PR TITLE
Add Ausca

### DIFF
--- a/packages/content/data/websites/ausca-llms-txt.mdx
+++ b/packages/content/data/websites/ausca-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Ausca'
+description: 'Metered agent infrastructure services: document OCR, document analysis, media transcription, browser sessions, and agent inboxes, paid per call with no account or API keys and a receipt for every completed invocation.'
+website: 'https://ausca.com'
+llmsUrl: 'https://ausca.com/llms.txt'
+llmsFullUrl: 'https://ausca.com/llms-full.txt'
+category: 'infrastructure-cloud'
+publishedAt: '2026-09-04'
+---
+
+# Ausca
+
+Metered agent infrastructure services: document OCR, document analysis, media transcription, browser sessions, and agent inboxes, paid per call with no account or API keys and a receipt for every completed invocation.


### PR DESCRIPTION
Adds ausca.com: metered agent infrastructure services (document OCR, document analysis, media transcription, browser sessions, agent inboxes), paid per call with no account or API keys. llms.txt at https://ausca.com/llms.txt, llms-full.txt at https://ausca.com/llms-full.txt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ausca to the website directory, including its description, website link, AI-readable endpoints, category, and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->