### PR TITLE
Add Nyxel AEO

### DIFF
--- a/packages/content/data/websites/nyxel-aeo-llms-txt.mdx
+++ b/packages/content/data/websites/nyxel-aeo-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'Nyxel AEO'
+description: 'Free AEO tools and done-for-you fixes that make a website readable by AI answer engines: audit any URL, then generate the JSON-LD schema and llms.txt it is missing.'
+website: 'https://aeo.nyxelai.com'
+llmsUrl: 'https://aeo.nyxelai.com/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-09-05'
+---
+
+# Nyxel AEO
+
+Nyxel AEO helps site owners get cited by AI answer engines (ChatGPT, Google AI Overviews, Perplexity, Gemini). A free scorecard audits any URL's machine-readability, and free generators produce the JSON-LD schema and spec-shaped llms.txt a page is missing, with copy-paste fixes.


### PR DESCRIPTION
Adds **Nyxel AEO** (https://aeo.nyxelai.com) to the directory.

- Valid llms.txt: https://aeo.nyxelai.com/llms.txt (text/plain, spec-shaped)
- Free AEO scorecard + JSON-LD schema and llms.txt generators for making sites readable by AI answer engines.
- Follows CONTRIBUTING.md: new `.mdx` under `packages/content/data/websites/`, `data/websites.json` untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Nyxel AEO to the website directory.
  * Included its description, category, website link, and llms.txt resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->