### PR TITLE
docs: add Proxy Compare llms.txt listing

### DIFF
--- a/packages/content/data/websites/proxy-compare-llms-txt.mdx
+++ b/packages/content/data/websites/proxy-compare-llms-txt.mdx
@@ -1,0 +1,14 @@
+---
+name: 'Proxy Compare'
+description: 'Compare proxy, scraping API and CAPTCHA solver prices, billing rules and provider policies, with dated evidence and browser-native cost calculators.'
+website: 'https://www.proxy-compare.com/'
+llmsUrl: 'https://www.proxy-compare.com/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-09-07'
+---
+
+# Proxy Compare
+
+Compare proxy, scraping API and CAPTCHA solver prices, billing rules and provider policies, with dated evidence and browser-native cost calculators.
+
+The llms.txt file links to provider records, pricing comparisons, buying guides and three WebMCP calculator tools. Prices include billing assumptions and the date they were checked. The site discloses affiliate provider links.


### PR DESCRIPTION
## Summary

Adds Proxy Compare to the Developer Tools directory, linking its public llms.txt and price comparison calculators. The entry describes proxy, scraping API and CAPTCHA pricing, dated evidence, billing assumptions and the site’s disclosed affiliate links.

Validation: the new entry passes `check-frontmatter.ts`; the website and llms.txt return HTTP 200. `validate-websites.ts` reports the same five pre-existing errors with and without this entry (two filename issues and three duplicate llmsUrl groups); this entry adds no validation errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new directory entry for Proxy Compare, featuring information about proxy, scraping API, and CAPTCHA solver pricing comparisons.
  * Included links to the website and its `llms.txt` resource, along with details about pricing evidence, cost calculators, and affiliate disclosures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->