### PR TITLE
feat(community): add 90好卡 to llms.txt hub

### DIFF
--- a/packages/content/data/websites/90-llms-txt.mdx
+++ b/packages/content/data/websites/90-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+category: 'content-media'
+description: '90好卡专注手机卡与宽带套餐真实测评，覆盖电信/联通/移动/广电四大运营商，提供流量卡、融合套餐、单宽带等产品的深度对比与避坑指南，帮你找到高性价比套餐.'
+llmsFullUrl: ''
+llmsUrl: 'https://www.90haoka.cn/llms.txt'
+name: '90好卡'
+publishedAt: '2026-09-10'
+website: 'https://www.90haoka.cn/'
+---
+
+# 90好卡
+
+90好卡专注手机卡与宽带套餐真实测评，覆盖电信/联通/移动/广电四大运营商，提供流量卡、融合套餐、单宽带等产品的深度对比与避坑指南，帮你找到高性价比套餐\.
+
+## Key Focus Areas
+
+- **AI Integration**: Details about AI/ML capabilities
+- **API Documentation**: Coverage of API endpoints and usage
+- **Developer Tools**: Build tools, SDKs, and integrations
+- **Data Processing**: How data is handled and transformed
+
+## About llms.txt Implementation
+
+Our llms.txt file provides comprehensive documentation about our platform's AI-ready content structure, making it easy for language models to understand and work with our system.


### PR DESCRIPTION
<!-- llms-hub-submission:sub_5bb0743d9a674463bc6160e8851914c9 -->

This PR adds 90好卡 to the llms.txt hub.

**Assessment:** manual_review
**Policy:** 2026-08-01.v1
**Website:** https://www.90haoka.cn/
**llms.txt:** https://www.90haoka.cn/llms.txt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new website profile for 90好卡 (90haoka.cn), including its description, publication details, and llms.txt links.
  - Added content describing the site’s mobile card and broadband plan reviews across four carriers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->