### PR TITLE
feat(community): add GitHub Docs to llms.txt hub

### DIFF
--- a/packages/content/data/websites/github-docs-llms-txt.mdx
+++ b/packages/content/data/websites/github-docs-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+category: 'developer-tools'
+description: 'Get started, troubleshoot, and make the most of GitHub. Documentation for new users, developers, administrators, and all of GitHub''s products.'
+llmsFullUrl: ''
+llmsUrl: 'https://docs.github.com/llms.txt'
+name: 'GitHub Docs'
+publishedAt: '2026-09-08'
+website: 'https://docs.github.com/'
+---
+
+# GitHub Docs
+
+Get started, troubleshoot, and make the most of GitHub\. Documentation for new users, developers, administrators, and all of GitHub's products\.


### PR DESCRIPTION
<!-- llms-hub-submission:sub_a8ed372d83bb4346933a183187db8eeb -->

This PR adds GitHub Docs to the llms.txt hub.

**Assessment:** manual_review
**Policy:** 2026-08-01.v1
**Website:** https://docs.github.com/
**llms.txt:** https://docs.github.com/llms.txt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added GitHub Docs to the available website directory.
  - Included metadata, website links, publication information, and a descriptive overview.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->