### PR TITLE
Add Comunicate.top

### DIFF
--- a/packages/content/data/websites/comunicate-top-llms-txt.mdx
+++ b/packages/content/data/websites/comunicate-top-llms-txt.mdx
@@ -1,0 +1,20 @@
+---
+name: 'Comunicate.top'
+description: 'Publish press releases and advertorials on 3,800+ news sites, with an open catalogue API and an MCP server.'
+website: 'https://comunicate.top'
+llmsUrl: 'https://comunicate.top/llms.txt'
+category: 'marketing-sales'
+publishedAt: '2026-09-09'
+---
+
+# Comunicate.top
+
+Romanian platform for publishing press releases, advertorials and SEO articles on a
+network of 3,800+ online publications. Prices and turnaround times are printed in the
+catalogue and are identical for everyone — no request for quote, no negotiation.
+
+The `llms.txt` is generated, not written: it carries the current price, the network
+size, the niches, and the four free API routes with their full URLs, so an assistant
+can read a price and call the catalogue without guessing. There is also an OpenAPI 3.1
+document, an APIs.json index, an RFC 9727 API catalogue, and a remote MCP server
+published in the official MCP registry as `top.comunicate/publishing`.


### PR DESCRIPTION
Adds **Comunicate.top** under `marketing-sales`.

Romanian platform for publishing press releases, advertorials and SEO articles on 3,800+ online publications. Prices and turnaround are printed in the catalogue and identical for everyone.

- llms.txt: https://comunicate.top/llms.txt — generated, not hand-written: it carries the current price, network size, niches, and the four free API routes with full URLs, so an assistant can read a price and call the catalogue without guessing.
- OpenAPI 3.1: https://comunicate.top/openapi.json (the `/public/*` routes carry `security: []` — free, no key)
- APIs.json: https://comunicate.top/apis.json · API catalogue (RFC 9727): https://comunicate.top/.well-known/api-catalog
- Remote MCP server in the official registry as `top.comunicate/publishing`

No `llms-full.txt` yet, so that field is omitted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a new Comunicate.top website entry to the content directory.
  - Included its marketing and sales classification, website URL, and `llms.txt` endpoint.
  - Added details about its press-release publishing network, transparent pricing, generated `llms.txt`, API routes, OpenAPI and APIs.json catalogs, RFC 9727 artifacts, and remote MCP server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->