### PR TITLE
feat: add send21 llms.txt listing

### DIFF
--- a/packages/content/data/websites/send21-llms-txt.mdx
+++ b/packages/content/data/websites/send21-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'send21'
+description: 'Non-custodial payment drafts and pay links for humans and AI agents across BTC, USDC, USDT, and EURC on Bitcoin, Solana, Ethereum, and Base.'
+website: 'https://send21.io'
+llmsUrl: 'https://send21.io/llms.txt'
+category: 'finance-fintech'
+publishedAt: '2026-09-04'
+---
+
+# send21
+
+send21 is a non-custodial payment-draft platform for BTC, USDC, USDT, and EURC with a first-class REST API and MCP server for AI agents. Agents create payment drafts or fiat-priced pay links; the sender always pays from their own wallet. send21 never holds keys or funds, never signs, and never broadcasts transactions.
+
+## Key Focus Areas
+
+- Non-custodial payment drafts and pay links
+- Agent-ready REST API and MCP tools
+- Multi-chain BTC / USDC / USDT / EURC support
+- Zero custody: software prepares instructions only
+
+## About llms.txt Implementation
+
+send21's llms.txt documents the API base URL, OpenAPI spec, MCP endpoint, auth scopes, fee model, and a typical agent payment flow for LLM clients.


### PR DESCRIPTION
## Summary

- Add **send21** (`https://send21.io`) to the directory
- Non-custodial payment drafts / pay links for humans and AI agents (BTC, USDC, USDT, EURC)
- Live `llms.txt` at https://send21.io/llms.txt
- Category: `finance-fintech`
- Contact: info@send21.io

## Checklist

- [x] Added `.mdx` under `packages/content/data/websites/` (did **not** edit `data/websites.json`)
- [x] `llmsUrl` ends with `llms.txt` and is publicly reachable
- [x] Name ≤ 30 chars, description 50–160 chars ending with a period
- [x] Valid category slug

## Links

- Website: https://send21.io
- llms.txt: https://send21.io/llms.txt
- OpenAPI: https://send21.io/swagger/v1/swagger.json
- MCP: https://send21.io/mcp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a directory entry for the send21 website, including its metadata, supported assets, key focus areas, and llms.txt information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->