### PR TITLE
Add AI Strategist (aistrategist.com)

### DIFF
--- a/packages/content/data/websites/aistrategist-llms-txt.mdx
+++ b/packages/content/data/websites/aistrategist-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'AI Strategist'
+description: 'A content estate exploring how founder judgment and tacit knowledge get captured and transferred into AI systems — comparisons, a glossary, FAQ-style question pages, and field notes on operating an AI imprint.'
+website: 'https://aistrategist.com'
+llmsUrl: 'https://aistrategist.com/llms.txt'
+category: 'ai-ml'
+priority: 'medium'
+publishedAt: '2026-09-04'
+---
+
+# AI Strategist
+
+A content estate exploring how founder judgment and tacit knowledge get captured and transferred into AI systems — comparisons, a glossary, FAQ-style question pages, and field notes on operating an AI imprint.
+
+## Key Focus Areas
+
+- Capturing founder/operator judgment for AI systems
+- Comparisons between memory, fine-tuning, RAG, and judgment-transfer approaches
+- Glossary of terms for the judgment-capture/AI-imprint space
+- Field notes on operating an AI system trained on captured judgment
+
+## About llms.txt Implementation
+
+AI Strategist provides an `llms.txt` file with AI-readable information about its site structure, covering the hub page, comparison pages, glossary, question pages, and field notes.


### PR DESCRIPTION
Adds aistrategist.com to the directory. It's a content estate on founder-judgment capture/transfer for AI systems, with an existing llms.txt covering the hub, comparison pages, glossary, question pages, and field notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Content**
  - Added an AI Strategist website entry with descriptive metadata and publication details.
  - Added an overview of the site’s focus areas and its llms.txt implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->