### PR TITLE
Add Sourcey, Frantic, and runx

### DIFF
--- a/packages/content/data/websites/frantic-llms-txt.mdx
+++ b/packages/content/data/websites/frantic-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'Frantic'
+description: 'A public bounty venue for capable AI agents: read the board, claim funded work, deliver public artifacts, and get paid in USDC on Base, with every consequential move sealed to a public receipt ledger.'
+website: 'https://gofrantic.com'
+llmsUrl: 'https://gofrantic.com/llms.txt'
+category: 'ai-ml'
+publishedAt: '2026-09-04'
+---
+
+# Frantic
+
+A public bounty venue for capable AI agents: read the board, claim funded work, deliver public artifacts, and get paid in USDC on Base, with every consequential move sealed to a public receipt ledger.

--- a/packages/content/data/websites/runx-llms-txt.mdx
+++ b/packages/content/data/websites/runx-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'runx'
+description: 'Governed runtime for agent skills: discover and install portable skills, run bounded skill graphs with explicit authority, and inspect signed receipts for what happened.'
+website: 'https://runx.ai'
+llmsUrl: 'https://runx.ai/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-09-04'
+---
+
+# runx
+
+Governed runtime for agent skills: discover and install portable skills, run bounded skill graphs with explicit authority, and inspect signed receipts for what happened.

--- a/packages/content/data/websites/sourcey-llms-txt.mdx
+++ b/packages/content/data/websites/sourcey-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Sourcey'
+description: 'The public record of what software vendors actually do: startup credits and offers, Agent Readiness grades, and open data, computed from signed releases.'
+website: 'https://sourcey.com'
+llmsUrl: 'https://sourcey.com/llms.txt'
+llmsFullUrl: 'https://sourcey.com/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-09-04'
+---
+
+# Sourcey
+
+The public record of what software vendors actually do: startup credits and offers, Agent Readiness grades, and open data, computed from signed releases.


### PR DESCRIPTION
Adds three sites serving llms.txt:

- Sourcey (https://sourcey.com): the public record of what software vendors actually do: startup credits and offers, Agent Readiness grades, and open data, computed from signed releases. llms.txt and llms-full.txt both live.
- Frantic (https://gofrantic.com): a public bounty venue for AI agents with a public receipt ledger. llms.txt live.
- runx (https://runx.ai): governed runtime for agent skills with bounded authority and signed receipts. llms.txt live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added website directory entries for Frantic, Sourcey, and runx.
  * Added descriptions, website links, LLM resource links, categories, and publication dates for each entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->