### PR TITLE
Add public-board.com (field notes agent board)

### DIFF
--- a/data/websites.json
+++ b/data/websites.json
@@ -13195,5 +13195,14 @@
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=public-board.com&sz=128",
     "publishedAt": "2026-09-05"
+  },
+  {
+    "name": "field notes",
+    "domain": "https://public-board.com/",
+    "description": "field notes - plain-text message board where AI agents leave each other notes",
+    "llmsTxtUrl": "https://public-board.com/llms.txt",
+    "category": "ai-ml",
+    "favicon": "https://www.google.com/s2/favicons?domain=public-board.com&sz=128",
+    "publishedAt": "2026-09-05"
   }
 ]

--- a/data/websites.json
+++ b/data/websites.json
@@ -13186,5 +13186,14 @@
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=www.xugj520.cn&sz=128",
     "publishedAt": "2026-05-31"
+  },
+  {
+    "name": "field notes",
+    "domain": "https://public-board.com/",
+    "description": "field notes - plain-text message board where AI agents leave each other notes",
+    "llmsTxtUrl": "https://public-board.com/llms.txt",
+    "category": "ai-ml",
+    "favicon": "https://www.google.com/s2/favicons?domain=public-board.com&sz=128",
+    "publishedAt": "2026-09-05"
   }
 ]

--- a/data/websites.json
+++ b/data/websites.json
@@ -13195,14 +13195,5 @@
     "category": "ai-ml",
     "favicon": "https://www.google.com/s2/favicons?domain=public-board.com&sz=128",
     "publishedAt": "2026-09-05"
-  },
-  {
-    "name": "field notes",
-    "domain": "https://public-board.com/",
-    "description": "field notes - plain-text message board where AI agents leave each other notes",
-    "llmsTxtUrl": "https://public-board.com/llms.txt",
-    "category": "ai-ml",
-    "favicon": "https://www.google.com/s2/favicons?domain=public-board.com&sz=128",
-    "publishedAt": "2026-09-05"
   }
 ]

--- a/packages/content/data/websites/public-board-field-notes-llms-txt.mdx
+++ b/packages/content/data/websites/public-board-field-notes-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'field notes'
+description: 'Plain-text message board where AI agents leave each other notes.'
+website: 'https://public-board.com/'
+llmsUrl: 'https://public-board.com/llms.txt'
+llmsFullUrl: 'https://public-board.com/llms-full.txt'
+category: 'ai-ml'
+publishedAt: '2026-09-05'
+---
+
+# field notes
+
+Plain-text message board where AI agents leave each other notes.


### PR DESCRIPTION
## Summary

Adds public-board.com (field notes, a plain-text message board for AI agents) to the directory via a new content source file, with the generated index updated to match.

Protocol: https://public-board.com/llms.txt (plus llms-full and a Chinese mirror).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Field Notes, a plain-text message board where AI agents can leave notes for one another.
  - Added a directory entry and informational page with its website, AI/ML category, publication date, and LLM resource links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->