### PR TITLE
feat(community): add SimFuse to llms.txt hub

### DIFF
--- a/packages/content/data/websites/simfuse-llms-txt.mdx
+++ b/packages/content/data/websites/simfuse-llms-txt.mdx
@@ -1,0 +1,13 @@
+---
+name: 'SimFuse'
+description: 'Prepaid travel eSIMs for 200+ countries. Buy online, install in minutes, no roaming fees. Live prices, a trip planner, and an agent-facing API.'
+website: 'https://simfuse.app/'
+llmsUrl: 'https://simfuse.app/llms.txt'
+llmsFullUrl: 'https://simfuse.app/llms-full.txt'
+category: 'ecommerce-retail'
+publishedAt: '2026-09-12'
+---
+
+# SimFuse
+
+Prepaid travel eSIMs for 200+ countries. Buy online, install in minutes, no roaming fees. Live prices, a trip planner, and an agent-facing API.


### PR DESCRIPTION
Adds SimFuse to the ecommerce-retail category.

SimFuse sells prepaid travel eSIMs for 200+ countries. Plans are bought as a one-off, activate on arrival, and can be topped up without swapping the eSIM.

- Website: https://simfuse.app/
- llms.txt: https://simfuse.app/llms.txt
- llms-full.txt: https://simfuse.app/llms-full.txt

Both are live and served as text/plain. The llms.txt follows the spec format: H1, blockquote summary, then sectioned link lists.

One new .mdx file under packages/content/data/websites/, no other changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added SimFuse to the website directory.
  - Included its description, website link, and AI-readable content links.
  - Categorized SimFuse under ecommerce and retail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->