### PR TITLE
Add Lurto (lurtoagency.com)

### DIFF
--- a/packages/content/data/websites/lurto-llms-txt.mdx
+++ b/packages/content/data/websites/lurto-llms-txt.mdx
@@ -1,0 +1,25 @@
+---
+name: 'Lurto'
+description: 'AI automation agency for US and UK businesses. Builds and repairs production AI automations: n8n, Make and Zapier workflows, voice agents, RAG assistants and eval harnesses, with every offer and its price documented.'
+website: 'https://lurtoagency.com'
+llmsUrl: 'https://lurtoagency.com/llms.txt'
+llmsFullUrl: 'https://lurtoagency.com/llms-full.txt'
+category: 'agency-services'
+publishedAt: '2026-09-06'
+---
+
+# Lurto
+
+Lurto is an AI automation agency operated by Meridal Group LLC (Sheridan, Wyoming) for US and UK businesses. It takes the work a team does by hand every day, puts it into production, and keeps it running: inbound enquiries, quotes, invoices, after-hours calls, reporting. It also diagnoses and repairs automations built by somebody else.
+
+## Key Focus Areas
+
+- AI Rescue: written diagnostic and repair of broken n8n, Make and Zapier workflows, chatbots and voice agents
+- Build Sprints: workflow automations, custom voice agents, RAG knowledge assistants, multi-agent platforms
+- Eval and reliability harnesses for AI systems already in production
+- Care retainers: monitoring, fixes and a monthly report
+- A fix library of real failure traces with importable workflows, and a price index of 21 AI automation agencies
+
+## About llms.txt Implementation
+
+Lurto's llms.txt is a short index of services, guarantees and contact details. llms-full.txt carries the whole site in one file: every service with its scope, price in dollars and pounds, timeline and what is included; the five guarantees; the FAQ as published; six production case studies; the fix library; the full agency price index with dated figures; and every article. It is regenerated from the same source files as the site, so an assistant reading it gets the same numbers a visitor sees.


### PR DESCRIPTION
Adds Lurto, an AI automation agency for US and UK businesses, to the agency-services category.

- Website: https://lurtoagency.com
- llms.txt: https://lurtoagency.com/llms.txt
- llms-full.txt: https://lurtoagency.com/llms-full.txt

Both files are served from the site and regenerated from the same source as the pages, so the prices and scopes in them match what a visitor sees.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Content**
  - Added a directory entry for Lurto, including its website details, AI automation services, focus areas, and llms.txt implementation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->