### PR TITLE
feat(community): add Slacker SEO to llms.txt hub

### DIFF
--- a/packages/content/data/websites/slacker-seo-llms-txt.mdx
+++ b/packages/content/data/websites/slacker-seo-llms-txt.mdx
@@ -1,0 +1,39 @@
+---
+category: 'agency-services'
+description: 'Slacker SEO is a veteran-owned technical SEO agency specializing in healthcare, addiction treatment, and mental health organizations. We combine deep.'
+llmsFullUrl: 'https://slackerseo.com/llms-full.txt'
+llmsUrl: 'https://slackerseo.com/llms.txt'
+name: 'Slacker SEO'
+publishedAt: '2026-09-10'
+website: 'https://slackerseo.com/'
+---
+
+# Slacker SEO
+
+Slacker SEO is a veteran\-owned technical SEO agency specializing in healthcare, addiction treatment, and mental health organizations\. We combine deep\.
+
+## Key Focus Areas
+
+- **Technical SEO for Healthcare**: Infrastructure-level search optimization for addiction treatment, behavioral health, and mental health organizations operating in Google's highest-quality YMYL categories
+- **Answer Engine Optimization (AEO)**: Content optimization for AI retrieval and citation across Google AI Overviews, ChatGPT, Perplexity, and Gemini using our proprietary 46-point AI Readiness Score (ARS) assessment
+- **Schema & Structured Data**: Connected entity architecture using @graph/@id methodology with MedicalBusiness typing, credential markup, and multi-location schemas
+- **AI Search Visibility**: Cross-platform citation monitoring and optimization for healthcare organizations across all major AI platforms
+
+## About llms.txt Implementation
+
+Our llms.txt file is a core component of our Answer Engine Optimization methodology, not an afterthought. It provides AI systems with explicit guidance on how to understand, prioritize, and cite our content — including preferred citation formats, content hierarchy, and proprietary framework attribution (SIO, ARS, Expert Delta).
+
+We also maintain an llms-full.txt containing the complete flattened content of all priority pages for efficient AI ingestion, and a dedicated /llm-info/ page with human-readable citation guidelines and entity information.
+
+## Verified Results
+
+- **Brooks Healing Center**: 2 admissions in two years to 41 in six months. $1M financial turnaround through technical SEO infrastructure and schema architecture.
+- **California Treatment Portfolio**: 45 to 125 monthly qualified opportunities (178% growth). Multi-site schema architecture across 6 California regions.
+
+## Proprietary Frameworks
+
+- **Search Intelligence Optimization (SIO)**: Three-pillar methodology integrating traditional SEO with Answer Engine Optimization
+- **AI Readiness Score (ARS)**: 46-point content retrievability assessment with llms.txt contributing up to 7 bonus points
+- **The Expert Delta**: Original research concept documenting how AI errors concentrate in current knowledge and case-specific judgment
+
+Veteran-owned. Faith-driven. Based in Cranberry Township, PA. Serving clients nationwide.


### PR DESCRIPTION
<!-- llms-hub-submission:sub_50090f0e03a44dff8b63c29693b78623 -->

This PR adds Slacker SEO to the llms.txt hub.

**Assessment:** manual_review
**Policy:** 2026-08-01.v1
**Website:** https://slackerseo.com/
**llms.txt:** https://slackerseo.com/llms.txt
**llms-full.txt:** https://slackerseo.com/llms-full.txt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Content**
  * Added a Slacker SEO profile page featuring its services, specialties, AI search visibility approach, client results, frameworks, and company background.
  * Included metadata and references to the agency’s llms.txt resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->