### PR TITLE
Add ToolTrace

### DIFF
--- a/packages/content/data/websites/tooltrace-llms-txt.mdx
+++ b/packages/content/data/websites/tooltrace-llms-txt.mdx
@@ -1,0 +1,23 @@
+---
+name: 'ToolTrace'
+description: 'Web data APIs and free browser tools for AI agents, including an llms.txt generator and validator that read your live pages.'
+website: 'https://tooltrace.io'
+llmsUrl: 'https://tooltrace.io/llms.txt'
+category: 'developer-tools'
+publishedAt: '2026-09-08'
+---
+
+# ToolTrace
+
+ToolTrace provides web data APIs for developers and AI agents, plus free browser-based tools that run the same analysis without an account. The APIs cover page scraping to Markdown, content and metadata extraction, link and JSON-LD schema extraction, on-page SEO auditing, tech stack detection, and XML sitemap validation.
+
+## Key Focus Areas
+
+- llms.txt Generation and Validation
+- Web Data Extraction
+- Technical SEO
+- Developer Tools
+
+## About llms.txt Implementation
+
+ToolTrace serves its own llms.txt, curated by hand rather than generated from the sitemap, and publishes two free tools for the format. The generator drafts a file from the pages a site actually serves, skipping URLs that return an error, redirect elsewhere, or carry noindex, and taking each title and description from the page itself instead of the URL slug. The validator separates errors that make a file unusable from warnings that are a matter of judgement, and reports the line number for each finding.


### PR DESCRIPTION
Adds ToolTrace under developer-tools.

Web data APIs and free browser tools for AI agents. Includes an llms.txt
generator that drafts a file from the pages a site actually serves, and a
validator that separates errors from warnings and reports line numbers.

- Website: https://tooltrace.io
- llms.txt: https://tooltrace.io/llms.txt

Only adds the .mdx file under packages/content/data/websites/. No changes to
data/websites.json.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a directory entry for ToolTrace, a developer-tools site offering web data APIs and browser tools for AI agents.
  * Documented its scraping, content extraction, SEO auditing, technology detection, sitemap validation, and related capabilities.
  * Added details about ToolTrace’s hand-curated llms.txt, generation workflow, and validation features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->