### PR TITLE
Add mock.shop

### DIFF
--- a/packages/content/data/websites/mock-shop-llms-txt.mdx
+++ b/packages/content/data/websites/mock-shop-llms-txt.mdx
@@ -10,6 +10,6 @@ publishedAt: '2026-09-10'
 
 # mock.shop
 
-mock.shop is Shopify's public Storefront GraphQL API backed by more than 100 fictional stores, each on its own host with its own catalog. It needs no store, no app, and no access token, so a developer or a coding agent can build a storefront against realistic products, collections, and carts, then switch to a real Shopify store by changing the domain.
+mock.shop is Shopify's public Storefront GraphQL API backed by more than 100 fictional stores, each on its own host with its own catalog. It needs no store, no app, and no access token, so a developer or a coding agent can build a storefront against realistic products, collections, and carts, then switch to a real Shopify store by changing the domain and adding the store's Storefront API access token.
 
 The root `llms.txt` is the store directory: one line per store with its name, what it sells, its categories, and its API URL. Every store also serves its own `llms.txt` at `https://<store>.mock.shop/llms.txt` with that store's categories, collections, and product counts, and every API response carries a `Link` header pointing back to it.

--- a/packages/content/data/websites/mock-shop-llms-txt.mdx
+++ b/packages/content/data/websites/mock-shop-llms-txt.mdx
@@ -1,0 +1,15 @@
+---
+name: 'mock.shop'
+description: "Shopify's public, auth-free Storefront GraphQL API backed by 100+ fictional stores, for building and testing storefronts and agents without a Shopify store or access token."
+website: 'https://mock.shop'
+llmsUrl: 'https://mock.shop/llms.txt'
+llmsFullUrl: ''
+category: 'developer-tools'
+publishedAt: '2026-09-10'
+---
+
+# mock.shop
+
+mock.shop is Shopify's public Storefront GraphQL API backed by more than 100 fictional stores, each on its own host with its own catalog. It needs no store, no app, and no access token, so a developer or a coding agent can build a storefront against realistic products, collections, and carts, then switch to a real Shopify store by changing the domain.
+
+The root `llms.txt` is the store directory: one line per store with its name, what it sells, its categories, and its API URL. Every store also serves its own `llms.txt` at `https://<store>.mock.shop/llms.txt` with that store's categories, collections, and product counts, and every API response carries a `Link` header pointing back to it.


### PR DESCRIPTION
Adds [mock.shop](https://mock.shop), Shopify's public, auth-free Storefront GraphQL API backed by 100+ fictional stores, under `developer-tools`.

- `llms.txt`: https://mock.shop/llms.txt (200, `text/plain`). It doubles as the store directory: one line per store with its API URL, and each store serves its own `llms.txt` at `https://<store>.mock.shop/llms.txt`.
- No `llms-full.txt`, so `llmsFullUrl` is empty.
- Docs: https://shopify.dev/docs/storefronts/headless/mock-shop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a website-directory entry for mock.shop, highlighting its public Storefront GraphQL API and fictional stores.
  * Included links to the directory’s `llms.txt` resource and individual store documentation.
  * Added metadata and a description explaining the available API, documentation resources, and `Link` header.
  * Documented the configuration changes required to connect the API to a real Shopify store.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->