### PR TITLE
Add smart402

### DIFF
--- a/packages/content/data/websites/smart402-llms-txt.mdx
+++ b/packages/content/data/websites/smart402-llms-txt.mdx
@@ -1,0 +1,38 @@
+---
+name: 'smart402'
+description: 'Deterministic risk engine for AI agent payments over the x402 protocol. Evaluates each payment request against configurable policies and returns approve or deny in under 50ms, with no LLM in the decision path.'
+website: 'https://www.smart402.com'
+llmsUrl: 'https://www.smart402.com/llms.txt'
+llmsFullUrl: 'https://www.smart402.com/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-09-03'
+---
+
+# smart402
+
+> smart402 is a spending-control layer for AI agents that pay for things. When a
+> server answers a request with HTTP 402 Payment Required, the agent asks smart402
+> whether the payment is allowed before signing anything. Policies cover amount
+> ceilings, rolling budget windows, token and chain allowlists, counterparty
+> allow/blocklists, time windows, and counterparty risk derived from on-chain
+> history. The decision is deterministic — the same inputs always produce the same
+> result, and any denial names the rules that fired.
+
+## Key Focus Areas
+
+- Policy evaluation for x402 payments, with Python and TypeScript SDKs
+- Rolling budget windows that count confirmed on-chain settlement
+- Counterparty risk signals: contract verification, wallet age, prior interactions
+- A public trust registry scoring x402 payment facilitators on Base mainnet
+
+## About llms.txt Implementation
+
+`llms.txt` is a short index pointing to conceptual documentation, the SDKs, and
+the public registry API.
+
+`llms-full.txt` is written to be self-contained rather than a link list: it
+carries the trust model, Python and TypeScript quickstarts, the full policy
+configuration reference with field types, every deny reason, the public JSON
+endpoints with example responses, and the deployed rate limits and quotas. The
+goal is that an agent which fetches it can integrate smart402 without any further
+requests.


### PR DESCRIPTION
Adds smart402 to the directory.

**What it is:** a deterministic risk engine for AI agent payments over the [x402](https://www.smart402.com/blog/how-x402-works) protocol. When a server answers with HTTP 402 Payment Required, the agent asks smart402 whether the payment is allowed *before* signing anything. Policies cover amount ceilings, rolling budget windows, token and chain allowlists, counterparty allow/blocklists, time windows, and counterparty risk from on-chain history. No LLM in the decision path — the same inputs always produce the same decision.

| Field | Value |
|---|---|
| Name | smart402 |
| Website | https://www.smart402.com |
| llms.txt | https://www.smart402.com/llms.txt |
| llms-full.txt | https://www.smart402.com/llms-full.txt |
| Category | `developer-tools` |

### On the llms.txt implementation

`llms.txt` is a short spec-shaped index — Docs, SDKs, Registry, Security, Optional.

`llms-full.txt` is written to be **self-contained** rather than a list of links: trust model, Python and TypeScript quickstarts, the full policy configuration reference with field types and constraints, every deny reason, the public JSON endpoints with example responses, and deployed rate limits and quotas. The goal was that an agent fetching it can integrate without any further requests.

Every URL in both files was verified with an anonymous request before publishing, and a CI job re-checks them weekly so they can't rot.

### Checks run

Followed `.github/CONTRIBUTING.md` Option 2 — a new `.mdx` under `packages/content/data/websites/`. `data/websites.json` is **not** touched, since it's auto-generated.

- `scripts/validate-websites.ts` — ran over all 2651 entries. My entry produces **no errors and no warnings**. (The 5 errors it reports are pre-existing: two filenames not ending in `-llms-txt.mdx`, and three duplicate `llmsUrl` pairs. Error count is identical with and without my file — happy to open a separate issue if useful.)
- `scripts/check-frontmatter.ts` — leaves the file unchanged, so all required fields are present.
- Filename follows the `<slug>-llms-txt.mdx` convention.
- `llmsUrl` is not a duplicate of any existing entry.
- All three URLs return 200 anonymously; both llms files are served as `text/plain`.

Thanks for maintaining the hub.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a directory entry for smart402, a risk engine for AI-agent payments.
  - Includes product details, website links, category information, publication date, and documentation covering policy evaluation, budget windows, and counterparty risk signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->