### PR TITLE
Add TranscriptFetch

### DIFF
--- a/packages/content/data/websites/transcriptfetch-llms-txt.mdx
+++ b/packages/content/data/websites/transcriptfetch-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'TranscriptFetch'
+description: 'Transcript API for AI: turns YouTube, TikTok, Instagram videos and podcasts into clean, structured transcripts, with an MCP server so agents can fetch them directly.'
+website: 'https://transcriptfetch.com'
+llmsUrl: 'https://transcriptfetch.com/llms.txt'
+llmsFullUrl: 'https://transcriptfetch.com/llms-full.txt'
+category: 'developer-tools'
+publishedAt: '2026-09-05'
+---
+
+# TranscriptFetch
+
+Transcript API for AI: turns YouTube, TikTok, Instagram videos and podcasts into clean, structured transcripts, with an MCP server so agents can fetch them directly.


### PR DESCRIPTION
## Summary

Adds TranscriptFetch (https://transcriptfetch.com) to the hub under developer-tools.

- llms.txt: https://transcriptfetch.com/llms.txt
- llms-full.txt: https://transcriptfetch.com/llms-full.txt

Only a new `.mdx` under `packages/content/data/websites/` is added; `data/websites.json` is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a website entry for TranscriptFetch, including its transcript API, supported media platforms, MCP server, relevant URLs, category, and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->