### PR TITLE
Add LovedByAI

### DIFF
--- a/packages/content/data/websites/lovedbyai-llms-txt.mdx
+++ b/packages/content/data/websites/lovedbyai-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'LovedByAI'
+description: 'WordPress plugin for AI search optimization that adds schema and FAQ markup, generates an llms.txt file, and tracks AI referral traffic.'
+website: 'https://www.lovedby.ai'
+llmsUrl: 'https://www.lovedby.ai/llms.txt'
+category: 'marketing-sales'
+publishedAt: '2026-09-08'
+---
+
+# LovedByAI
+
+WordPress plugin for AI search optimization that adds schema and FAQ markup, generates an llms.txt file, and tracks AI referral traffic.


### PR DESCRIPTION
Adds one new website entry: `packages/content/data/websites/lovedbyai-llms-txt.mdx`.

Following CONTRIBUTING.md — new `.mdx` in `packages/content/data/websites/`, branch named `add/…`, and `data/websites.json` left untouched.

- **Website:** https://www.lovedby.ai
- **llms.txt:** https://www.lovedby.ai/llms.txt (live, returns 200, ~9KB)
- **Category:** `marketing-sales`

LovedByAI is a WordPress plugin that generates and maintains `llms.txt` automatically, alongside schema and FAQ markup, and reports AI referral traffic from ChatGPT, Perplexity, Claude and Gemini. On the WordPress.org plugin directory since January 2026.

No `llmsFullUrl` is set: `/llms-full.txt` currently 308-redirects to `/llms.txt`, so listing it would be misleading.

One file added, nothing else changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new directory entry for the LovedByAI WordPress plugin.
  - Includes plugin details, website links, category, publication date, and a brief feature description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->