### PR TITLE
add: citybiteguide.com

### DIFF
--- a/packages/content/data/websites/citybiteguide-llms-txt.mdx
+++ b/packages/content/data/websites/citybiteguide-llms-txt.mdx
@@ -3,8 +3,8 @@ name: 'CityBiteGuide'
 description: 'Onafhankelijke restaurantgids voor Amsterdam: redactionele shortlists, live bookability en unieke terras-zonuren uit open geodata (3DBAG).'
 website: 'https://www.citybiteguide.com/'
 llmsUrl: 'https://www.citybiteguide.com/llms.txt'
-llmsFullUrl: ''
-category: 'media-content'
+llmsFullUrl: 'https://www.citybiteguide.com/llms-full.txt'
+category: 'data-analytics'
 priority: 'medium'
 publishedAt: '2026-09-06'
 ---
@@ -17,9 +17,9 @@ CityBiteGuide is an independent restaurant guide for Dutch cities (starting with
 
 - Amsterdam restaurant shortlists
 - Walk-in and terrace guides
-- Measured terrace sun hours
-- Methodology and Food Pulse data
+- Measured terrace sun hours (open data)
+- Methodology and Food Pulse datasets
 
 ## About llms.txt Implementation
 
-CityBiteGuide provides an `llms.txt` file with extractable shortlists (best restaurants, walk-in, terraces), measured sun-hour rankings, and links to methodology and monthly Food Pulse stats.
+CityBiteGuide provides `llms.txt` and `llms-full.txt` with extractable shortlists, measured sun-hour rankings, and links to methodology and monthly Food Pulse stats.

--- a/packages/content/data/websites/citybiteguide-llms-txt.mdx
+++ b/packages/content/data/websites/citybiteguide-llms-txt.mdx
@@ -1,0 +1,25 @@
+---
+name: 'CityBiteGuide'
+description: 'Onafhankelijke restaurantgids voor Amsterdam: redactionele shortlists, live bookability en unieke terras-zonuren uit open geodata (3DBAG).'
+website: 'https://www.citybiteguide.com/'
+llmsUrl: 'https://www.citybiteguide.com/llms.txt'
+llmsFullUrl: ''
+category: 'media-content'
+priority: 'medium'
+publishedAt: '2026-09-06'
+---
+
+# CityBiteGuide
+
+CityBiteGuide is an independent restaurant guide for Dutch cities (starting with Amsterdam). Editorial shortlists with published criteria, live online-bookability per venue, and terrace sun-hours ranked from open geodata (3DBAG, tree register, terrace permits).
+
+## Key Focus Areas
+
+- Amsterdam restaurant shortlists
+- Walk-in and terrace guides
+- Measured terrace sun hours
+- Methodology and Food Pulse data
+
+## About llms.txt Implementation
+
+CityBiteGuide provides an `llms.txt` file with extractable shortlists (best restaurants, walk-in, terraces), measured sun-hour rankings, and links to methodology and monthly Food Pulse stats.


### PR DESCRIPTION
## Summary
Add CityBiteGuide (`https://www.citybiteguide.com/llms.txt`) to the directory.

- Independent Amsterdam restaurant guide
- `llms.txt` includes extractable editorial shortlists, terrace sun-hour rankings, and methodology links
- Live file: https://www.citybiteguide.com/llms.txt (HTTP 200, text/plain)

## Test plan
- [ ] `llmsUrl` returns HTTP 200 and is not HTML
- [ ] Category `media-content` fits a publication/guide
- [ ] Links resolve


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Content**
  - Added CityBiteGuide to the website directory.
  - Includes details about Amsterdam restaurant recommendations, booking availability, terrace sun-hour rankings, and its llms.txt implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->