### PR TITLE
feat(community): add eight llms.txt listings (PageAudit, HookPulse, Radar CNPJ, PontoFato, EditalMD, Grade TV, Meta Agent Tools, CommsHarbor)

### DIFF
--- a/packages/content/data/websites/commsharbor-llms-txt.mdx
+++ b/packages/content/data/websites/commsharbor-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'CommsHarbor'
+description: 'Transactional e-mail and permission-based campaigns with verified sending domains, idempotent sends, suppressions, append-only audit trail, MCP server and API'
+website: 'https://commsharbor.com/'
+llmsUrl: 'https://commsharbor.com/llms.txt'
+llmsFullUrl: 'https://commsharbor.com/llms-full.txt'
+category: 'integration-automation'
+priority: 'medium'
+publishedAt: '2026-09-05'
+---
+
+# CommsHarbor
+
+Transactional e-mail and permission-based campaigns with verified sending domains, idempotent sends, suppressions, append-only audit trail, MCP server and API.
+
+## Key Focus Areas
+
+- Transactional e-mail API
+- Consent-based campaigns
+- MCP server for agents
+
+## About llms.txt Implementation
+
+CommsHarbor serves `llms.txt` and `llms-full.txt` at the site root, generated from the same API catalog that feeds `/api/`, `openapi.json` and the MCP server at `https://commsharbor.com/mcp`, so the three always describe the same routes, prices and limits.

--- a/packages/content/data/websites/commsharbor-llms-txt.mdx
+++ b/packages/content/data/websites/commsharbor-llms-txt.mdx
@@ -4,7 +4,7 @@ description: 'Transactional e-mail and permission-based campaigns with verified 
 website: 'https://commsharbor.com/'
 llmsUrl: 'https://commsharbor.com/llms.txt'
 llmsFullUrl: 'https://commsharbor.com/llms-full.txt'
-category: 'integration-automation'
+category: 'automation-workflow'
 priority: 'medium'
 publishedAt: '2026-09-05'
 ---

--- a/packages/content/data/websites/editalmd-llms-txt.mdx
+++ b/packages/content/data/websites/editalmd-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'EditalMD'
+description: 'Brazilian public procurement (PNCP) notices as Markdown with provenance, proposal and challenge deadlines, qualification requirements, alerts and watches — API and MCP'
+website: 'https://editalmd.com/'
+llmsUrl: 'https://editalmd.com/llms.txt'
+llmsFullUrl: 'https://editalmd.com/llms-full.txt'
+category: 'data-analytics'
+priority: 'medium'
+publishedAt: '2026-09-05'
+---
+
+# EditalMD
+
+Brazilian public procurement (PNCP) notices as Markdown with provenance, proposal and challenge deadlines, qualification requirements, alerts and watches — API and MCP.
+
+## Key Focus Areas
+
+- PNCP notices in Markdown
+- Deadline alerts and watches
+- MCP server for agents
+
+## About llms.txt Implementation
+
+EditalMD serves `llms.txt` and `llms-full.txt` at the site root, generated from the same API catalog that feeds `/api/`, `openapi.json` and the MCP server at `https://editalmd.com/mcp`, so the three always describe the same routes, prices and limits.

--- a/packages/content/data/websites/grade-tv-llms-txt.mdx
+++ b/packages/content/data/websites/grade-tv-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Grade TV'
+description: 'Public TV channels and radio stations from the iptv-org catalog with measured health, folders with stable M3U/JSON/XSPF playlist URLs, a browser player, API and MCP'
+website: 'https://gradetv.net/'
+llmsUrl: 'https://gradetv.net/llms.txt'
+llmsFullUrl: 'https://gradetv.net/llms-full.txt'
+category: 'developer-tools'
+priority: 'medium'
+publishedAt: '2026-09-05'
+---
+
+# Grade TV
+
+Public TV channels and radio stations from the iptv-org catalog with measured health, folders with stable M3U/JSON/XSPF playlist URLs, a browser player, API and MCP.
+
+## Key Focus Areas
+
+- Channel catalog API
+- Playlists for VLC
+- MCP server for agents
+
+## About llms.txt Implementation
+
+Grade TV serves `llms.txt` and `llms-full.txt` at the site root, generated from the same API catalog that feeds `/api/`, `openapi.json` and the MCP server at `https://gradetv.net/mcp`, so the three always describe the same routes, prices and limits.

