### PR TITLE
Add SnapCard (trysnapcard.com)

### DIFF
--- a/packages/content/data/websites/snapcard-llms-txt.mdx
+++ b/packages/content/data/websites/snapcard-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'SnapCard'
+description: 'Free iPhone app that scans sports cards and Pokémon cards, identifies them, shows recent sold prices from eBay, Goldin, Heritage, PWCC and Pristine, and estimates condition on the PSA scale.'
+website: 'https://trysnapcard.com/'
+llmsUrl: 'https://trysnapcard.com/llms.txt'
+category: 'ai-ml'
+priority: 'medium'
+publishedAt: '2026-09-05'
+---
+
+# SnapCard
+
+SnapCard is a free iPhone app for card collectors. Point the camera at a sports card or a Pokémon, Magic: The Gathering or Yu-Gi-Oh! card and the app identifies it, shows recent sold prices, and gives an AI condition estimate on the PSA 1 to 10 scale before you pay a grading company. It also reads the labels on PSA, BGS, SGC and CGC slabs. No account is required.
+
+## Key Focus Areas
+
+- Card identification and recent sold prices for nine sports and three trading card games
+- AI condition estimate on the PSA scale, with graded versus raw price comparison
+- Collection tracking with iCloud sync
+- Guides on grading costs, PSA tiers, rookie cards and card values, in 11 languages
+
+## About llms.txt Implementation
+
+SnapCard publishes `llms.txt` and `llms-full.txt` at trysnapcard.com. They describe the product facts, the pages of the site and the full text of its guides so AI assistants can answer questions about card scanning, grading and values with accurate, current information.


### PR DESCRIPTION
Adds SnapCard, a free iPhone app that scans sports cards and Pokémon cards, shows recent sold prices and estimates condition on the PSA scale.

- Website: https://trysnapcard.com/
- llms.txt: https://trysnapcard.com/llms.txt
- llms-full.txt: https://trysnapcard.com/llms-full.txt

Category: ai-ml. One .mdx under packages/content/data/websites/, following the existing template.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SnapCard to the websites directory.
  - Included details about card identification, recent sales prices, AI condition estimates, collection tracking with iCloud sync, and multilingual guides.
  - Added links to SnapCard’s website and published `llms.txt` resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->