### PR TITLE
Add SmartCrunch

### DIFF
--- a/packages/content/data/websites/smartcrunch-llms-txt.mdx
+++ b/packages/content/data/websites/smartcrunch-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'SmartCrunch'
+description: 'One number, every day: how much is left to eat. An iPhone calorie tracker whose daily budget is derived from your own logged weeks — what you ate against where your weight actually went — instead of a formula over height, weight and age.'
+website: 'https://smartcrunch.org'
+llmsUrl: 'https://smartcrunch.org/llms.txt'
+category: 'other'
+publishedAt: '2026-09-08'
+---
+
+# SmartCrunch
+
+SmartCrunch is an iPhone calorie tracker built around a single goal weight. It sets one number a day — how much is left to eat — and derives the maintenance figure behind it from the user's own history: average intake against the energy in their weight trend, recomputed as weeks accumulate.
+
+## Key Focus Areas
+
+- Adaptive calorie budget — maintenance learned from logged intake and weight trend, not fixed once from height, weight, age and an activity multiplier
+- Published method — every threshold, formula and constant documented at /methodology, with the site's other pages linking to its anchors rather than restating numbers
+- Stated uncertainty — below the data thresholds the app names the fallback estimate it used instead of printing a personalised number; totals carry the entry count they were computed from, and unknown values are shown as unknown rather than zero
+- Open Food Facts — barcode scanning and packaged-food search run against the open database
+- Local diary — no account, no sign-up, no server holding the food log
+
+## About llms.txt Implementation
+
+SmartCrunch's llms.txt states the product surface an assistant is likely to be asked about: what is free versus paid, the five sources tried for the maintenance figure and the order they are tried in, the interface languages, and the platform requirement. It points at /methodology as the single canonical source for every threshold, so an assistant can quote the published method rather than reconstruct it — the site deliberately keeps one copy of each number and links to it from everywhere else.


### PR DESCRIPTION
Adds `packages/content/data/websites/smartcrunch-llms-txt.mdx`.

**SmartCrunch** — https://smartcrunch.org — an iPhone calorie tracker whose daily budget is derived from the user's own logged weeks rather than a formula over height, weight and age.

- `llms.txt`: https://smartcrunch.org/llms.txt (live, 200)
- No `llms-full.txt`, so `llmsFullUrl` is omitted (the field is optional in the schema)
- Category: `other`
- Only the new `.mdx` file is touched — `data/websites.json` is left alone, per CONTRIBUTING

The `llms.txt` points at https://smartcrunch.org/methodology as the single canonical source for every threshold and formula the app uses, so an assistant can quote the published method instead of reconstructing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a SmartCrunch website entry to the directory.
  - Includes details about its adaptive calorie budget, methodology, uncertainty handling, Open Food Facts integration, and local-only diary storage.
  - Provides the site’s category, description, website link, llms.txt link, and publication date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->