### PR TITLE
feat(websites): add AstraMedia llms.txt entry

### DIFF
--- a/packages/content/data/websites/astramedia-llms-txt.mdx
+++ b/packages/content/data/websites/astramedia-llms-txt.mdx
@@ -1,0 +1,25 @@
+---
+name: 'AstraMedia'
+description: 'AI-powered media visibility platform that helps founders, experts and small businesses turn their stories into journalist-ready pitches. The system finds media opportunities, drafts outreach, and lets you review and approve every message before it is sent.'
+website: 'https://astramedia.app'
+llmsUrl: 'https://astramedia.app/llms.txt'
+llmsFullUrl: ''
+category: 'marketing-sales'
+publishedAt: '2026-09-07'
+---
+
+# AstraMedia
+
+AI-powered media visibility platform for founders, experts and small businesses. The system finds relevant media opportunities, drafts journalist-ready pitches, matches contacts, and sends outreach automatically — with human review and approval before anything goes out.
+
+## Key Focus Areas
+
+- Media visibility for founders and startup launches
+- Media visibility for solopreneurs, consultants and experts
+- Media visibility for authors, coaches and creators
+- AI-matched media opportunities and journalist contact matching
+- Automated outreach with human-in-the-loop approval
+
+## About llms.txt Implementation
+
+AstraMedia provides an `llms.txt` file with AI-readable information about the platform, its audience pages, methodology, evidence, newsroom, and security pages.


### PR DESCRIPTION
Adds AstraMedia (https://astramedia.app) to the llms.txt directory.

- **Name:** AstraMedia
- **Website:** https://astramedia.app
- **llms.txt:** https://astramedia.app/llms.txt (verified 200)
- **Category:** marketing-sales

AstraMedia is an AI-powered media visibility platform that helps founders, experts and small businesses turn their stories into journalist-ready pitches. Its llms.txt file lists the homepage, comparison, audience pages, methodology, evidence, about, newsroom, security and responsible-AI pages.

The llms.txt file is live and returns HTTP 200 with 14 URLs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added an AstraMedia website entry with descriptive metadata, category, publication date, and `llms.txt` link.
  * Included an overview of AstraMedia’s focus areas and `llms.txt` implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->