### PR TITLE
Add TrickyBird

### DIFF
--- a/packages/content/data/websites/trickybird-llms-txt.mdx
+++ b/packages/content/data/websites/trickybird-llms-txt.mdx
@@ -3,6 +3,7 @@ name: 'TrickyBird'
 description: 'A free web proxy that opens a blocked site in your browser tab. There is no account and nothing to install.'
 website: 'https://trickybird.com'
 llmsUrl: 'https://trickybird.com/llms.txt'
+llmsFullUrl: 'https://trickybird.com/llms-full.txt'
 category: 'other'
 publishedAt: '2026-09-09'
 ---

--- a/packages/content/data/websites/trickybird-llms-txt.mdx
+++ b/packages/content/data/websites/trickybird-llms-txt.mdx
@@ -1,0 +1,12 @@
+---
+name: 'TrickyBird'
+description: 'A free web proxy that opens a blocked site in your browser tab. There is no account and nothing to install.'
+website: 'https://trickybird.com'
+llmsUrl: 'https://trickybird.com/llms.txt'
+category: 'other'
+publishedAt: '2026-09-09'
+---
+
+# TrickyBird
+
+TrickyBird is a web proxy, not a VPN. You paste a link and it opens that one site in the same tab, rewritten as it loads. There is no account and nothing to install, so it runs in any browser, including on a managed device where you cannot add software. The llms.txt file maps the site's public pages, each with a one-line description taken from the page itself.


### PR DESCRIPTION
Adding TrickyBird: a free web proxy that opens one site in a browser tab, with an llms.txt at https://trickybird.com/llms.txt.

Disclosure: I work on TrickyBird, so this is a self-submission.

One file, `packages/content/data/websites/trickybird-llms-txt.mdx`. Frontmatter follows the shape of the live entries, quotes on every field. `category` is `other`, matching where the directory already files this class.

The llms.txt is generated from the site's own shipped copy rather than written separately, so it stays in step with the pages it maps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new TrickyBird website entry with descriptive metadata, category information, publication details, and links.
  - Added information describing TrickyBird as a browser-based web proxy that opens rewritten websites in the same tab without requiring an account or installation.
  - Included links to TrickyBird’s website and available text resources for additional information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->