### PR TITLE
Add Kids Stay (family-friendly hotels in Japan) to the llms.txt hub

### DIFF
--- a/packages/content/data/websites/kids-stay-llms-txt.mdx
+++ b/packages/content/data/websites/kids-stay-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'Kids Stay'
+description: 'Directory of family-friendly hotels and ryokan in Japan for parents traveling with babies and toddlers. 2,100+ properties verified on 51 criteria (cribs, diaper rules in baths and pools, kids meals, nursing rooms), with sources and last-checked dates. Bilingual (English and Japanese), plus a free MCP server.'
+website: 'https://kids-stay.com/en/'
+llmsUrl: 'https://kids-stay.com/llms.txt'
+category: 'international'
+priority: 'medium'
+publishedAt: '2026-09-08'
+---
+
+# Kids Stay
+
+Kids Stay is a directory of family-friendly hotels and ryokan across Japan for parents traveling with babies and toddlers. Each property is checked against its official website and the major Japanese booking sites on 51 criteria, such as crib and baby futon lending, whether a child in diapers may enter the communal bath or pool, kids' meals, nursing rooms and babysitting, with sources and last-checked dates shown on every property page. The site is published in English and Japanese.
+
+## Key Focus Areas
+
+- Verified kid-friendly facility data for 2,100+ hotels and ryokan in Japan
+- Search by condition, area and child age
+- Annual fact sheet with verified statistics (Family Hotel Data 2026)
+- Free MCP server exposing the same verified data to AI agents
+
+## About llms.txt Implementation
+
+Kids Stay provides an `llms.txt` file with an English summary of the site, its key pages, the MCP endpoint and citation guidance, followed by the same information in Japanese.

--- a/packages/content/data/websites/kids-stay-llms-txt.mdx
+++ b/packages/content/data/websites/kids-stay-llms-txt.mdx
@@ -16,9 +16,9 @@ Kids Stay is a directory of family-friendly hotels and ryokan across Japan for p
 
 - Verified kid-friendly facility data for 2,100+ hotels and ryokan in Japan
 - Search by condition, area and child age
-- Annual fact sheet with verified statistics (Family Hotel Data 2026)
-- Free MCP server exposing the same verified data to AI agents
+- Research reports on what family-friendly properties in Japan publish (Research Report vol.1 and vol.2)
+- Free MCP server exposing the verified data, 49 conditions per property, to AI agents
 
 ## About llms.txt Implementation
 
-Kids Stay provides an `llms.txt` file with an English summary of the site, its key pages, the MCP endpoint and citation guidance, followed by the same information in Japanese.
+Kids Stay provides an `llms.txt` file with a Japanese summary of the site, its key pages, the MCP endpoint and citation guidance, followed by the same information in English.

--- a/packages/content/data/websites/kids-stay-llms-txt.mdx
+++ b/packages/content/data/websites/kids-stay-llms-txt.mdx
@@ -16,9 +16,9 @@ Kids Stay is a directory of family-friendly hotels and ryokan across Japan for p
 
 - Verified kid-friendly facility data for 2,100+ hotels and ryokan in Japan
 - Search by condition, area and child age
-- Research reports on what family-friendly properties in Japan publish (Research Report vol.1 and vol.2)
-- Free MCP server exposing the verified data, 49 conditions per property, to AI agents
+- Annual fact sheet with verified statistics (Family Hotel Data 2026)
+- Free MCP server exposing the same verified data (all 51 criteria) to AI agents
 
 ## About llms.txt Implementation
 
-Kids Stay provides an `llms.txt` file with a Japanese summary of the site, its key pages, the MCP endpoint and citation guidance, followed by the same information in English.
+Kids Stay provides an `llms.txt` file with an English summary of the site, its key pages, the MCP endpoint and citation guidance, followed by the same information in Japanese.


### PR DESCRIPTION
This PR adds Kids Stay to the llms.txt hub.

Submitted by: @sitebox

Website: https://kids-stay.com/en/
llms.txt: https://kids-stay.com/llms.txt
Category: international

Kids Stay is a bilingual (English/Japanese) directory of family-friendly hotels and ryokan in Japan, with 2,100+ properties verified on 51 kid-friendly criteria and a free MCP server for AI agents. The llms.txt file starts with an English summary and key pages, followed by the Japanese version.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Content**
  - Added the Kids Stay website to the directory, with metadata and an English description.
  - Documented its verified kid-friendly facility data covering more than 2,100 hotels and ryokan, search options by area, conditions, and child age, plus the annual Family Hotel Data 2026 fact sheet.
  - Included details about the free MCP server, its 51 property criteria, and bilingual `llms.txt` content with the English summary presented first.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->