### PR TITLE
Add Taylor Tides to llms.txt directory

### DIFF
--- a/packages/content/data/websites/taylor-tides-llms-txt.mdx
+++ b/packages/content/data/websites/taylor-tides-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: Taylor Tides
+description: Plain-language educational information about peptides, proteins, hormones, amino acids, vitamins, enzymes, and related research topics. Content is educational only and is not medical advice.
+website: https://taylortides.com/
+llmsUrl: https://taylortides.com/llms.txt
+llmsFullUrl: https://taylortides.com/llms-full.txt
+category: education
+publishedAt: 2026-09-07
+---
+
+# Taylor Tides
+
+Plain-language educational information about peptides, proteins, hormones, amino acids, vitamins, enzymes, and related research topics. Content is educational only and is not medical advice.


### PR DESCRIPTION
## Summary

Adds Taylor Tides as a plain-language educational health resource with working llms.txt and llms-full.txt endpoints.

## Public endpoints

- Website: https://taylortides.com/
- llms.txt: https://taylortides.com/llms.txt
- llms-full.txt: https://taylortides.com/llms-full.txt

Taylor Tides states that its content is educational only and is not medical advice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Content**
  - Added a directory entry for the Taylor Tides website.
  - Includes educational category information, publication details, website links, and a plain-language description of its content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->