### PR TITLE
feat(community): add angeo.dev to llms.txt hub

### DIFF
--- a/packages/content/data/websites/angeo-dev-llms-txt.mdx
+++ b/packages/content/data/websites/angeo-dev-llms-txt.mdx
@@ -1,0 +1,30 @@
+---
+category: 'developer-tools'
+description: 'Open-source Magento 2 modules and audits for AI search visibility and agentic commerce: llms.txt, AI crawler rules, JSON-LD, product feeds, MCP and UCP.'
+llmsFullUrl: ''
+llmsUrl: 'https://angeo.dev/llms.txt'
+name: 'angeo.dev'
+publishedAt: '2026-09-11'
+website: 'https://angeo.dev/'
+---
+
+# angeo\.dev
+
+Open\-source Magento 2 modules and audits for AI search visibility and agentic commerce: llms\.txt, AI crawler rules, JSON\-LD, product feeds, MCP and UCP\.
+
+## What angeo.dev is
+
+angeo.dev publishes free, MIT-licensed Magento 2 modules that make stores readable to AI assistants and AI agents. It is run by one engineer.
+
+## What the llms.txt covers
+
+- **Start here:** what AEO means for Magento and how to check a store
+- **Modules:** 12 open-source modules, including an llms.txt generator for Magento 2 (also on the Adobe Commerce Marketplace)
+- **Research:** scans of live Magento stores and what the evidence shows
+- **Docs:** MCP setup, AI crawlers and a compatibility matrix
+
+## Links
+
+- [Modules](https://angeo.dev/modules/)
+- [GitHub](https://github.com/angeo-dev)
+- [Packagist](https://packagist.org/packages/angeo/)


### PR DESCRIPTION
<!-- llms-hub-submission:sub_385ea96973644ca08d227e655c821dfb -->

This PR adds angeo\.dev to the llms.txt hub.

**Assessment:** manual_review
**Policy:** 2026-08-01.v1
**Website:** https://angeo.dev/
**llms.txt:** https://angeo.dev/llms.txt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Content**
  - Added a directory entry for angeo.dev, including its category, description, publication date, website, and llms.txt links.
  - Documented the site’s open-source Magento 2 modules and resources for AI search visibility.
  - Added links to relevant modules, GitHub, and Packagist pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->