### PR TITLE
feat(content): add SearchD to llms.txt directory

### DIFF
--- a/packages/content/data/websites/searchd-llms-txt.mdx
+++ b/packages/content/data/websites/searchd-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'SearchD'
+description: 'San Francisco-based answer engine optimization agency for Asian consumer brands selling to US buyers.'
+website: 'https://searchd.ai/'
+llmsUrl: 'https://searchd.ai/llms.txt'
+category: 'agency-services'
+publishedAt: '2026-09-09'
+---
+
+# SearchD
+
+San Francisco-based answer engine optimization agency for Asian consumer brands selling to US buyers.


### PR DESCRIPTION
## Summary
Add SearchD, a San Francisco-based AEO agency for Asian consumer brands selling to US buyers, to `agency-services` with its live https://searchd.ai/llms.txt URL. This adds only `packages/content/data/websites/searchd-llms-txt.mdx`; generated catalog files are unchanged.

Disclosure: I am Bale from SearchD and am submitting our own website. The description follows the current website and About page and makes no client-results or ranking claims.

## Verification
- Website, `/llms.txt`, and `/about` returned HTTP 200.
- `/llms-full.txt` returned HTTP 404, so `llmsFullUrl` is omitted.
- Checked required metadata and the accepted `agency-services` category against the repository validator; focused Node assertions for fields, URLs, category and date passed.
- `git diff --cached --check`: passed; one new MDX file only.
- `pnpm check:frontmatter searchd-llms-txt.mdx` and `pnpm check:websites` were attempted but could not run because this isolated checkout has no dependencies installed (`tsx: command not found`). No application code or configuration was changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SearchD to the website directory, including its description, website link, and llms.txt resource.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->