### PR TITLE
docs: add FITsociety developer documentation

### DIFF
--- a/packages/content/data/websites/fitsociety-llms-txt.mdx
+++ b/packages/content/data/websites/fitsociety-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+name: 'FITsociety'
+description: 'Fitness business software with developer documentation for its Public API and hosted MCP server.'
+website: 'https://fitsociety.io'
+llmsUrl: 'https://docs.fitsociety.io/llms.txt'
+llmsFullUrl: 'https://docs.fitsociety.io/llms-full.txt'
+category: 'business-operations'
+publishedAt: '2026-09-09'
+priority: 'low'
+---
+
+# FITsociety
+
+FITsociety provides software for fitness coaches and businesses to manage clients, scheduling, bookings, training and nutrition coaching.
+
+## Key Focus Areas
+
+- Fitness business and client management
+- Public API integrations
+- Hosted MCP access with OAuth and explicit permissions
+
+## About llms.txt Implementation
+
+The [developer documentation](https://docs.fitsociety.io) provides an llms.txt index covering the Public API and MCP server, including authentication, setup, available resources and security guidance. A full llms-full.txt resource is also available.


### PR DESCRIPTION
## Summary

Adds FITsociety under Business Operations with links to the product website and its public developer documentation. The llms.txt index covers the Public API and hosted MCP service; llms-full.txt provides the full documentation.

Both documentation resources were fetched successfully over HTTPS and inspected as text. No existing FITsociety entry or submission was found. Only the new website MDX file is included; generated data is unchanged.

Validation: repository frontmatter, filename-length and website-entry validators; `git diff --check`. No application code or configuration changed, so a full application build was not run locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a directory entry for FITsociety, including its website, AI-readable resources, category, and publication details.
  - Documented FITsociety’s focus areas and available API and hosted MCP server resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->