### PR TITLE
feat(community): add 90号卡 to llms.txt hub

### DIFF
--- a/packages/content/data/websites/90-llms-txt.mdx
+++ b/packages/content/data/websites/90-llms-txt.mdx
@@ -1,0 +1,24 @@
+---
+category: 'content-media'
+description: '90号卡专注手机卡与宽带套餐真实测评，覆盖电信/联通/移动/广电四大运营商，提供流量卡、光纤宽带、融合套餐等产品的深度实测与避坑指南，帮你选出真正划算的套餐.'
+llmsFullUrl: ''
+llmsUrl: 'https://www.90haoka.net/llms.txt'
+name: '90号卡'
+publishedAt: '2026-09-10'
+website: 'https://www.90haoka.net/'
+---
+
+# 90号卡
+
+90号卡专注手机卡与宽带套餐真实测评，覆盖电信/联通/移动/广电四大运营商，提供流量卡、光纤宽带、融合套餐等产品的深度实测与避坑指南，帮你选出真正划算的套餐\.
+
+## Key Focus Areas
+
+- **AI Integration**: Details about AI/ML capabilities
+- **API Documentation**: Coverage of API endpoints and usage
+- **Developer Tools**: Build tools, SDKs, and integrations
+- **Data Processing**: How data is handled and transformed
+
+## About llms.txt Implementation
+
+Our llms.txt file provides comprehensive documentation about our platform's AI-ready content structure, making it easy for language models to understand and work with our system.


### PR DESCRIPTION
<!-- llms-hub-submission:sub_cda4595d60ca4fd399d80df8a31b6ba6 -->

This PR adds 90号卡 to the llms.txt hub.

**Assessment:** manual_review
**Policy:** 2026-08-01.v1
**Website:** https://www.90haoka.net/
**llms.txt:** https://www.90haoka.net/llms.txt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Content**
  - Added a website profile for 90号卡 (90haoka.net), a Chinese review site covering mobile SIM cards and broadband plans.
  - Included metadata, llms.txt links, publication details, and an overview of the site’s content focus and llms.txt implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->