--- a/packages/content/data/websites/hookpulse-llms-txt.mdx
+++ b/packages/content/data/websites/hookpulse-llms-txt.mdx
@@ -4,7 +4,7 @@ description: 'Dead man''s switch for cron jobs, webhooks and pipelines: a check-
 website: 'https://hookpulse.net/'
 llmsUrl: 'https://hookpulse.net/llms.txt'
 llmsFullUrl: 'https://hookpulse.net/llms-full.txt'
-category: 'integration-automation'
+category: 'automation-workflow'
 priority: 'medium'
 publishedAt: '2026-09-05'
 ---

--- a/packages/content/data/websites/hookpulse-llms-txt.mdx
+++ b/packages/content/data/websites/hookpulse-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'HookPulse'
+description: 'Dead man''s switch for cron jobs, webhooks and pipelines: a check-in URL per monitor, an alert when it goes silent, JSON miss payloads, MCP server and API'
+website: 'https://hookpulse.net/'
+llmsUrl: 'https://hookpulse.net/llms.txt'
+llmsFullUrl: 'https://hookpulse.net/llms-full.txt'
+category: 'integration-automation'
+priority: 'medium'
+publishedAt: '2026-09-05'
+---
+
+# HookPulse
+
+Dead man's switch for cron jobs, webhooks and pipelines: a check-in URL per monitor, an alert when it goes silent, JSON miss payloads, MCP server and API.
+
+## Key Focus Areas
+
+- Cron and webhook monitoring
+- Alert webhooks and e-mail
+- MCP server for agents
+
+## About llms.txt Implementation
+
+HookPulse serves `llms.txt` and `llms-full.txt` at the site root, generated from the same API catalog that feeds `/api/`, `openapi.json` and the MCP server at `https://hookpulse.net/mcp`, so the three always describe the same routes, prices and limits.

--- a/packages/content/data/websites/meta-agent-tools-llms-txt.mdx
+++ b/packages/content/data/websites/meta-agent-tools-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Meta Agent Tools'
+description: 'Registry of MCP servers, agent skills and plugins synced from the official MCP registry, Smithery and skill dumps, enriched daily from GitHub, with community likes and comments'
+website: 'https://classificado.app.br/'
+llmsUrl: 'https://classificado.app.br/llms.txt'
+llmsFullUrl: 'https://classificado.app.br/llms-full.txt'
+category: 'ai-ml'
+priority: 'medium'
+publishedAt: '2026-09-05'
+---
+
+# Meta Agent Tools
+
+Registry of MCP servers, agent skills and plugins synced from the official MCP registry, Smithery and skill dumps, enriched daily from GitHub, with community likes and comments.
+
+## Key Focus Areas
+
+- MCP server registry
+- Agent skills catalog
+- Publish via API (x402)
+
+## About llms.txt Implementation
+
+Meta Agent Tools serves `llms.txt` and `llms-full.txt` at the site root, generated from the same API catalog that feeds `/api/`, `openapi.json` and the MCP server at `https://classificado.app.br/mcp`, so the three always describe the same routes, prices and limits.

