### PR TITLE
feat: add springhire to llms.txt hub

### DIFF
--- a/packages/content/data/websites/springhire-llms-txt.mdx
+++ b/packages/content/data/websites/springhire-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'springhire'
+description: 'Pre-hire assessment platform for recruiters and staffing agencies: skills tests, AI one-way video interviews, resume scoring and psychometric inventories behind one candidate link, returning a ranked shortlist. Plus a free library of HR tools.'
+website: 'https://springhire.io'
+llmsUrl: 'https://springhire.io/llms.txt'
+llmsFullUrl: 'https://springhire.io/llms-full.txt'
+category: 'business-operations'
+priority: 'medium'
+publishedAt: '2026-09-08'
+---
+
+# springhire
+
+Pre-hire assessment platform for recruiters and staffing agencies: skills tests, AI one-way video interviews, resume scoring and psychometric inventories behind one candidate link, returning a ranked shortlist. Plus a free library of HR tools.
+
+## Key Focus Areas
+
+- Hiring and recruitment
+- Skills testing and talent assessment
+- HR tools and templates
+
+## About llms.txt Implementation
+
+springhire provides an `llms.txt` index of its product pages, role hubs, comparisons and guides, and an `llms-full.txt` with the full text of those pages.


### PR DESCRIPTION
Adds springhire (https://springhire.io), a pre-hire assessment platform for recruiters and staffing agencies.

- llms.txt: https://springhire.io/llms.txt
- llms-full.txt: https://springhire.io/llms-full.txt
- Category: business-operations

Both files are live and the entry follows the format of existing website entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Content**
  - Added a Springhire website entry with metadata and a description of its pre-hire assessment offerings.
  - Documented key focus areas and available `llms.txt` and `llms-full.txt` resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->