### PR TITLE
feat(community): add SAGARIS to llms.txt hub

### DIFF
--- a/packages/content/data/websites/sagaris-llms-txt.mdx
+++ b/packages/content/data/websites/sagaris-llms-txt.mdx
@@ -1,6 +1,6 @@
 ---
 name: 'SAGARIS'
-description: 'Agentic revenue operating system for B2B sales teams: CRM, parallel dialer, unified inbox, SMS, an AI receptionist and an AI coach in one system, where AI agents act on the pipeline under approval gates and an audit trail.'
+description: 'An agentic revenue operating system for B2B sales teams: CRM, dialer, inbox, SMS, an AI receptionist and an AI coach on one shared record.'
 website: 'https://www.sagaris.ai'
 llmsUrl: 'https://www.sagaris.ai/llms.txt'
 category: 'marketing-sales'

--- a/packages/content/data/websites/sagaris-llms-txt.mdx
+++ b/packages/content/data/websites/sagaris-llms-txt.mdx
@@ -1,0 +1,26 @@
+---
+name: 'SAGARIS'
+description: 'Agentic revenue operating system for B2B sales teams: CRM, parallel dialer, unified inbox, SMS, an AI receptionist and an AI coach in one system, where AI agents act on the pipeline under approval gates and an audit trail.'
+website: 'https://www.sagaris.ai'
+llmsUrl: 'https://www.sagaris.ai/llms.txt'
+category: 'marketing-sales'
+publishedAt: '2026-09-08'
+---
+
+# SAGARIS
+
+SAGARIS is an agentic revenue operating system for B2B sales teams. CRM and pipeline, a parallel dialer, a unified inbox for email, SMS and calls, an AI receptionist for inbound calls, an AI sales coach and data enrichment run as one system rather than a stack of integrations. AI agents act on the pipeline under approval gates and an audit trail rather than only reporting on it.
+
+## Key Focus Areas
+
+- CRM and pipeline management
+- Parallel and power dialing with live coaching
+- Unified inbox across email, SMS and calls
+- AI receptionist for inbound calls
+- AI sales coach on every call
+- Data enrichment with per-field source and confidence
+- Analytics and forecasting
+
+## About llms.txt Implementation
+
+The 33KB llms.txt documents the machine-readable surfaces of sagaris.ai (sitemap, robots.txt, apis.json) and the pages that answer common buyer questions, including public pricing at 499 USD per founding seat per month. It deliberately omits the authenticated REST and Model Context Protocol endpoints, which live under /api and are disallowed in robots.txt, rather than pointing a crawler at URLs the same site asks it not to fetch.


### PR DESCRIPTION
Adds SAGARIS to the directory, following Option 3 (manual pull request) in the README.

**Entry:** `packages/content/data/websites/sagaris-llms-txt.mdx`

- **Website:** https://www.sagaris.ai
- **llms.txt:** https://www.sagaris.ai/llms.txt (HTTP 200, 33,492 bytes, verified today)
- **Category:** `marketing-sales`
- **llms-full.txt:** not published, so `llmsFullUrl` is omitted rather than pointing at a 404.

SAGARIS is an agentic revenue operating system for B2B sales teams. The llms.txt follows the standard structure (H1, blockquote summary, sectioned link lists) and points at the site's machine-readable surfaces plus the pages that answer common buyer questions. It deliberately excludes the authenticated REST and MCP endpoints, which live under `/api` and are disallowed in robots.txt.

Formatting matches the existing entries: single-quoted frontmatter, the same field order, and plain ASCII throughout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a documentation page for SAGARIS, including platform details, key focus areas, pricing, and implementation notes.
  - Documented publicly available machine-readable resources for easier discovery and reference.
  - Clarified that restricted authenticated API and MCP endpoints are not included because they are not publicly available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->