--- a/packages/content/data/websites/pageaudit-llms-txt.mdx
+++ b/packages/content/data/websites/pageaudit-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'PageAudit'
+description: 'Technical SEO audit that returns the fix: 24 deterministic checks, a patch for head, robots and sitemap, saved tabs, MCP server and x402 pay-per-call API'
+website: 'https://pageaudit.online/'
+llmsUrl: 'https://pageaudit.online/llms.txt'
+llmsFullUrl: 'https://pageaudit.online/llms-full.txt'
+category: 'developer-tools'
+priority: 'medium'
+publishedAt: '2026-09-05'
+---
+
+# PageAudit
+
+Technical SEO audit that returns the fix: 24 deterministic checks, a patch for head, robots and sitemap, saved tabs, MCP server and x402 pay-per-call API.
+
+## Key Focus Areas
+
+- SEO audit API
+- MCP server for agents
+- Free single-check tools
+
+## About llms.txt Implementation
+
+PageAudit serves `llms.txt` and `llms-full.txt` at the site root, generated from the same API catalog that feeds `/api/`, `openapi.json` and the MCP server at `https://pageaudit.online/mcp`, so the three always describe the same routes, prices and limits.

--- a/packages/content/data/websites/pontofato-llms-txt.mdx
+++ b/packages/content/data/websites/pontofato-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'PontoFato'
+description: 'Brazilian postal codes (CEP) with IBGE coordinates from the 2022 Census address base, the companies registered at the same place and a radius view by activity'
+website: 'https://pontofato.com/'
+llmsUrl: 'https://pontofato.com/llms.txt'
+llmsFullUrl: 'https://pontofato.com/llms-full.txt'
+category: 'data-analytics'
+priority: 'medium'
+publishedAt: '2026-09-05'
+---
+
+# PontoFato
+
+Brazilian postal codes (CEP) with IBGE coordinates from the 2022 Census address base, the companies registered at the same place and a radius view by activity.
+
+## Key Focus Areas
+
+- CEP with latitude and longitude
+- Companies by postal code
+- MCP server for agents
+
+## About llms.txt Implementation
+
+PontoFato serves `llms.txt` and `llms-full.txt` at the site root, generated from the same API catalog that feeds `/api/`, `openapi.json` and the MCP server at `https://pontofato.com/mcp`, so the three always describe the same routes, prices and limits.

--- a/packages/content/data/websites/radar-cnpj-llms-txt.mdx
+++ b/packages/content/data/websites/radar-cnpj-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Radar CNPJ'
+description: 'Brazilian company data (CNPJ): lookup, search by activity and place, a market check for a business idea by area, and monitoring — API, MCP server and x402'
+website: 'https://radar-cnpj.com/'
+llmsUrl: 'https://radar-cnpj.com/llms.txt'
+llmsFullUrl: 'https://radar-cnpj.com/llms-full.txt'
+category: 'data-analytics'
+priority: 'medium'
+publishedAt: '2026-09-05'
+---
+
+# Radar CNPJ
+
+Brazilian company data (CNPJ): lookup, search by activity and place, a market check for a business idea by area, and monitoring — API, MCP server and x402.
+
+## Key Focus Areas
+
+- CNPJ lookup and search
+- Market evaluation by area
+- MCP server for agents
+
+## About llms.txt Implementation
+
+Radar CNPJ serves `llms.txt` and `llms-full.txt` at the site root, generated from the same API catalog that feeds `/api/`, `openapi.json` and the MCP server at `https://radar-cnpj.com/mcp`, so the three always describe the same routes, prices and limits.


### PR DESCRIPTION
Adds eight sites from the same maintainer, each serving `llms.txt` and `llms-full.txt` at the root (generated from the API catalog that also feeds `/api/`, `openapi.json` and an MCP server):

- **PageAudit** — https://pageaudit.online/llms.txt (developer-tools)
- **HookPulse** — https://hookpulse.net/llms.txt (automation-workflow)
- **Radar CNPJ** — https://radar-cnpj.com/llms.txt (data-analytics)
- **PontoFato** — https://pontofato.com/llms.txt (data-analytics)
- **EditalMD** — https://editalmd.com/llms.txt (data-analytics)
- **Grade TV** — https://gradetv.net/llms.txt (developer-tools)
- **Meta Agent Tools** — https://classificado.app.br/llms.txt (ai-ml)
- **CommsHarbor** — https://commsharbor.com/llms.txt (automation-workflow)

One `.mdx` per site under `packages/content/data/websites/`, following the template; `data/websites.json` untouched (auto-generated). Happy to split into one PR per site if you prefer.
