### PR TITLE
docs: add FORMWEFT llms.txt listing

### DIFF
--- a/packages/content/data/websites/formweft-llms-txt.mdx
+++ b/packages/content/data/websites/formweft-llms-txt.mdx
@@ -1,0 +1,22 @@
+---
+name: FORMWEFT
+description: Enterprise AI workflow implementation, custom workspaces, FDE training, and public learning resources.
+website: https://formweft.com/
+llmsUrl: https://formweft.com/llms.txt
+category: international
+publishedAt: "2026-09-12"
+---
+
+# FORMWEFT
+
+FORMWEFT provides enterprise AI workflow implementation, custom AI workspaces, and practical training for forward-deployed engineers (FDEs). Its public resources cover workflow design, knowledge preparation, business analysis, content production, and human review.
+
+## Key Focus Areas
+
+- Enterprise AI workflows and system integration
+- FDE training through practical projects
+- Public guides, reusable skills, and browser-based tools
+
+## About llms.txt Implementation
+
+The [official llms.txt](https://formweft.com/llms.txt) is a Chinese-language Markdown index of public service pages, engineering guides, and learning resources. It excludes signed-in content, private workspaces, chats, customer projects, and administration data. An [English website](https://formweft.com/en/) is also available.


### PR DESCRIPTION
## Summary

Add FORMWEFT, an enterprise AI workflow and training service with public learning resources, to the international directory. Its official llms.txt is a Chinese-language index of public services, engineering guides, and resources.

## Verification

- https://formweft.com/llms.txt is publicly accessible as text/plain and contains a Markdown index.
- The website and English entry point (https://formweft.com/en/) are accessible.
- Checked the repository tree and existing pull requests for FORMWEFT; no duplicate was found before submission.
- Only packages/content/data/websites/formweft-llms-txt.mdx is added; frontmatter matches the current website schema and GitHub preview renders correctly.
- Full application build was not run for this content-only submission.

Submitted on behalf of FORMWEFT for directory consideration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a FORMWEFT resource page with website metadata, enterprise AI workflow services, FDE training, and public resources.
  * Documented the official website and `llms.txt` URL, publication date, focus areas, and excluded private or authenticated content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->