### PR TITLE
feat(community): add Jagelski & Partners to llms.txt hub

### DIFF
--- a/packages/content/data/websites/jagelski-partners-llms-txt.mdx
+++ b/packages/content/data/websites/jagelski-partners-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+category: 'finance-fintech'
+description: 'Reference library on crypto licensing, company formation and banking access: 52 jurisdiction guides, three open comparison tools and an open dataset with a DOI.'
+llmsFullUrl: ''
+llmsUrl: 'https://jagelski.com/llms.txt'
+name: 'Jagelski & Partners'
+publishedAt: '2026-09-09'
+website: 'https://jagelski.com/'
+---
+
+# Jagelski \& Partners
+
+Reference library on crypto licensing, company formation and banking access: 52 jurisdiction guides, three open comparison tools and an open dataset with a DOI\.


### PR DESCRIPTION
<!-- llms-hub-submission:sub_7923b54bad904e63bb8314ba218ceb40 -->

This PR adds Jagelski \& Partners to the llms.txt hub.

**Assessment:** manual_review
**Policy:** 2026-08-01.v1
**Website:** https://jagelski.com/
**llms.txt:** https://jagelski.com/llms.txt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Content**
  - Added a profile page for Jagelski & Partners.
  - Includes information about its finance and fintech services, crypto licensing, company formation, banking access, comparison tools, and open datasets.
  - Added publication metadata, website links, and LLM resource URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->